### PR TITLE
CombatLog/6.0.3: Fix structure SMSG_SPELLENERGIZELOG

### DIFF
--- a/WowPacketParserModule.V6_0_2_19033/Parsers/CombatLogHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/CombatLogHandler.cs
@@ -125,8 +125,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadPackedGuid128("CasterGUID");
             packet.ReadPackedGuid128("TargetGUID");
 
-            packet.ReadEnum<PowerType>("Type", TypeCode.UInt32);
             packet.ReadEntry<Int32>(StoreNameType.Spell, "SpellID");
+            packet.ReadEnum<PowerType>("Type", TypeCode.UInt32);
             packet.ReadInt32("Amount");
 
             packet.ResetBitReader();


### PR DESCRIPTION
it was

ServerToClient: SMSG_SPELLENERGIZELOG (0x137C) Length: 31 ConnIdx: 0 EP:  Time: 01/19/2015 21:22:40.578 Number: 68
CasterGUID: Full: 0x08193C0000000000000000000389DD47 Player/0 R1615/S0 Map: 0 Low: 59366727
TargetGUID: Full: 0x08193C0000000000000000000389DD47 Player/0 R1615/S0 Map: 0 Low: 59366727
Type: 95810 (95810)
SpellID: 7
Amount: 300
HasLogData: False