### PR TITLE
Rename a few unks in SMSG_UNIT_SPELLCAST_START

### DIFF
--- a/WowPacketParser/Parsing/Parsers/SpellHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/SpellHandler.cs
@@ -1354,10 +1354,10 @@ namespace WowPacketParser.Parsing.Parsers
             packet.ReadInt32("Time Casted");
             packet.ReadInt32("Cast time");
 
-            if (packet.ReadBool("Unknown bool"))
+            if (packet.ReadBool("HasImmunities"))
             {
-                packet.ReadUInt32("Unk");
-                packet.ReadUInt32("Unk");
+                packet.ReadUInt32("Cast School Immunities");
+                packet.ReadUInt32("Cast Immunities");
             }
         }
 


### PR DESCRIPTION
....

@Shauren: why is the core never sending this? It seems to be in charge of channel spells as well.

Trying to figure out how to have the client properly refresh the channel bar on recast of Mind Flay.
Mind flay is supposed to behave like a DoT since Cataclysm, where re-channels will not re-cast the DoT, but rather update it, rolling over the last tick if refreshed between the last and second to last. Currently, re-channeling Mind Flay removes the aura (`RemoveOwnedAura` called by `InterruptNonMeleeSpell`, from `Spell::cancel`) and applies a new one (aka Wrath behavior). Basically, the time remaining for the previous channel of Mind Flay (on the same target, naturally) should be added back to the beginning of the following cast, with the corresponding extra tick.

Channeled spells with such behavior have `SPELL_ATTR_CHANNELED_1 | SPELL_ATTR_CHANNELED_2` and `SPELL_ATTR8_DONT_RESET_PERIODIC_TIMER`.

DoT rolling is not implemented at all, by the way. (I currently have it locally where the extra tick is correctly added serverside, but the channel bar does not perceive it)