### PR TITLE
Changed the type of the timestamp field from signed to unsigned int in MOVE packets

### DIFF
--- a/WowPacketParser/Parsing/Parsers/MovementHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/MovementHandler.cs
@@ -42,7 +42,7 @@ namespace WowPacketParser.Parsing.Parsers
                 if (packet.ReadGuid("GUID 2", index) != guid)
                     throw new InvalidDataException("Guids are not equal.");
 
-            packet.ReadInt32("Time", index);
+            packet.ReadUInt32("Time", index);
 
             info.Position = packet.ReadVector3("Position", index);
             info.Orientation = packet.ReadSingle("Orientation", index);
@@ -135,7 +135,7 @@ namespace WowPacketParser.Parsing.Parsers
 
             packet.ReadGuid("GUID 2", index);
 
-            packet.ReadInt32("Time", index);
+            packet.ReadUInt32("Time", index);
 
             info.Position = packet.ReadVector3("Position", index);
             info.Orientation = packet.ReadSingle("Orientation", index);
@@ -503,7 +503,7 @@ namespace WowPacketParser.Parsing.Parsers
             else
             {
                 packet.ReadInt32E<MovementFlag>("Move Flags");
-                packet.ReadInt32("Time");
+                packet.ReadUInt32("Time");
             }
         }
 
@@ -545,7 +545,7 @@ namespace WowPacketParser.Parsing.Parsers
             if (interPolatedTurning)
                 jumping = packet.ReadBit("Jumping");
 
-            packet.ReadInt32("Time");
+            packet.ReadUInt32("Time");
             packet.ReadVector4("Position");
 
             packet.ReadXORByte(guidBytes, 7);
@@ -644,7 +644,7 @@ namespace WowPacketParser.Parsing.Parsers
             if (interPolatedTurning)
                 jumping = packet.ReadBit("Jumping");
 
-            packet.ReadInt32("Time");
+            packet.ReadUInt32("Time");
             packet.ReadVector4("Position");
 
             packet.ReadXORByte(guidBytes, 7);
@@ -747,7 +747,7 @@ namespace WowPacketParser.Parsing.Parsers
                 jumping = packet.ReadBit("HasFallDirection");
 
             packet.ReadVector3("Position");
-            packet.ReadInt32("Time");
+            packet.ReadUInt32("Time");
             packet.ReadSingle("Orientation");
 
             packet.ReadXORByte(guidBytes, 1);
@@ -1731,7 +1731,7 @@ namespace WowPacketParser.Parsing.Parsers
         public static void HandleMoveTimeSkippedMsg(Packet packet)
         {
             packet.ReadPackedGuid("Guid");
-            packet.ReadInt32("Time");
+            packet.ReadUInt32("Time");
         }
 
         [Parser(Opcode.CMSG_MOVE_TIME_SKIPPED, ClientVersionBuild.Zero, ClientVersionBuild.V4_3_4_15595)]
@@ -1741,7 +1741,7 @@ namespace WowPacketParser.Parsing.Parsers
                 packet.ReadGuid("GUID");
             else
                 packet.ReadPackedGuid("GUID");
-            packet.ReadInt32("Time");
+            packet.ReadUInt32("Time");
         }
 
         [Parser(Opcode.SMSG_MOVE_SPLINE_ROOT, ClientVersionBuild.Zero, ClientVersionBuild.V4_3_4_15595)]


### PR DESCRIPTION
Changed the type of the time field in MSG_MOVE messages to uint32 from int32.

The same change should be done to the parsers of the other versions (4.x and up) but I'm not working on those so it won't be part of this PR.

Proof that unsigned int32 should be used instead of signed int32:

**Before**:

> ServerToClient: SMSG_SPELL_GO (0x0132) Length: 51 ConnIdx: 0 Time: 10/06/2010 17:11:19.000 **Number: 654**
> Caster GUID: Full: 0xAAAAAAAAAAAAAAA Type: Player Low: 999999999
> Caster Unit GUID: Full: 0xAAAAAAAAAAAAAAA  Type: Player Low: 999999999
> Cast Count: 31
> Spell ID: 403 (403)
> Cast Flags: Unknown7, PredictedPower, Unknown16 (264448)
> **Time: 2189852173**
> Hit Count: 1
> [0] Hit GUID: Full: 0xF130000B8E010E0E Type: Creature Entry: 2958 Low: 69134
> Miss Count: 0
> Target Flags: Unit (2)
> Target GUID: Full: 0xF130000B8E010E0E Type: Creature Entry: 2958 Low: 69134
> Rune Cooldown: 60
> 
> ServerToClient: MSG_MOVE_HEARTBEAT (0x00EE) Length: 36 ConnIdx: 0 Time: 10/06/2010 17:11:19.000 **Number: 655**
> GUID: Full: 0xAAAAAAAAAAAAAAA  Type: Player Low: 999999999 Name: XXXXXXXX
> Movement Flags: Forward (1)
> Extra Movement Flags: None (0)
> **Time: -2105113555**
> Position: X: -2695.974 Y: -10.04808 Z: 6.521426
> Orientation: 2.258534
> Fall Time: 3

**After**:
> ServerToClient: SMSG_SPELL_GO (0x0132) Length: 51 ConnIdx: 0 Time: 10/06/2010 17:11:19.000 **Number: 654**
> Caster GUID: Full: 0xAAAAAAAAAAAAAAA Type: Player Low: 999999999
> Caster Unit GUID: Full: 0xAAAAAAAAAAAAAAA Type: Player Low: 999999999
> Cast Count: 31
> Spell ID: 403 (403)
> Cast Flags: Unknown7, PredictedPower, Unknown16 (264448)
> **Time: 2189852173**
> Hit Count: 1
> [0] Hit GUID: Full: 0xF130000B8E010E0E Type: Creature Entry: 2958 Low: 69134
> Miss Count: 0
> Target Flags: Unit (2)
> Target GUID: Full: 0xF130000B8E010E0E Type: Creature Entry: 2958 Low: 69134
> Rune Cooldown: 60
> 
> ServerToClient: MSG_MOVE_HEARTBEAT (0x00EE) Length: 36 ConnIdx: 0 Time: 10/06/2010 17:11:19.000 **Number: 655**
> GUID: Full: 0xAAAAAAAAAAAAAAA Type: Player Low: 999999999 Name: XXXXXXXX
> Movement Flags: Forward (1)
> Extra Movement Flags: None (0)
> **Time: 2189853741**
> Position: X: -2695.974 Y: -10.04808 Z: 6.521426
> Orientation: 2.258534
> Fall Time: 3