### PR TITLE
fix the parsing of MSG_MOVE_SET_COLLISION_HGT and MSG_MOVE_KNOCK_BACK

### DIFF
--- a/WowPacketParser/Enums/Version/Opcodes.cs
+++ b/WowPacketParser/Enums/Version/Opcodes.cs
@@ -340,6 +340,7 @@ namespace WowPacketParser.Enums.Version
                         return opcode;
                     break;
                 case Direction.ServerToClient:
+                case Direction.Bidirectional:
                     if (_serverDict.TryGetBySecond(opcodeId, out opcode))
                         return opcode;
                     if (_miscDict.TryGetBySecond(opcodeId, out opcode))
@@ -361,6 +362,7 @@ namespace WowPacketParser.Enums.Version
                         return opcode;
                     break;
                 case Direction.ServerToClient:
+                case Direction.Bidirectional:
                     if (_serverDict.TryGetByFirst(opcodeId, out opcode))
                         return opcode;
                     if (_miscDict.TryGetByFirst(opcodeId, out opcode))


### PR DESCRIPTION
fix GetOpcode() which didn't handle properly Direction.Bidirectional as second parameter.

MSG_MOVE_SET_COLLISION_HGT and MSG_MOVE_KNOCK_BACK were affected by this issue.