### PR TITLE
Improve spell_areatrigger with DBC & fix DBC path locales

### DIFF
--- a/WowPacketParser/App.config
+++ b/WowPacketParser/App.config
@@ -227,6 +227,13 @@
           <add key="DBCPath" value="\dbc"/>
 
           <!--
+                 Option:      DbcLocale
+                 Description: Set DBC/DB2 Locales
+                 Default:     "enUS"
+            -->
+          <add key="DBCLocale" value="enUS"/>
+
+          <!--
                  Option:      ParseSpellInfos
                  Description: Parse spell infos to output file (only *.txt)
                  Default:     "false" (No prompt)

--- a/WowPacketParser/DBC/DBC.cs
+++ b/WowPacketParser/DBC/DBC.cs
@@ -36,7 +36,7 @@ namespace WowPacketParser.DBC
 
         private static string GetPath()
         {
-            return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + Settings.DBCPath + @"\" + BinaryPacketReader.GetLocale() + @"\";
+            return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location) + Settings.DBCPath + @"\" + Settings.DBCLocale + @"\";
         }
 
         public static async void Load()

--- a/WowPacketParser/Misc/Settings.cs
+++ b/WowPacketParser/Misc/Settings.cs
@@ -48,6 +48,7 @@ namespace WowPacketParser.Misc
 
         // DB2
         public static readonly string DBCPath = Conf.GetString("DBCPath", $@"\dbc");
+        public static readonly string DBCLocale = Conf.GetString("DBCLocale", "enUS");
         public static readonly bool UseDBC = Conf.GetBoolean("UseDBC", false);
         public static readonly bool ParseSpellInfos = Conf.GetBoolean("ParseSpellInfos", false);
 


### PR DESCRIPTION
Use DBC to determine spell_areatrigger miscId, it will be set if the spell has only one "SPELL_EFFECT_CREATE_AREATRIGGER" or "SPELL_AURA_AREA_TRIGGER", otherwise it will be let undefined

Also fix DBC locale pathing by adding a setting, at the time the DBC are loaded, locale has not been defined from .pkt file, and it was always taking default (enUS) locale