### PR TITLE
Parsing: Updated PKT 3.1 parsing to reflect changes on TC's PacketLogger...

### DIFF
--- a/WowPacketParser/Misc/Packet.cs
+++ b/WowPacketParser/Misc/Packet.cs
@@ -65,6 +65,7 @@ namespace WowPacketParser.Misc
         public ParsedStatus Status { get; set; }
         public bool WriteToFile { get; private set; }
         public int ConnectionIndex { get; set; }
+        public byte[] SocketIdentifier { get; set; }
 
         public void AddSniffData(StoreNameType type, int id, string data)
         {


### PR DESCRIPTION
... - An additional 20 bytes of data is appended to each of the headers that are attached to a packet, and that is used to write each packet to the file that corresponds to the socket they were sent to.

@Nayd, @Shauren: ping!
