### PR TITLE
4.3.4: Fix CMSG_LF_GUILD_SET_GUILD_POST and update SMSG_LF_GUILD_BROWSE_UPDATED

### DIFF
--- a/WowPacketParser/Parsing/Parsers/GuildFinderHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/GuildFinderHandler.cs
@@ -30,11 +30,10 @@ namespace WowPacketParser.Parsing.Parsers
         [Parser(Opcode.CMSG_LF_GUILD_SET_GUILD_POST, ClientVersionBuild.V4_3_4_15595)]
         public static void HandleGuildFinderSetGuildPost434(Packet packet)
         {
-            // order for the next 4 ints not confirmed
-            packet.ReadEnum<GuildFinderOptionsInterest>("Guild Interests", TypeCode.UInt32);
+            packet.ReadEnum<GuildFinderOptionsLevel>("Level", TypeCode.UInt32);
             packet.ReadEnum<GuildFinderOptionsAvailability>("Availability", TypeCode.UInt32);
             packet.ReadEnum<GuildFinderOptionsRoles>("Class Roles", TypeCode.UInt32);
-            packet.ReadEnum<GuildFinderOptionsLevel>("Level", TypeCode.UInt32);
+            packet.ReadEnum<GuildFinderOptionsInterest>("Guild Interests", TypeCode.UInt32);
             var length = packet.ReadBits(11);
             packet.ReadBit("Listed");
             packet.ReadWoWString("Comment", length);
@@ -151,7 +150,7 @@ namespace WowPacketParser.Parsing.Parsers
             for (int i = 0; i < count; ++i)
             {
                 packet.ReadInt32("Tabard Emblem Color", i);
-                packet.ReadInt32("Unk Int 1", i); // + 140
+                packet.ReadInt32("Tabard Border Style", i); // Guessed from sniffs
                 packet.ReadInt32("Tabard Icon", i);
                 packet.ReadWoWString("Comment", strlen[i][0], i);
                 packet.ReadBoolean("Cached", i);
@@ -179,7 +178,7 @@ namespace WowPacketParser.Parsing.Parsers
                 packet.ReadXORByte(guids[i], 1);
 
                 packet.ReadInt32("Tabard Background Color", i);
-                packet.ReadInt32("Unk Int 2", i); // + 128
+                packet.ReadInt32("Unk Int 2", i); // + 128 (Always 0 or 1)
                 packet.ReadInt32("Tabard Border Color", i);
                 packet.ReadEnum<GuildFinderOptionsRoles>("Class Roles", TypeCode.UInt32, i);
 


### PR DESCRIPTION
CMSG_LF_GUILD_SET_GUILD_POST verified ingame
SMSG_LF_GUILD_BROWSE_UPDATED verified from a sniff with over 1k5 guilds (Blizzard seems to send -1 in any tabard related field if for w/e reason they can't get the data, the first unk was set to -1 in such situations)
