### PR TITLE
Fix a crash on spawn builder if not using dbc

### DIFF
--- a/WowPacketParser/Store/Objects/WoWObject.cs
+++ b/WowPacketParser/Store/Objects/WoWObject.cs
@@ -41,7 +41,7 @@ namespace WowPacketParser.Store.Objects
 
         public int GetDefaultSpawnTime(uint difficultyID)
         {
-             if (DBC.DBC.Map != null)
+             if (Settings.UseDBC && DBC.DBC.Map != null)
              {
                  if (DBC.DBC.Map.ContainsKey((int)Map))
                  {


### PR DESCRIPTION
Without the check creature/gameobject table data is never extracted

```
20/45 - Error: Failed writing Creature
WowPacketParser.exe Error: 0 : System.TypeInitializationException: Se produjo una excepción en el inicializador de tipo de 'WowPacketParser.DBC.DBC'. ---> System.IO.DirectoryNotFoundException: No se puede encontrar una parte de la ruta de acceso 'E:\WowPacketParser-master\WowPacketParser\bin\Release\dbc\enUS\AreaTable.db2'.
   en System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   en System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   en System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   en System.IO.File.Open(String path, FileMode mode, FileAccess access, FileShare share)
   en DBFilesClient.NET.Storage`1..ctor(String fileName, Boolean readOnly)
   en WowPacketParser.DBC.DBC..cctor() en E:\WowPacketParser-master\WowPacketParser\DBC\DBC.cs:línea 16
   --- Fin del seguimiento de la pila de la excepción interna ---
   en WowPacketParser.Store.Objects.WoWObject.GetDefaultSpawnTime(UInt32 difficultyID) en E:\WowPacketParser-master\WowPacketParser\Store\Objects\WoWObject.cs:línea 44
   en WowPacketParser.SQL.Builders.Spawns.Creature(Dictionary`2 units) en E:\WowPacketParser-master\WowPacketParser\SQL\Builders\Spawns.cs:línea 128
21/45 - Write GameObject
21/45 - Error: Failed writing GameObject
WowPacketParser.exe Error: 0 : System.TypeInitializationException: Se produjo una excepción en el inicializador de tipo de 'WowPacketParser.DBC.DBC'. ---> System.IO.DirectoryNotFoundException: No se puede encontrar una parte de la ruta de acceso 'E:\WowPacketParser-master\WowPacketParser\bin\Release\dbc\enUS\AreaTable.db2'.
   en System.IO.__Error.WinIOError(Int32 errorCode, String maybeFullPath)
   en System.IO.FileStream.Init(String path, FileMode mode, FileAccess access, Int32 rights, Boolean useRights, FileShare share, Int32 bufferSize, FileOptions options, SECURITY_ATTRIBUTES secAttrs, String msgPath, Boolean bFromProxy, Boolean useLongPath, Boolean checkHost)
   en System.IO.FileStream..ctor(String path, FileMode mode, FileAccess access, FileShare share)
   en System.IO.File.Open(String path, FileMode mode, FileAccess access, FileShare share)
   en DBFilesClient.NET.Storage`1..ctor(String fileName, Boolean readOnly)
   en WowPacketParser.DBC.DBC..cctor() en E:\WowPacketParser-master\WowPacketParser\DBC\DBC.cs:línea 16
   --- Fin del seguimiento de la pila de la excepción interna ---
   en WowPacketParser.Store.Objects.WoWObject.GetDefaultSpawnTime(UInt32 difficultyID) en E:\WowPacketParser-master\WowPacketParser\Store\Objects\WoWObject.cs:línea 44
   en WowPacketParser.SQL.Builders.Spawns.GameObject(Dictionary`2 gameObjects) en E:\WowPacketParser-master\WowPacketParser\SQL\Builders\Spawns.cs:línea 346
22/45 - Write SpellTargetPosition
```