### PR TITLE
Add QuestObjective hotfix

### DIFF
--- a/WowPacketParserModule.V7_0_3_22248/Hotfix/QuestObjectiveEntry.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Hotfix/QuestObjectiveEntry.cs
@@ -1,7 +1,5 @@
-﻿using System.Runtime.CompilerServices;
-using WowPacketParser.Enums;
+﻿using WowPacketParser.Enums;
 using WowPacketParser.Hotfix;
-
 
 namespace WowPacketParserModule.V7_0_3_22248.Hotfix
 {

--- a/WowPacketParserModule.V7_0_3_22248/Hotfix/QuestObjectiveEntry.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Hotfix/QuestObjectiveEntry.cs
@@ -1,0 +1,20 @@
+﻿using System.Runtime.CompilerServices;
+using WowPacketParser.Enums;
+using WowPacketParser.Hotfix;
+
+
+namespace WowPacketParserModule.V7_0_3_22248.Hotfix
+{
+    [HotfixStructure(DB2Hash.QuestObjective, HasIndexInData = false)]
+    public class QuestObjectiveEntry
+    {
+        public uint Amount { get; set; }
+        public uint ObjectID { get; set; }
+        public string Description { get; set; }
+        public ushort QuestID { get; set; }
+        public byte Type { get; set; }
+        public byte ObjectivePanelorder { get; set; }
+        public byte MapOrder { get; set; }
+        public byte Flags { get; set; }
+    }
+}

--- a/WowPacketParserModule.V7_0_3_22248/WowPacketParserModule.V7_0_3_22248.csproj
+++ b/WowPacketParserModule.V7_0_3_22248/WowPacketParserModule.V7_0_3_22248.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Hotfix\PvpRewardEntry.cs" />
     <Compile Include="Hotfix\QuestFactionRewardEntry.cs" />
     <Compile Include="Hotfix\QuestMoneyRewardEntry.cs" />
+    <Compile Include="Hotfix\QuestObjectiveEntry.cs" />
     <Compile Include="Hotfix\QuestPackageItemEntry.cs" />
     <Compile Include="Hotfix\QuestPackageItemEntry720.cs" />
     <Compile Include="Hotfix\QuestSortEntry.cs" />


### PR DESCRIPTION
ObjectivePanelorder  and MapOrder might be unclear (naming & meaning)

So to clear it out with an example:
Let's take quest [33145](http://www.wowhead.com/quest=33145)
With these objectives
```
+--------+--------+----------+----------------------------+---------+------+---------------------+----------+------+
| ID     | Amount | ObjectID | Description                | QuestID | Type | ObjectivePanelOrder | MapOrder | Flag |
+--------+--------+----------+----------------------------+---------+------+---------------------+----------+------+
| 270941 |      3 |    73284 | Captured Frostwolves Freed |   33145 |    0 |                   1 |        0 |    0 |
| 274612 |      8 |    72953 | Grimfrost ogres slain      |   33145 |    0 |                   0 |        1 |    0 |
+--------+--------+----------+----------------------------+---------+------+---------------------+----------+------+
```
<details>

![maporder](https://cloud.githubusercontent.com/assets/6825243/25700364/be68300e-30c7-11e7-9bf9-abdcfb1feb58.PNG)

![objectivepanelorder](https://cloud.githubusercontent.com/assets/6825243/25700365/c0da0826-30c7-11e7-92fb-c16e7b82daae.PNG)

</details>