### PR TITLE
Update Scaling for 7.3.5

### DIFF
--- a/WowPacketParser/Store/Objects/CreatureTemplateScaling.cs
+++ b/WowPacketParser/Store/Objects/CreatureTemplateScaling.cs
@@ -15,8 +15,11 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("LevelScalingMax")]
         public uint? LevelScalingMax;
 
-        [DBFieldName("LevelScalingDelta")]
-        public int? LevelScalingDelta;
+        [DBFieldName("LevelScalingDeltaMin")]
+        public int? LevelScalingDeltaMin;
+
+        [DBFieldName("LevelScalingDeltaMax")]
+        public int? LevelScalingDeltaMax;
 
         [DBFieldName("VerifiedBuild")]
         public int? VerifiedBuild = ClientVersion.BuildInt;

--- a/WowPacketParser/Store/Objects/Unit.cs
+++ b/WowPacketParser/Store/Objects/Unit.cs
@@ -39,7 +39,7 @@ namespace WowPacketParser.Store.Objects
         public uint? Level;
         public uint? ScalingMinLevel;
         public uint? ScalingMaxLevel;
-        public uint? ScalingDelta;
+        public int? ScalingDelta;
         public uint? Faction;
         public uint[] EquipmentItemId;
         public ushort[] EquipmentAppearanceModId;
@@ -134,17 +134,7 @@ namespace WowPacketParser.Store.Objects
             {
                 ScalingMinLevel = UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_SCALING_LEVEL_MIN);
                 ScalingMaxLevel = UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_SCALING_LEVEL_MAX);
-
-                if (ScalingMinLevel != null && ScalingMaxLevel != null)
-                {
-                    CreatureTemplateScaling creatureTemplateScaling = new CreatureTemplateScaling();
-                    creatureTemplateScaling.Entry                   = UpdateFields.GetValue<ObjectField, uint>(ObjectField.OBJECT_FIELD_ENTRY);
-                    creatureTemplateScaling.LevelScalingMin         = ScalingMinLevel;
-                    creatureTemplateScaling.LevelScalingMax         = ScalingMaxLevel;
-                    creatureTemplateScaling.LevelScalingDelta       = UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_SCALING_LEVEL_DELTA);
-                    Storage.CreatureTemplateScalings.Add(creatureTemplateScaling);
-                }
-
+                ScalingDelta = UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_SCALING_LEVEL_DELTA); ;
                 EquipmentRaw = UpdateFields.GetArray<UnitField, uint>(UnitField.UNIT_VIRTUAL_ITEM_SLOT_ID, 6);
             }
             else

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/UpdateHandler.cs
@@ -722,6 +722,9 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 }
 
                 // HACK...
+                if (key == UnitField.UNIT_FIELD_SCALING_LEVEL_DELTA.ToString())
+                    value = (int)blockVal.UInt32Value + "/" + blockVal.SingleValue;
+
                 if (key == UnitField.UNIT_FIELD_FACTIONTEMPLATE.ToString())
                     packet.AddValue(key, value + $" ({ StoreGetters.GetName(StoreNameType.Faction, (int)blockVal.UInt32Value, false) })", index);
                 else


### PR DESCRIPTION
[#21521](https://github.com/TrinityCore/TrinityCore/pull/21521)

LevelDelta is no constant.
Creatures vari in there level.

Also there might be no need for Min and Max level because all values i've found are similar to their SandboxScaling data selected by their sandboxscalingid.