### PR TITLE
Use '--' as cmd option delimiter to avoid confusion with paths starti…

### DIFF
--- a/WowPacketParser/Misc/Configuration.cs
+++ b/WowPacketParser/Misc/Configuration.cs
@@ -29,11 +29,11 @@ namespace WowPacketParser.Misc
             for (int i = 1; i < args.Length - 1; ++i)
             {
                 string opt = args[i];
-                if (opt[0] != '/')
+                if (!opt.StartsWith("--", StringComparison.CurrentCultureIgnoreCase))
                     break;
 
                 // analyze options
-                string optname = opt.Substring(1);
+                string optname = opt.Substring(2);
                 switch (optname)
                 {
                     case "ConfigFile":
@@ -52,11 +52,9 @@ namespace WowPacketParser.Misc
 
                 try
                 {
-                    // Map the new configuration file.
-                    var configFileMap = new ExeConfigurationFileMap { ExeConfigFilename = configPath };
-
                     // Get the mapped configuration file
-                    var config = ConfigurationManager.OpenMappedExeConfiguration(configFileMap, ConfigurationUserLevel.None);
+                    var config = ConfigurationManager.OpenExeConfiguration(configPath);
+
 
                     settings = ((AppSettingsSection)config.GetSection("appSettings")).Settings;
                 }

--- a/WowPacketParser/Misc/Utilities.cs
+++ b/WowPacketParser/Misc/Utilities.cs
@@ -176,7 +176,7 @@ namespace WowPacketParser.Misc
         {
             for (var i = 0; i < files.Count - 1; ++i)
             {
-                if (files[i][0] == '/')
+                if (files[i].StartsWith("--", StringComparison.CurrentCultureIgnoreCase))
                 {
                     // remove value
                     files.RemoveAt(i + 1);

--- a/WowPacketParser/Program.cs
+++ b/WowPacketParser/Program.cs
@@ -83,9 +83,9 @@ namespace WowPacketParser
         {
             Console.WriteLine("Error: No files selected to be parsed.");
             Console.WriteLine("Usage: Drag a file, or group of files on the executable to parse it.");
-            Console.WriteLine("Command line usage: WowPacketParser.exe [/ConfigFile path /Option1 value1 ...] filetoparse1 ...");
-            Console.WriteLine("/ConfigFile path - file to read config from, default: WowPacketParser.exe.config.");
-            Console.WriteLine("/Option1 value1 - override Option1 setting from config file with value1.");
+            Console.WriteLine("Command line usage: WowPacketParser.exe [--ConfigFile path --Option1 value1 ...] filetoparse1 ...");
+            Console.WriteLine("--ConfigFile path - file to read config from, default: WowPacketParser.exe.config.");
+            Console.WriteLine("--Option1 value1 - override Option1 setting from config file with value1.");
             Console.WriteLine("Configuration: Modify WowPacketParser.exe.config file.");
             EndPrompt(true);
         }


### PR DESCRIPTION
…ng with '/'. Also work around ConfigurationManager.OpenMappedExeConfiguration not throwing ConfigurationErrorsException on Mono when the specified config file isn't found