### PR TITLE
Show proper GO rotation in sql

### DIFF
--- a/WowPacketParser/App.config
+++ b/WowPacketParser/App.config
@@ -102,6 +102,7 @@
         <add key="creature_template_addon"          value="false"/>
         <add key="creature_text"                    value="false"/>
         <add key="gameobject"                       value="false"/>
+        <add key="gameobject_addon"                 value="false"/>
         <add key="gameobject_template"              value="false"/>
         <add key="gossip_menu"                      value="false"/>
         <add key="gossip_menu_option"               value="false"/>

--- a/WowPacketParser/Enums/SQLOutput.cs
+++ b/WowPacketParser/Enums/SQLOutput.cs
@@ -11,6 +11,7 @@
         creature_template_addon,
         creature_text,
         gameobject,
+        gameobject_addon,
         gameobject_template,
         gossip_menu,
         gossip_menu_option,

--- a/WowPacketParser/SQL/Builders/Spawns.cs
+++ b/WowPacketParser/SQL/Builders/Spawns.cs
@@ -28,7 +28,7 @@ namespace WowPacketParser.SQL.Builders
 
             if (SQLConnector.Enabled)
             {
-                var transportTemplates = SQLDatabase.Get(new RowList<GameObjectTemplate> {new GameObjectTemplate {Entry = entry.UInt32Value} });
+                var transportTemplates = SQLDatabase.Get(new RowList<GameObjectTemplate> { new GameObjectTemplate { Entry = entry.UInt32Value } });
                 if (transportTemplates.Count == 0)
                     return false;
 
@@ -48,7 +48,7 @@ namespace WowPacketParser.SQL.Builders
                 return string.Empty;
 
             uint count = 0;
-            var rows  = new RowList<Creature>();
+            var rows = new RowList<Creature>();
             var addonRows = new RowList<CreatureAddon>();
             foreach (var unit in units)
             {
@@ -229,6 +229,7 @@ namespace WowPacketParser.SQL.Builders
 
             uint count = 0;
             var rows = new RowList<GameObjectModel>();
+            var addonRows = new RowList<GameObjectAddon>();
             foreach (var gameobject in gameObjects)
             {
                 Row<GameObjectModel> row = new Row<GameObjectModel>();
@@ -293,11 +294,38 @@ namespace WowPacketParser.SQL.Builders
                     row.Data.Orientation = go.Movement.TransportOffset.O;
                 }
 
-                var rotation = go.GetRotation();
-                if (rotation != null && rotation.Length == 4)
-                    row.Data.Rotation = rotation.Cast<float?>().ToArray();
-                else
-                    row.Data.Rotation = new float?[] { 0, 0, 0, 0 };
+                var rotation = go.GetStaticRotation();
+                row.Data.Rotation = new float?[] { rotation.X, rotation.Y, rotation.Z, rotation.W };
+
+                bool add = true;
+                var addonRow = new Row<GameObjectAddon>();
+                if (Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.gameobject_addon))
+                {
+                    addonRow.Data.GUID = "@OGUID+" + count;
+
+                    var parentRotation = go.GetParentRotation();
+
+                    if (parentRotation != null)
+                    {
+                        addonRow.Data.parentRot0 = parentRotation[0].GetValueOrDefault(0.0f);
+                        addonRow.Data.parentRot1 = parentRotation[1].GetValueOrDefault(0.0f);
+                        addonRow.Data.parentRot2 = parentRotation[2].GetValueOrDefault(0.0f);
+                        addonRow.Data.parentRot3 = parentRotation[3].GetValueOrDefault(1.0f);
+
+                        if (addonRow.Data.parentRot0 == 0.0f &&
+                            addonRow.Data.parentRot1 == 0.0f &&
+                            addonRow.Data.parentRot2 == 0.0f &&
+                            addonRow.Data.parentRot3 == 1.0f)
+                            add = false;
+                    }
+                    else
+                        add = false;
+
+                    addonRow.Comment += StoreGetters.GetName(StoreNameType.GameObject, (int)gameobject.Key.GetEntry(), false);
+
+                    if (add)
+                        addonRows.Add(addonRow);
+                }
 
                 row.Data.SpawnTimeSecs = (int)go.GetDefaultSpawnTime();
                 row.Data.AnimProgress = animprogress;
@@ -332,17 +360,25 @@ namespace WowPacketParser.SQL.Builders
                 rows.Add(row);
             }
 
-            StringBuilder result = new StringBuilder();
+            if (count == 0)
+                return String.Empty;
 
-            if (count > 0)
-            {
-                // delete query for GUIDs
-                var delete = new SQLDelete<GameObjectModel>(Tuple.Create("@OGUID+0", "@OGUID+" + --count));
-                result.Append(delete.Build());
-            }
+            StringBuilder result = new StringBuilder();
+            // delete query for GUIDs
+            var delete = new SQLDelete<GameObjectModel>(Tuple.Create("@OGUID+0", "@OGUID+" + --count));
+            result.Append(delete.Build());
 
             var sql = new SQLInsert<GameObjectModel>(rows, false);
             result.Append(sql.Build());
+
+            if (Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.gameobject_addon))
+            {
+                var addonDelete = new SQLDelete<GameObjectAddon>(Tuple.Create("@OGUID+0", "@OGUID+" + count));
+                result.Append(addonDelete.Build());
+                var addonSql = new SQLInsert<GameObjectAddon>(addonRows, false);
+                result.Append(addonSql.Build());
+            }
+
             return result.ToString();
         }
     }

--- a/WowPacketParser/Store/Objects/GameObject.cs
+++ b/WowPacketParser/Store/Objects/GameObject.cs
@@ -31,9 +31,14 @@ namespace WowPacketParser.Store.Objects
             return false;
         }
 
-        public float[] GetRotation()
+        public Quaternion GetStaticRotation()
         {
-            return UpdateFields.GetArray<GameObjectField, float>(GameObjectField.GAMEOBJECT_PARENTROTATION, 4);
+            return Movement.Rotation;
+        }
+
+        public float?[] GetParentRotation()
+        {
+            return UpdateFields.GetArray<GameObjectField, float?>(GameObjectField.GAMEOBJECT_PARENTROTATION, 4);
         }
 
         public bool IsTransport()

--- a/WowPacketParser/Store/Objects/GameObjectAddon.cs
+++ b/WowPacketParser/Store/Objects/GameObjectAddon.cs
@@ -1,0 +1,23 @@
+using WowPacketParser.SQL;
+
+namespace WowPacketParser.Store.Objects
+{
+    [DBTableName("gameobject_addon")]
+    public sealed class GameObjectAddon : IDataModel
+    {
+        [DBFieldName("guid", true)]
+        public string GUID;
+
+        [DBFieldName("parent_rotation0")]
+        public float? parentRot0;
+
+        [DBFieldName("parent_rotation1")]
+        public float? parentRot1;
+
+        [DBFieldName("parent_rotation2")]
+        public float? parentRot2;
+
+        [DBFieldName("parent_rotation3")]
+        public float? parentRot3;
+    }
+}

--- a/WowPacketParser/WowPacketParser.csproj
+++ b/WowPacketParser/WowPacketParser.csproj
@@ -511,6 +511,7 @@
     <Compile Include="Store\Objects\CreatureTemplateAddon.cs" />
     <Compile Include="Store\Objects\CreatureText.cs" />
     <Compile Include="Store\Objects\CurvePoint.cs" />
+    <Compile Include="Store\Objects\GameObjectAddon.cs" />
     <Compile Include="Store\Objects\GameObject.cs" />
     <Compile Include="Store\Objects\GameObjectModel.cs" />
     <Compile Include="Store\Objects\GameObjects.cs" />


### PR DESCRIPTION
As of now, WPP sql is not handling properly GO rotation Quat, this should fix it.

Ref: https://github.com/TrinityCore/TrinityCore/pull/14146

Example sql output:

```sql
INSERT INTO gameobject (`guid`, `id`, `map`, `zoneId`, `areaId`, `spawnMask`, `phaseMask`, `PhaseGroup`, `position_x`, `position_y`, `position_z`, `orientation`, `rotation0`, `rotation1`, `rotation2`, `rotation3`, `spawntimesecs`, `animprogress`, `state`, `VerifiedBuild`) VALUES
('@OGUID+0', 2113, 0, 0, 0, 1, 1, 0, -8735.72, 704.7566, 98.09462, -2.452184, 0, 0, 0.944089, -0.3296907, 120, 255, 1, 11159), -- 2113 (Area: 0)
('@OGUID+1', 3662, 0, 0, 0, 1, 1, 0, -8672.726, 822.5149, 98.71033, 0.4188786, 0, 0, 0, 1, 120, 255, 1, 11159), -- 3662 (Area: 0)
('@OGUID+2', 25340, 0, 0, 0, 1, 1, 0, -8684.513, 709.8165, 109.4213, -2.46964, 0, 0, 0.944089, -0.3296907, 120, 255, 1, 11159), -- 25340 (Area: 0)
('@OGUID+3', 180772, 0, 0, 0, 1, 1, 0, -8794.099, 771.608, 96.33801, 0.08726601, 0, 0, 0, 1, 120, 255, 1, 11159), -- 180772 (Area: 0)
(...)
```