### PR TITLE
Second Upgrade for WPP

### DIFF
--- a/WowPacketParser/App.config
+++ b/WowPacketParser/App.config
@@ -149,6 +149,14 @@
 
         <add key="hotfix_data"                            value="false"/>
 
+
+        <!--
+               Option:      ForceInsertQueries
+               Description: Won't generate UPDATE queries, but DELETE and INSERT queries.
+               Default:     "false"
+        -->
+        <add key="ForceInsertQueries" value="false"/>
+
         <!--
                Option:      RecalcDiscount
                Description: Recalculate repuation discounts on moneyCost to receive originalMoneyCost (only works with DBCs and NON-fusion .pkt)

--- a/WowPacketParser/App.config
+++ b/WowPacketParser/App.config
@@ -117,6 +117,7 @@
         <add key="creature_model_info"                    value="false"/>
         <add key="creature_template"                      value="false"/>
         <add key="creature_template_addon"                value="false"/>
+        <add key="creature_template_locale"               value="false"/>
         <add key="creature_template_scaling"              value="false"/>
         <add key="creature_text"                          value="false"/>
         <add key="gameobject"                             value="false"/>

--- a/WowPacketParser/DBC/Structures/Legion/BroadcastTextEntry.cs
+++ b/WowPacketParser/DBC/Structures/Legion/BroadcastTextEntry.cs
@@ -6,14 +6,14 @@ namespace WowPacketParser.DBC.Structures
 
     public sealed class BroadcastTextEntry
     {
-        public string MaleText;
-        public string FemaleText;
+        public string Text;
+        public string Text1;
         public ushort[] EmoteID;
         public ushort[] EmoteDelay;
-        public ushort UnkEmoteID;
-        public byte Language;
-        public byte Type;
-        public uint[] SoundID;
-        public uint PlayerConditionID;
+        public ushort EmotesID;
+        public byte LanguageID;
+        public byte Flags;
+        public uint[] SoundEntriesID;
+        public uint ConditionID;
     }
 }

--- a/WowPacketParser/Misc/Settings.cs
+++ b/WowPacketParser/Misc/Settings.cs
@@ -19,6 +19,7 @@ namespace WowPacketParser.Misc
         public static readonly ulong SQLOutputFlag = GetSQLOutputFlag();
         public static readonly bool SQLOrderByKey = Conf.GetBoolean("SqlOrderByKey", false);
         public static readonly bool SkipOnlyVerifiedBuildUpdateRows = Conf.GetBoolean("SkipOnlyVerifiedBuildUpdateRows", false);
+        public static readonly bool ForceInsertQueries = Conf.GetBoolean("ForceInsertQueries", false);
         public static readonly bool RecalcDiscount = Conf.GetBoolean("RecalcDiscount", false);
         public static readonly string SQLFileName = Conf.GetString("SQLFileName", string.Empty);
         public static readonly bool ShowEndPrompt = Conf.GetBoolean("ShowEndPrompt", false);

--- a/WowPacketParser/Misc/Utilities.cs
+++ b/WowPacketParser/Misc/Utilities.cs
@@ -258,7 +258,7 @@ namespace WowPacketParser.Misc
                 return str1 == str2;
 
             if (o1 is ulong && o2 is ulong)
-                return o1 == o2;
+                return Convert.ToUInt64(o1) == Convert.ToUInt64(o2);
 
             // this still works if objects are booleans or enums
             return Convert.ToInt64(o1) == Convert.ToInt64(o2);

--- a/WowPacketParser/Misc/Utilities.cs
+++ b/WowPacketParser/Misc/Utilities.cs
@@ -257,6 +257,9 @@ namespace WowPacketParser.Misc
             if (str1 != null)
                 return str1 == str2;
 
+            if (o1 is ulong && o2 is ulong)
+                return o1 == o2;
+
             // this still works if objects are booleans or enums
             return Convert.ToInt64(o1) == Convert.ToInt64(o2);
         }

--- a/WowPacketParser/Parsing/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/MiscellaneousHandler.cs
@@ -1112,7 +1112,6 @@ namespace WowPacketParser.Parsing.Parsers
         [Parser(Opcode.SMSG_VOICESESSION_FULL)] // 61 bytes in 2.4.1
         [Parser(Opcode.SMSG_DEBUG_SERVER_GEO)] // Was unknown
         [Parser(Opcode.SMSG_RESUME_COMMS)]
-        [Parser(Opcode.SMSG_GOSSIP_COMPLETE)]
         [Parser(Opcode.SMSG_INVALID_PROMOTION_CODE)]
         [Parser(Opcode.CMSG_COMPLETE_CINEMATIC)]
         [Parser(Opcode.CMSG_NEXT_CINEMATIC_CAMERA)]

--- a/WowPacketParser/Program.cs
+++ b/WowPacketParser/Program.cs
@@ -37,6 +37,16 @@ namespace WowPacketParser
             Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
             CultureInfo.DefaultThreadCurrentCulture = CultureInfo.InvariantCulture;
 
+            if (Settings.UseDBC)
+            {
+                var startTime = DateTime.Now;
+
+                DBC.DBC.Load();
+
+                var span = DateTime.Now.Subtract(startTime);
+                Trace.WriteLine($"DBC loaded in { span.ToFormattedString() }.");
+            }
+
             // Disable DB when we don't need its data (dumping to a binary file)
             if (!Settings.DumpFormatWithSQL())
             {
@@ -47,16 +57,6 @@ namespace WowPacketParser
                 Filters.Initialize();
 
             SQLConnector.ReadDB();
-
-            if (Settings.UseDBC)
-            {
-                var startTime = DateTime.Now;
-
-                DBC.DBC.Load();
-
-                var span = DateTime.Now.Subtract(startTime);
-                Trace.WriteLine($"DBC loaded in { span.ToFormattedString() }.");
-            }
 
             var count = 0;
             foreach (var file in files)

--- a/WowPacketParser/SQL/Builders/HotfixBuilder.cs
+++ b/WowPacketParser/SQL/Builders/HotfixBuilder.cs
@@ -75,6 +75,9 @@ namespace WowPacketParser.SQL.Builders
             if (!Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.broadcast_text))
                 return string.Empty;
 
+            foreach (var broadcastText in Storage.BroadcastTexts)
+                broadcastText.Item1.ConvertToDBStruct();
+
             // pass empty list, because we want to select the whole db table (faster than select only needed columns)
             var templatesDb = SQLDatabase.Get(new RowList<Store.Objects.BroadcastText>(), Settings.HotfixesDatabase);
 

--- a/WowPacketParser/SQL/Builders/WDBTemplates.cs
+++ b/WowPacketParser/SQL/Builders/WDBTemplates.cs
@@ -70,6 +70,12 @@ namespace WowPacketParser.SQL.Builders
             if (Storage.CreatureTemplates.IsEmpty())
                 return string.Empty;
 
+            foreach (var creatureTemplate in Storage.CreatureTemplates)
+            {
+                if (creatureTemplate.Item1.FemaleName == null)
+                    creatureTemplate.Item1.FemaleName = string.Empty;
+            }
+
             var templatesDb = SQLDatabase.Get(Storage.CreatureTemplates);
             return SQLUtil.Compare(Storage.CreatureTemplates, templatesDb, StoreNameType.Unit);
         }

--- a/WowPacketParser/SQL/SQLUtil.cs
+++ b/WowPacketParser/SQL/SQLUtil.cs
@@ -202,7 +202,7 @@ namespace WowPacketParser.SQL
 
             foreach (var elem1 in storeList)
             {
-                if (dbList != null && dbList.ContainsKey(elem1.Item1)) // update
+                if (dbList != null && dbList.ContainsKey(elem1.Item1) && !Settings.ForceInsertQueries) // update
                 {
 
                     var lastField = fields[fields.Count - 1];

--- a/WowPacketParser/SQL/SQLUtil.cs
+++ b/WowPacketParser/SQL/SQLUtil.cs
@@ -54,12 +54,8 @@ namespace WowPacketParser.SQL
         /// <returns>Modified string</returns>
         public static string EscapeString(string str)
         {
-            str = MySqlHelper.DoubleQuoteString(str);
-            str = str.Replace(Environment.NewLine, @"\n");
-            str = str.Replace("’’", "’"); // french is gay ... 
-
-            // prevent double escaping
-            return str.Replace("\"\"", "\"");
+            str = MySqlHelper.EscapeString(str);
+            return str.Replace(Environment.NewLine, @"\n");
         }
 
         /// <summary>
@@ -249,11 +245,7 @@ namespace WowPacketParser.SQL
                             continue;
 
                         if (val1 is string)
-                        {
                             val1 = ((string)val1).Replace(Environment.NewLine, "\n");
-                            // prevent double escaping
-                            val1 =  ((string)val1).Replace("\"\"", "\"");
-                        }
 
                         if (Utilities.EqualValues(val1, val2))
                             field.Item2.SetValue(elem1.Item1, null);

--- a/WowPacketParser/Store/Objects/BroadcastText.cs
+++ b/WowPacketParser/Store/Objects/BroadcastText.cs
@@ -7,35 +7,68 @@ namespace WowPacketParser.Store.Objects
     [DBTableName("broadcast_text")]
     public sealed class BroadcastText : IDataModel
     {
+        public ushort?[] EmoteID;
+        public ushort?[] EmoteDelay;
+        public uint?[] SoundEntriesID;
+
+        public void ConvertToDBStruct()
+        {
+            EmoteID1 = EmoteID[0];
+            EmoteID2 = EmoteID[1];
+            EmoteID3 = EmoteID[2];
+
+            EmoteDelay1 = EmoteDelay[0];
+            EmoteDelay2 = EmoteDelay[1];
+            EmoteDelay3 = EmoteDelay[2];
+
+            SoundEntriesID1 = SoundEntriesID[0];
+            SoundEntriesID2 = SoundEntriesID[1];
+        }
+
         [DBFieldName("ID", true)]
         public uint? ID;
 
-        [DBFieldName("MaleText", LocaleConstant.enUS)]
-        public string MaleText;
+        [DBFieldName("Text", LocaleConstant.enUS)]
+        public string Text;
 
-        [DBFieldName("FemaleText", LocaleConstant.enUS)]
-        public string FemaleText;
+        [DBFieldName("Text1", LocaleConstant.enUS)]
+        public string Text1;
 
-        [DBFieldName("EmoteID", 3)]
-        public ushort?[] EmoteID;
+        [DBFieldName("EmoteID1")]
+        public ushort? EmoteID1;
 
-        [DBFieldName("EmoteDelay", 3)]
-        public ushort?[] EmoteDelay;
+        [DBFieldName("EmoteID2")]
+        public ushort? EmoteID2;
 
-        [DBFieldName("UnkEmoteID")]
-        public ushort? UnkEmoteID;
+        [DBFieldName("EmoteID3")]
+        public ushort? EmoteID3;
 
-        [DBFieldName("Language")]
-        public byte? Language;
+        [DBFieldName("EmoteDelay1")]
+        public ushort? EmoteDelay1;
 
-        [DBFieldName("Type")]
-        public byte? Type;
+        [DBFieldName("EmoteDelay2")]
+        public ushort? EmoteDelay2;
 
-        [DBFieldName("SoundID", 2)]
-        public uint?[] SoundID;
+        [DBFieldName("EmoteDelay3")]
+        public ushort? EmoteDelay3;
 
-        [DBFieldName("PlayerConditionID")]
-        public uint? PlayerConditionID;
+        [DBFieldName("EmotesID")]
+        public ushort? EmotesID;
+
+        [DBFieldName("LanguageID")]
+        public byte? LanguageID;
+
+        [DBFieldName("Flags")]
+        public byte? Flags;
+
+        [DBFieldName("ConditionID")]
+        public uint? ConditionID;
+
+        [DBFieldName("SoundEntriesID1")]
+        public uint? SoundEntriesID1;
+
+        [DBFieldName("SoundEntriesID2")]
+        public uint? SoundEntriesID2;
 
         [DBFieldName("VerifiedBuild")]
         public int? VerifiedBuild = ClientVersion.BuildInt;

--- a/WowPacketParser/Store/Objects/BroadcastTextLocale.cs
+++ b/WowPacketParser/Store/Objects/BroadcastTextLocale.cs
@@ -13,11 +13,11 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("locale", true)]
         public string Locale = BinaryPacketReader.GetClientLocale();
 
-        [DBFieldName("MaleText_lang")]
-        public string MaleTextLang;
+        [DBFieldName("Text_lang")]
+        public string TextLang;
 
-        [DBFieldName("FemaleText_lang")]
-        public string FemaleTextLang;
+        [DBFieldName("Text1_lang")]
+        public string Text1Lang;
 
         [DBFieldName("VerifiedBuild")]
         public int? VerifiedBuild = ClientVersion.BuildInt;

--- a/WowPacketParser/Store/Objects/CreatureTemplate.cs
+++ b/WowPacketParser/Store/Objects/CreatureTemplate.cs
@@ -19,7 +19,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("name")]
         public string Name;
 
-        [DBFieldName("femaleName", TargetedDatabase.Cataclysm, nullable: true)]
+        [DBFieldName("femaleName", TargetedDatabase.Cataclysm)]
         public string FemaleName;
 
         [DBFieldName("subname", nullable: true)]

--- a/WowPacketParser/Store/Objects/CreatureTemplateLocale.cs
+++ b/WowPacketParser/Store/Objects/CreatureTemplateLocale.cs
@@ -13,7 +13,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("locale", true)]
         public string Locale = BinaryPacketReader.GetClientLocale();
 
-        [DBFieldName("Name")]
+        [DBFieldName("Name", nullable: true)]
         public string Name;
 
         [DBFieldName("NameAlt", nullable: true)]

--- a/WowPacketParser/Store/Objects/GossipMenu.cs
+++ b/WowPacketParser/Store/Objects/GossipMenu.cs
@@ -1,4 +1,5 @@
 using WowPacketParser.Enums;
+using WowPacketParser.Misc;
 using WowPacketParser.SQL;
 
 namespace WowPacketParser.Store.Objects
@@ -11,6 +12,9 @@ namespace WowPacketParser.Store.Objects
 
         [DBFieldName("TextId", true)]
         public uint? TextID;
+
+        [DBFieldName("VerifiedBuild")]
+        public int? VerifiedBuild = ClientVersion.BuildInt;
 
         public ObjectType ObjectType;
 

--- a/WowPacketParser/Store/Objects/GossipMenuOption.cs
+++ b/WowPacketParser/Store/Objects/GossipMenuOption.cs
@@ -1,4 +1,5 @@
 ﻿using WowPacketParser.Enums;
+using WowPacketParser.Misc;
 using WowPacketParser.SQL;
 
 namespace WowPacketParser.Store.Objects
@@ -20,6 +21,9 @@ namespace WowPacketParser.Store.Objects
 
         [DBFieldName("OptionBroadcastTextId")]
         public int? OptionBroadcastTextId;
+
+        [DBFieldName("VerifiedBuild")]
+        public int? VerifiedBuild = ClientVersion.BuildInt;
 
         public string BroadcastTextIDHelper;
     }

--- a/WowPacketParser/Store/Objects/GossipMenuOptionAction.cs
+++ b/WowPacketParser/Store/Objects/GossipMenuOptionAction.cs
@@ -14,7 +14,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("ActionMenuId")]
         public uint? ActionMenuId;
 
-        [DBFieldName("ActionPoiId")]
-        public uint? ActionPoiId;
+        [DBFieldName("ActionPoiId", false, true)]
+        public object ActionPoiId;
     }
 }

--- a/WowPacketParser/Store/Objects/IBroadcastTextEntry.cs
+++ b/WowPacketParser/Store/Objects/IBroadcastTextEntry.cs
@@ -2,7 +2,7 @@
 {
     public interface IBroadcastTextEntry
     {
-        string MaleText { get; set; }
-        string FemaleText { get; set; }
+        string Text { get; set; }
+        string Text1 { get; set; }
     }
 }

--- a/WowPacketParser/Store/Objects/PointsOfInterest.cs
+++ b/WowPacketParser/Store/Objects/PointsOfInterest.cs
@@ -7,8 +7,8 @@ namespace WowPacketParser.Store.Objects
     [DBTableName("points_of_interest")]
     public sealed class PointsOfInterest : IDataModel
     {
-        [DBFieldName("ID", true)]
-        public uint? ID;
+        [DBFieldName("ID", true, true)]
+        public object ID;
 
         [DBFieldName("PositionX")]
         public float? PositionX;

--- a/WowPacketParserModule.V5_3_0_16981/Hotfix/BroadcastTextEntry.cs
+++ b/WowPacketParserModule.V5_3_0_16981/Hotfix/BroadcastTextEntry.cs
@@ -9,8 +9,8 @@ namespace WowPacketParserModule.V5_3_0_16981.Hotfix
     {
         public int ID { get; set; }
         public int Language { get; set; }
-        public string MaleText { get; set; }
-        public string FemaleText { get; set; }
+        public string Text { get; set; }
+        public string Text1 { get; set; }
         [HotfixArray(3)]
         public int[] EmoteID { get; set; }
         [HotfixArray(3)]

--- a/WowPacketParserModule.V5_4_0_17359/Hotfix/BroadcastTextEntry.cs
+++ b/WowPacketParserModule.V5_4_0_17359/Hotfix/BroadcastTextEntry.cs
@@ -9,8 +9,8 @@ namespace WowPacketParserModule.V5_4_0_17359.Hotfix
     {
         public int ID { get; set; }
         public int Language { get; set; }
-        public string MaleText { get; set; }
-        public string FemaleText { get; set; }
+        public string Text { get; set; }
+        public string Text1 { get; set; }
         [HotfixArray(3)]
         public int[] EmoteID { get; set; }
         [HotfixArray(3)]

--- a/WowPacketParserModule.V5_4_0_17359/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V5_4_0_17359/Parsers/NpcHandler.cs
@@ -159,8 +159,9 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
         [Parser(Opcode.SMSG_GOSSIP_POI)]
         public static void HandleGossipPoi(Packet packet)
         {
+            ++LastGossipPOIEntry;
             PointsOfInterest gossipPOI = new PointsOfInterest();
-            gossipPOI.ID = ++LastGossipPOIEntry;
+            gossipPOI.ID = "@ID+" + LastGossipPOIEntry.ToString();
 
             gossipPOI.Flags = (uint) packet.ReadInt32E<UnknownFlags>("Flags");
 

--- a/WowPacketParserModule.V5_4_1_17538/Hotfix/BroadcastTextEntry.cs
+++ b/WowPacketParserModule.V5_4_1_17538/Hotfix/BroadcastTextEntry.cs
@@ -9,8 +9,8 @@ namespace WowPacketParserModule.V5_4_1_17538.Hotfix
     {
         public int ID { get; set; }
         public int Language { get; set; }
-        public string MaleText { get; set; }
-        public string FemaleText { get; set; }
+        public string Text { get; set; }
+        public string Text1 { get; set; }
         [HotfixArray(3)]
         public int[] EmoteID { get; set; }
         [HotfixArray(3)]

--- a/WowPacketParserModule.V5_4_2_17658/Hotfix/BroadcastTextEntry.cs
+++ b/WowPacketParserModule.V5_4_2_17658/Hotfix/BroadcastTextEntry.cs
@@ -9,8 +9,8 @@ namespace WowPacketParserModule.V5_4_2_17658.Hotfix
     {
         public int ID { get; set; }
         public int Language { get; set; }
-        public string MaleText { get; set; }
-        public string FemaleText { get; set; }
+        public string Text { get; set; }
+        public string Text1 { get; set; }
         [HotfixArray(3)]
         public int[] EmoteID { get; set; }
         [HotfixArray(3)]

--- a/WowPacketParserModule.V5_4_2_17658/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V5_4_2_17658/Parsers/NpcHandler.cs
@@ -180,8 +180,9 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
         [Parser(Opcode.SMSG_GOSSIP_POI)]
         public static void HandleGossipPoi(Packet packet)
         {
+            ++LastGossipPOIEntry;
             PointsOfInterest gossipPOI = new PointsOfInterest();
-            gossipPOI.ID = ++LastGossipPOIEntry;
+            gossipPOI.ID = "@ID+" + LastGossipPOIEntry.ToString();
 
             gossipPOI.Flags = (uint)packet.ReadInt32E<UnknownFlags>("Flags");
 

--- a/WowPacketParserModule.V5_4_7_17898/Hotfix/BroadcastTextEntry.cs
+++ b/WowPacketParserModule.V5_4_7_17898/Hotfix/BroadcastTextEntry.cs
@@ -9,8 +9,8 @@ namespace WowPacketParserModule.V5_4_7_17898.Hotfix
     {
         public int ID { get; set; }
         public int Language { get; set; }
-        public string MaleText { get; set; }
-        public string FemaleText { get; set; }
+        public string Text { get; set; }
+        public string Text1 { get; set; }
         [HotfixArray(3)]
         public int[] EmoteID { get; set; }
         [HotfixArray(3)]

--- a/WowPacketParserModule.V5_4_7_17898/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V5_4_7_17898/Parsers/NpcHandler.cs
@@ -222,8 +222,9 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
         [Parser(Opcode.SMSG_GOSSIP_POI)]
         public static void HandleGossipPoi(Packet packet)
         {
+            ++LastGossipPOIEntry;
             PointsOfInterest gossipPOI = new PointsOfInterest();
-            gossipPOI.ID = ++LastGossipPOIEntry;
+            gossipPOI.ID = "@ID+" + LastGossipPOIEntry.ToString();
 
             gossipPOI.Flags = (uint)packet.ReadInt32E<UnknownFlags>("Flags");
 

--- a/WowPacketParserModule.V5_4_8_18291/Hotfix/BroadcastTextEntry.cs
+++ b/WowPacketParserModule.V5_4_8_18291/Hotfix/BroadcastTextEntry.cs
@@ -9,8 +9,8 @@ namespace WowPacketParserModule.V5_4_8_18291.Hotfix
     {
         public int ID { get; set; }
         public int Language { get; set; }
-        public string MaleText { get; set; }
-        public string FemaleText { get; set; }
+        public string Text { get; set; }
+        public string Text1 { get; set; }
         [HotfixArray(3)]
         public int[] EmoteID { get; set; }
         [HotfixArray(3)]

--- a/WowPacketParserModule.V5_4_8_18291/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V5_4_8_18291/Parsers/NpcHandler.cs
@@ -169,8 +169,9 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
         [Parser(Opcode.SMSG_GOSSIP_POI)]
         public static void HandleGossipPoi(Packet packet)
         {
+            ++LastGossipPOIEntry;
             PointsOfInterest gossipPOI = new PointsOfInterest();
-            gossipPOI.ID = ++LastGossipPOIEntry;
+            gossipPOI.ID = "@ID+" + LastGossipPOIEntry.ToString();
 
             gossipPOI.Flags = (uint)packet.ReadInt32E<UnknownFlags>("Flags");
 

--- a/WowPacketParserModule.V6_0_2_19033/Hotfix/BroadcastTextEntry.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Hotfix/BroadcastTextEntry.cs
@@ -9,8 +9,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Hotfix
     {
         public int ID { get; set; }
         public int Language { get; set; }
-        public string MaleText { get; set; }
-        public string FemaleText { get; set; }
+        public string Text { get; set; }
+        public string Text1 { get; set; }
         [HotfixArray(3)]
         public int[] EmoteID { get; set; }
         [HotfixArray(3)]

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
@@ -44,7 +44,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             List<int> boxTextList;
             List<int> optionTextList;
 
-            if (gossipMenuOptionBox.BoxText != string.Empty && SQLDatabase.BroadcastMaleTexts.TryGetValue(gossipMenuOptionBox.BoxText, out boxTextList))
+            if (gossipMenuOptionBox.BoxText != string.Empty && SQLDatabase.BroadcastTexts.TryGetValue(gossipMenuOptionBox.BoxText, out boxTextList))
             {
                 if (boxTextList.Count == 1)
                     gossipMenuOptionBox.BoxBroadcastTextId = boxTextList[0];
@@ -57,7 +57,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             else
                 gossipMenuOptionBox.BoxBroadcastTextId = 0;
 
-            if (gossipOption.OptionText != string.Empty && SQLDatabase.BroadcastMaleTexts.TryGetValue(gossipOption.OptionText, out optionTextList))
+            if (gossipOption.OptionText != string.Empty && SQLDatabase.BroadcastTexts.TryGetValue(gossipOption.OptionText, out optionTextList))
             {
                 if (optionTextList.Count == 1)
                     gossipOption.OptionBroadcastTextId = optionTextList[0];
@@ -168,13 +168,20 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             CoreParsers.NpcHandler.LastGossipOption.MenuId = menuEntry;
             CoreParsers.NpcHandler.LastGossipOption.OptionIndex = gossipIdx;
-        }
+            CoreParsers.NpcHandler.LastGossipOption.ActionMenuId = null;
+            CoreParsers.NpcHandler.LastGossipOption.ActionPoiId = null;
+
+            CoreParsers.NpcHandler.TempGossipOptionPOI.MenuId = menuEntry;
+            CoreParsers.NpcHandler.TempGossipOptionPOI.OptionIndex = gossipIdx;
+            CoreParsers.NpcHandler.TempGossipOptionPOI.ActionMenuId = null;
+            CoreParsers.NpcHandler.TempGossipOptionPOI.ActionPoiId = null;
+
+    }
 
         [Parser(Opcode.SMSG_GOSSIP_POI)]
         public static void HandleGossipPoi(Packet packet)
         {
             PointsOfInterest gossipPOI = new PointsOfInterest();
-            gossipPOI.ID = ++LastGossipPOIEntry;
 
             gossipPOI.Flags = packet.ReadBits("Flags", 14);
             uint bit84 = packet.ReadBits(6);
@@ -187,10 +194,66 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             gossipPOI.Importance = packet.ReadUInt32("Importance");
             gossipPOI.Name = packet.ReadWoWString("Name", bit84);
 
-            Storage.GossipPOIs.Add(gossipPOI, packet.TimeSpan);
             var lastGossipOption = CoreParsers.NpcHandler.LastGossipOption;
-            if (lastGossipOption.HasSelection)
-                Storage.GossipMenuOptionActions.Add(new GossipMenuOptionAction { MenuId = lastGossipOption.MenuId, OptionIndex = lastGossipOption.OptionIndex, ActionPoiId = gossipPOI.ID }, packet.TimeSpan);
+            var tempGossipOptionPOI = CoreParsers.NpcHandler.TempGossipOptionPOI;
+
+            // DB PART STARTS HERE
+            if (Settings.DBEnabled)
+            {
+                foreach (var poi in SQLDatabase.POIs)
+                {
+                    if (gossipPOI.Name == poi.Name && (uint)gossipPOI.Icon == poi.Icon && gossipPOI.Flags == poi.Flags)
+                    {
+                        if (Math.Abs(pos.X - poi.PositionX) <= 0.01f && Math.Abs(pos.Y - poi.PositionY) <= 0.01f)
+                        {
+                            gossipPOI.ID = poi.ID;
+                            break;
+                        }
+                    }
+                }
+
+                if (gossipPOI.ID == null)
+                {
+                    gossipPOI.ID = (SQLDatabase.POIs[SQLDatabase.POIs.Count - 1].ID + 1);
+
+                    // Add to list to prevent double data while parsing
+                    var poiData = new SQLDatabase.POIData()
+                    {
+                        ID = (uint)gossipPOI.ID,
+                        PositionX = (float)gossipPOI.PositionX,
+                        PositionY = (float)gossipPOI.PositionY,
+                        Icon = (uint)gossipPOI.Icon,
+                        Flags = (uint)gossipPOI.Flags,
+                        Importance = (uint)gossipPOI.Importance,
+                        Name = gossipPOI.Name
+                    };
+
+                    SQLDatabase.POIs.Add(poiData);
+                }
+            }
+            else
+            {
+                gossipPOI.ID = "@PID+" + LastGossipPOIEntry.ToString();
+                ++LastGossipPOIEntry;
+            }
+
+            lastGossipOption.ActionPoiId = gossipPOI.ID;
+            tempGossipOptionPOI.ActionPoiId = gossipPOI.ID;
+
+            Storage.GossipPOIs.Add(gossipPOI, packet.TimeSpan);
+
+            if (tempGossipOptionPOI.HasSelection)
+            {
+                if (tempGossipOptionPOI.ActionMenuId != null)
+                {
+                    Storage.GossipMenuOptionActions.Add(new GossipMenuOptionAction { MenuId = tempGossipOptionPOI.MenuId, OptionIndex = tempGossipOptionPOI.OptionIndex, ActionMenuId = tempGossipOptionPOI.ActionMenuId, ActionPoiId = gossipPOI.ID }, packet.TimeSpan);
+                    //clear temp
+                    tempGossipOptionPOI.MenuId = null;
+                    tempGossipOptionPOI.OptionIndex = null;
+                    tempGossipOptionPOI.ActionMenuId = null;
+                    tempGossipOptionPOI.ActionPoiId = null;
+                }
+            }
         }
 
         [HasSniffData]
@@ -226,8 +289,23 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             Storage.Gossips.Add(gossip, packet.TimeSpan);
             var lastGossipOption = CoreParsers.NpcHandler.LastGossipOption;
+            var tempGossipOptionPOI = CoreParsers.NpcHandler.TempGossipOptionPOI;
             if (lastGossipOption.HasSelection)
-                Storage.GossipMenuOptionActions.Add(new GossipMenuOptionAction { MenuId = lastGossipOption.MenuId, OptionIndex = lastGossipOption.OptionIndex, ActionMenuId = gossip.Entry }, packet.TimeSpan);
+            {
+                Storage.GossipMenuOptionActions.Add(new GossipMenuOptionAction { MenuId = lastGossipOption.MenuId, OptionIndex = lastGossipOption.OptionIndex, ActionMenuId = gossip.Entry, ActionPoiId = lastGossipOption.ActionPoiId }, packet.TimeSpan);
+
+                //keep temp data
+                tempGossipOptionPOI.MenuId = lastGossipOption.MenuId;
+                tempGossipOptionPOI.OptionIndex = lastGossipOption.OptionIndex;
+                tempGossipOptionPOI.ActionMenuId = gossip.Entry;
+                tempGossipOptionPOI.ActionPoiId = lastGossipOption.ActionPoiId;
+
+                // clear lastgossip
+                lastGossipOption.MenuId = null;
+                lastGossipOption.OptionIndex = null;
+                lastGossipOption.ActionMenuId = null;
+                lastGossipOption.ActionPoiId = null;
+            }
 
             packet.AddSniffData(StoreNameType.Gossip, menuId, guid.GetEntry().ToString(CultureInfo.InvariantCulture));
         }

--- a/WowPacketParserModule.V7_0_3_22248/Hotfix/BroadcastTextEntry.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Hotfix/BroadcastTextEntry.cs
@@ -7,17 +7,17 @@ namespace WowPacketParserModule.V7_0_3_22248.Hotfix
     [HotfixStructure(DB2Hash.BroadcastText, HasIndexInData = false)]
     public class BroadcastTextEntry : IBroadcastTextEntry
     {
-        public string MaleText { get; set; }
-        public string FemaleText { get; set; }
+        public string Text { get; set; }
+        public string Text1 { get; set; }
         [HotfixArray(3)]
         public ushort[] EmoteID { get; set; }
         [HotfixArray(3)]
         public ushort[] EmoteDelay { get; set; }
-        public ushort UnkEmoteID { get; set; }
-        public byte Language { get; set; }
-        public byte Type { get; set; }
+        public ushort EmotesID { get; set; }
+        public byte LanguageID { get; set; }
+        public byte Flags { get; set; }
         [HotfixArray(2)]
-        public uint[] SoundID { get; set; }
-        public uint PlayerConditionID { get; set; }
+        public uint[] SoundEntriesID { get; set; }
+        public uint ConditionID { get; set; }
     }
 }

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/HotfixHandler.cs
@@ -39,8 +39,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                         var bct = new BroadcastText()
                         {
                             ID = (uint)entry,
-                            MaleText = db2File.ReadCString("MaleText"),
-                            FemaleText = db2File.ReadCString("FemaleText"),
+                            Text = db2File.ReadCString("Text"),
+                            Text1 = db2File.ReadCString("Text1"),
                         };
 
                         bct.EmoteID = new ushort?[3];
@@ -51,15 +51,19 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                         for (int i = 0; i < 3; ++i)
                             bct.EmoteDelay[i] = db2File.ReadUInt16("EmoteDelay", i);
 
-                        bct.UnkEmoteID = db2File.ReadUInt16("UnkEmoteID");
-                        bct.Language = db2File.ReadByte("Language");
-                        bct.Type = db2File.ReadByte("Type");
+                        bct.EmotesID = db2File.ReadUInt16("EmotesID");
+                        bct.LanguageID = db2File.ReadByte("LanguageID");
+                        bct.Flags = db2File.ReadByte("Flags");
 
-                        bct.SoundID = new uint?[2];
+                        if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
+                            bct.ConditionID = db2File.ReadUInt32("ConditionID");
+
+                        bct.SoundEntriesID = new uint?[2];
                         for (int i = 0; i < 2; ++i)
-                            bct.SoundID[i] = db2File.ReadUInt32("SoundID", i);
+                            bct.SoundEntriesID[i] = db2File.ReadUInt32("SoundEntriesID", i);
 
-                        bct.PlayerConditionID = db2File.ReadUInt32("PlayerConditionID");
+                        if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_0_3_22248) && ClientVersion.RemovedInVersion(ClientVersionBuild.V7_3_5_25848))
+                            bct.ConditionID = db2File.ReadUInt32("ConditionID");
 
                         Storage.BroadcastTexts.Add(bct, packet.TimeSpan);
 
@@ -68,8 +72,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                             BroadcastTextLocale lbct = new BroadcastTextLocale
                             {
                                 ID = bct.ID,
-                                MaleTextLang = bct.MaleText,
-                                FemaleTextLang = bct.FemaleText
+                                TextLang = bct.Text,
+                                Text1Lang = bct.Text1
                             };
                             Storage.BroadcastTextLocales.Add(lbct, packet.TimeSpan);
                         }

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/NpcHandler.cs
@@ -67,8 +67,22 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
             Storage.Gossips.Add(gossip, packet.TimeSpan);
             var lastGossipOption = CoreParsers.NpcHandler.LastGossipOption;
+            var tempGossipOptionPOI = CoreParsers.NpcHandler.TempGossipOptionPOI;
             if (lastGossipOption.HasSelection)
-                Storage.GossipMenuOptionActions.Add(new GossipMenuOptionAction { MenuId = lastGossipOption.MenuId, OptionIndex = lastGossipOption.OptionIndex, ActionMenuId = gossip.Entry }, packet.TimeSpan);
+            {
+                Storage.GossipMenuOptionActions.Add(new GossipMenuOptionAction { MenuId = lastGossipOption.MenuId, OptionIndex = lastGossipOption.OptionIndex, ActionMenuId = gossip.Entry, ActionPoiId = lastGossipOption.ActionPoiId }, packet.TimeSpan);
+
+                //keep temp data (for case SMSG_GOSSIP_POI is delayed)
+                tempGossipOptionPOI.MenuId = lastGossipOption.MenuId;
+                tempGossipOptionPOI.OptionIndex = lastGossipOption.OptionIndex;
+                tempGossipOptionPOI.ActionMenuId = gossip.Entry;
+
+                // clear lastgossip so no faulty linkings appear
+                lastGossipOption.MenuId = null;
+                lastGossipOption.OptionIndex = null;
+                lastGossipOption.ActionMenuId = null;
+                lastGossipOption.ActionPoiId = null;
+            }
 
             packet.AddSniffData(StoreNameType.Gossip, menuId, guid.GetEntry().ToString(CultureInfo.InvariantCulture));
         }


### PR DESCRIPTION
Automates the point of interests update.
Automates the gossip_option_menu_action update.

Prevents duplicated in points_of_interests.

Avoid crash on ulong comparing

Fixes broadcast_text parsing/comparsion with DB

Added ForceInsertQueries option to force Delete/Insert queries instead Update queries