### PR TITLE
Update/Improve Parser (including 7.3.5)

### DIFF
--- a/WowPacketParser/App.config
+++ b/WowPacketParser/App.config
@@ -149,6 +149,13 @@
         <add key="hotfix_data"                            value="false"/>
 
         <!--
+               Option:      RecalcDiscount
+               Description: Recalculate repuation discounts on moneyCost to receive originalMoneyCost (only works with DBCs and NON-fusion .pkt)
+               Default:     "false" (No prompt)
+          -->
+        <add key="RecalcDiscount" value="false"/>
+
+        <!--
              Option:      SQLFileName
              Description: Sets the file to write all sql data to. If is not set each file parsed will write it's own sql file
              Default:     "" (No global sql file output)

--- a/WowPacketParser/DBC/DBC.cs
+++ b/WowPacketParser/DBC/DBC.cs
@@ -21,6 +21,7 @@ namespace WowPacketParser.DBC
         public static Storage<CreatureFamilyEntry> CreatureFamily = new Storage<CreatureFamilyEntry>(GetPath("CreatureFamily.db2"));
         public static Storage<CreatureDisplayInfoEntry> CreatureDisplayInfo = new Storage<CreatureDisplayInfoEntry>(GetPath("CreatureDisplayInfo.db2"));
         public static Storage<CriteriaTreeEntry> CriteriaTree = new Storage<CriteriaTreeEntry>(GetPath("CriteriaTree.db2"));
+        public static Storage<CriteriaEntry> Criteria = new Storage<CriteriaEntry>(GetPath("Criteria.db2"));
         public static Storage<DifficultyEntry> Difficulty = new Storage<DifficultyEntry>(GetPath("Difficulty.db2"));
         public static Storage<FactionEntry> Faction = new Storage<FactionEntry>(GetPath("Faction.db2"));
         public static Storage<FactionTemplateEntry> FactionTemplate = new Storage<FactionTemplateEntry>(GetPath("FactionTemplate.db2"));
@@ -136,7 +137,7 @@ namespace WowPacketParser.DBC
                     foreach (var factionTemplate in FactionTemplate)
                     {
                         if (Faction.ContainsKey(factionTemplate.Value.Faction))
-                            FactionStores.Add((uint)factionTemplate.Key, Faction[factionTemplate.Value.Faction].Name);
+                            FactionStores.Add((uint)factionTemplate.Key, Faction[factionTemplate.Value.Faction]);
                     }
                 }
             }), Task.Run(() =>
@@ -190,7 +191,7 @@ namespace WowPacketParser.DBC
         public static readonly Dictionary<uint, string> Zones = new Dictionary<uint, string>();
         public static readonly Dictionary<int, int> MapSpawnMaskStores = new Dictionary<int, int>();
         public static readonly Dictionary<ushort, string> CriteriaStores = new Dictionary<ushort, string>();
-        public static readonly Dictionary<uint, string> FactionStores = new Dictionary<uint, string>();
+        public static readonly Dictionary<uint, FactionEntry> FactionStores = new Dictionary<uint, FactionEntry>();
         public static readonly Dictionary<Tuple<uint, uint>, SpellEffectEntry> SpellEffectStores = new Dictionary<Tuple<uint, uint>, SpellEffectEntry>();
         public static readonly Dictionary<ushort, List<ushort>> Phases = new Dictionary<ushort, List<ushort>>();
     }

--- a/WowPacketParser/DBC/Structures/Legion/CriteriaEntry.cs
+++ b/WowPacketParser/DBC/Structures/Legion/CriteriaEntry.cs
@@ -1,0 +1,20 @@
+﻿using DBFilesClient.NET;
+
+namespace WowPacketParser.DBC.Structures
+{
+    [DBFile("Criteria")]
+    public sealed class CriteriaEntry
+    {
+        public uint Asset;
+        public uint StartAsset;
+        public uint FailAsset;
+        public ushort StartTime;
+        public ushort ModifiertTreeId;
+        public ushort EligibilityWorldStateID;
+        public byte Type;
+        public byte StartEvent;
+        public byte FailEvent;
+        public byte Flags;
+        public byte EligibilityWorldStateValue;
+    }
+}

--- a/WowPacketParser/Misc/Settings.cs
+++ b/WowPacketParser/Misc/Settings.cs
@@ -19,6 +19,7 @@ namespace WowPacketParser.Misc
         public static readonly ulong SQLOutputFlag = GetSQLOutputFlag();
         public static readonly bool SQLOrderByKey = Conf.GetBoolean("SqlOrderByKey", false);
         public static readonly bool SkipOnlyVerifiedBuildUpdateRows = Conf.GetBoolean("SkipOnlyVerifiedBuildUpdateRows", false);
+        public static readonly bool RecalcDiscount = Conf.GetBoolean("RecalcDiscount", false);
         public static readonly string SQLFileName = Conf.GetString("SQLFileName", string.Empty);
         public static readonly bool ShowEndPrompt = Conf.GetBoolean("ShowEndPrompt", false);
         public static readonly bool LogErrors = Conf.GetBoolean("LogErrors", false);

--- a/WowPacketParser/Misc/StoreGetters.cs
+++ b/WowPacketParser/Misc/StoreGetters.cs
@@ -45,7 +45,7 @@ namespace WowPacketParser.Misc
                         break;
                     case StoreNameType.Faction:
                         if (DBC.DBC.FactionStores.ContainsKey((uint)entry))
-                            return DBC.DBC.FactionStores[(uint)entry];
+                            return DBC.DBC.FactionStores[(uint)entry].Name;
                         break;
                     case StoreNameType.Item:
                         if (DBC.DBC.ItemSparse.ContainsKey(entry))

--- a/WowPacketParser/SQL/Builders/UnitMisc.cs
+++ b/WowPacketParser/SQL/Builders/UnitMisc.cs
@@ -236,6 +236,9 @@ namespace WowPacketParser.SQL.Builders
             if (!Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.trainer))
                 return string.Empty;
 
+            foreach (var trainerSpell in Storage.TrainerSpells)
+                trainerSpell.Item1.ConvertToDBStruct();
+
             var templatesDb = SQLDatabase.Get(Storage.TrainerSpells);
 
             return SQLUtil.Compare(Storage.TrainerSpells, templatesDb, StoreNameType.None);

--- a/WowPacketParser/SQL/Builders/UnitMisc.cs
+++ b/WowPacketParser/SQL/Builders/UnitMisc.cs
@@ -241,7 +241,7 @@ namespace WowPacketParser.SQL.Builders
 
             var templatesDb = SQLDatabase.Get(Storage.TrainerSpells);
 
-            return SQLUtil.Compare(Storage.TrainerSpells, templatesDb, StoreNameType.None);
+            return SQLUtil.Compare(Storage.TrainerSpells, templatesDb, t => t.FactionHelper);
         }
 
         [BuilderMethod]

--- a/WowPacketParser/Saving/FusionBinaryPacketWriter.cs
+++ b/WowPacketParser/Saving/FusionBinaryPacketWriter.cs
@@ -20,7 +20,7 @@ namespace WowPacketParser.Saving
             var groups = packets.GroupBy(p => p.Opcode);
 
             // since we have one file per opcode it's possible to parallelize groups writing
-            Parallel.ForEach(groups, WriteGroup);
+            Parallel.ForEach(groups, new ParallelOptions { MaxDegreeOfParallelism = 1 }, WriteGroup);
         }
 
         private static void WriteGroup(IGrouping<int, Packet> groups)

--- a/WowPacketParser/Store/Objects/QuestPOI.cs
+++ b/WowPacketParser/Store/Objects/QuestPOI.cs
@@ -50,6 +50,9 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("WoDUnk1", TargetedDatabase.WarlordsOfDraenor)]
         public int? WoDUnk1;
 
+        [DBFieldName("AlwaysAllowMergingBlobs", TargetedDatabase.Legion)]
+        public bool AlwaysAllowMergingBlobs;
+
         [DBFieldName("VerifiedBuild")]
         public int? VerifiedBuild = ClientVersion.BuildInt;
     }

--- a/WowPacketParser/Store/Objects/QuestTemplate.cs
+++ b/WowPacketParser/Store/Objects/QuestTemplate.cs
@@ -16,7 +16,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("QuestLevel")]
         public int? QuestLevel;
 
-        [DBFieldName("QuestMaxScalingLevel", TargetedDatabase.Legion)]
+        [DBFieldName("MaxScalingLevel", TargetedDatabase.Legion)]
         public int? QuestMaxScalingLevel;
 
         [DBFieldName("QuestPackageID", TargetedDatabase.WarlordsOfDraenor)]

--- a/WowPacketParser/Store/Objects/QuestTemplate.cs
+++ b/WowPacketParser/Store/Objects/QuestTemplate.cs
@@ -16,6 +16,9 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("QuestLevel")]
         public int? QuestLevel;
 
+        [DBFieldName("QuestMaxScalingLevel", TargetedDatabase.Legion)]
+        public int? QuestMaxScalingLevel;
+
         [DBFieldName("QuestPackageID", TargetedDatabase.WarlordsOfDraenor)]
         public uint? QuestPackageID;
 
@@ -238,7 +241,7 @@ namespace WowPacketParser.Store.Objects
         public RaceMask? AllowableRaces;
 
         [DBFieldName("AllowableRaces", TargetedDatabase.WarlordsOfDraenor)]
-        public int? AllowableRacesWod;
+        public long? AllowableRacesWod;
 
         [DBFieldName("QuestRewardID", TargetedDatabase.Legion)]
         public int? QuestRewardID;

--- a/WowPacketParser/Store/Objects/QuestTemplate.cs
+++ b/WowPacketParser/Store/Objects/QuestTemplate.cs
@@ -241,7 +241,7 @@ namespace WowPacketParser.Store.Objects
         public RaceMask? AllowableRaces;
 
         [DBFieldName("AllowableRaces", TargetedDatabase.WarlordsOfDraenor)]
-        public long? AllowableRacesWod;
+        public ulong? AllowableRacesWod;
 
         [DBFieldName("QuestRewardID", TargetedDatabase.Legion)]
         public int? QuestRewardID;

--- a/WowPacketParser/Store/Objects/TrainerSpell.cs
+++ b/WowPacketParser/Store/Objects/TrainerSpell.cs
@@ -44,5 +44,7 @@ namespace WowPacketParser.Store.Objects
 
         [DBFieldName("VerifiedBuild")]
         public int? VerifiedBuild = ClientVersion.BuildInt;
+
+        public string FactionHelper;
     }
 }

--- a/WowPacketParser/Store/Objects/TrainerSpell.cs
+++ b/WowPacketParser/Store/Objects/TrainerSpell.cs
@@ -6,6 +6,15 @@ namespace WowPacketParser.Store.Objects
     [DBTableName("trainer_spell")]
     public sealed class TrainerSpell : IDataModel
     {
+        public uint[] ReqAbility;
+
+        public void ConvertToDBStruct()
+        {
+            ReqAbility1 = ReqAbility[0];
+            ReqAbility2 = ReqAbility[1];
+            ReqAbility3 = ReqAbility[2];
+        }
+
         [DBFieldName("TrainerId", true)]
         public uint? TrainerId;
 
@@ -21,8 +30,14 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("ReqSkillRank")]
         public uint? ReqSkillRank;
 
-        [DBFieldName("ReqAbility", 3)]
-        public uint[] ReqAbility;
+        [DBFieldName("ReqAbility1")]
+        public uint? ReqAbility1;
+
+        [DBFieldName("ReqAbility2")]
+        public uint? ReqAbility2;
+
+        [DBFieldName("ReqAbility3")]
+        public uint? ReqAbility3;
 
         [DBFieldName("ReqLevel")]
         public byte? ReqLevel;

--- a/WowPacketParser/WowPacketParser.csproj
+++ b/WowPacketParser/WowPacketParser.csproj
@@ -126,6 +126,7 @@
     <Compile Include="DBC\Structures\Legion\CreatureEntry.cs" />
     <Compile Include="DBC\Structures\Legion\CreatureDisplayInfoEntry.cs" />
     <Compile Include="DBC\Structures\Legion\CreatureFamilyEntry.cs" />
+    <Compile Include="DBC\Structures\Legion\CriteriaEntry.cs" />
     <Compile Include="DBC\Structures\Legion\CriteriaTreeEntry.cs" />
     <Compile Include="DBC\Structures\Legion\DBFileAttribute.cs" />
     <Compile Include="DBC\Structures\Legion\DifficultyEntry.cs" />

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/AchievementHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/AchievementHandler.cs
@@ -1,21 +1,30 @@
 using WowPacketParser.Enums;
 using WowPacketParser.Misc;
 using WowPacketParser.Parsing;
+using WowPacketParser.DBC;
+using System.Collections.Generic;
 
 namespace WowPacketParserModule.V6_0_2_19033.Parsers
 {
     public static class AchievementHandler
     {
+        public static Dictionary<uint, ulong> FactionReputationStore { get; } = new Dictionary<uint, ulong>();
+
         [Parser(Opcode.SMSG_CRITERIA_UPDATE)]
         public static void HandleCriteriaPlayer(Packet packet)
         {
-            packet.ReadInt32<CriteriaId>("Id");
-            packet.ReadInt64("Quantity");
+            int criteriaId = packet.ReadInt32<CriteriaId>("Id");
+            ulong quantity = (ulong)packet.ReadInt64("Quantity");
             packet.ReadPackedGuid128("Guid");
             packet.ReadInt32("Flags");
             packet.ReadPackedTime("Date");
             packet.ReadTime("TimeFromStart");
             packet.ReadTime("TimeFromCreate");
+
+            if (Settings.UseDBC)
+                if (DBC.Criteria.ContainsKey(criteriaId))
+                    if (DBC.Criteria[criteriaId].Type == 46)
+                        FactionReputationStore[DBC.Criteria[criteriaId].Asset] = quantity;
         }
 
         [Parser(Opcode.SMSG_ACCOUNT_CRITERIA_UPDATE)]
@@ -26,12 +35,17 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
         public static void ReadCriteriaProgress(Packet packet, params object[] idx)
         {
-            packet.ReadInt32<CriteriaId>("Id", idx);
-            packet.ReadUInt64("Quantity", idx);
+            int criteriaId = packet.ReadInt32<CriteriaId>("Id", idx);
+            ulong quantity = packet.ReadUInt64("Quantity", idx);
             packet.ReadPackedGuid128("Player", idx);
             packet.ReadPackedTime("Date", idx);
             packet.ReadTime("TimeFromStart", idx);
             packet.ReadTime("TimeFromCreate", idx);
+
+            if (Settings.UseDBC)
+                if (DBC.Criteria.ContainsKey(criteriaId))
+                    if (DBC.Criteria[criteriaId].Type == 46)
+                        FactionReputationStore[DBC.Criteria[criteriaId].Asset] = quantity;
 
             packet.ResetBitReader();
             packet.ReadBits("Flags", 4, idx); // some flag... & 1 -> delete

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
@@ -9,6 +9,8 @@ using WowPacketParser.SQL;
 using WowPacketParser.Store;
 using WowPacketParser.Store.Objects;
 using CoreParsers = WowPacketParser.Parsing.Parsers;
+using WowPacketParser.DBC;
+using WowPacketParser.Enums.Version;
 
 namespace WowPacketParserModule.V6_0_2_19033.Parsers
 {
@@ -271,10 +273,54 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         {
             Trainer trainer = new Trainer();
 
-            packet.ReadPackedGuid128("TrainerGUID");
+            WowGuid guid = packet.ReadPackedGuid128("TrainerGUID");
+            float discount = 1.0f;
+
+            if (Settings.UseDBC && Settings.RecalcDiscount)
+                if (Storage.Objects != null && Storage.Objects.ContainsKey(guid))
+                {
+                    WoWObject obj = Storage.Objects[guid].Item1;
+                    if (obj.Type == ObjectType.Unit)
+                    {
+                        int factionTemplateId = 0;
+                        uint faction = 35;
+                        UpdateField uf;
+
+                        if (obj.UpdateFields != null && obj.UpdateFields.TryGetValue(UpdateFields.GetUpdateField(UnitField.UNIT_FIELD_FACTIONTEMPLATE), out uf))
+                            factionTemplateId = (int)uf.UInt32Value;
+
+
+                        if (factionTemplateId != 0 && DBC.FactionTemplate.ContainsKey(factionTemplateId))
+                            faction = DBC.FactionTemplate[factionTemplateId].Faction;
+
+                        ulong reputation = 0;
+
+                        if (AchievementHandler.FactionReputationStore.ContainsKey(faction))
+                        {
+                            reputation = AchievementHandler.FactionReputationStore[faction];
+                        }
+
+                        uint multiplier = 0;
+
+                        if (reputation >= 3000) // Friendly
+                            multiplier = 1;
+                        if (reputation >= 9000) // Honored
+                            multiplier = 2;
+                        if (reputation >= 21000) // Revered
+                            multiplier = 3;
+                        if (reputation >= 42000) // Exalted
+                            multiplier = 4;
+
+                        if (multiplier != 0)
+                            discount = 1.0f - 0.05f * multiplier;
+
+                        packet.WriteLine("ReputationDiscount: {0}%", (int)((discount * 100) - 100));
+                    }
+                }
 
             trainer.Type = packet.ReadInt32E<TrainerType>("TrainerType");
             trainer.Id = packet.ReadUInt32("TrainerID");
+
             var count = packet.ReadUInt32("Spells");
 
             for (var i = 0u; i < count; ++i)
@@ -282,11 +328,18 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 TrainerSpell trainerSpell = new TrainerSpell
                 {
                     TrainerId = trainer.Id,
-                    SpellId = packet.ReadUInt32<SpellId>("SpellID", i),
-                    MoneyCost = packet.ReadUInt32("MoneyCost", i),
-                    ReqSkillLine = packet.ReadUInt32("ReqSkillLine", i),
-                    ReqSkillRank = packet.ReadUInt32("ReqSkillRank", i)
+                    SpellId = packet.ReadUInt32<SpellId>("SpellID", i)
                 };
+
+                uint moneyCost = packet.ReadUInt32("MoneyCost", i);
+                uint moneyCostOriginal = (uint)(moneyCost / discount);
+
+                if (Settings.RecalcDiscount)
+                    packet.WriteLine("[{0}] MoneyCostOriginal: {1}", i, moneyCostOriginal);
+
+                trainerSpell.MoneyCost = moneyCostOriginal;
+                trainerSpell.ReqSkillLine = packet.ReadUInt32("ReqSkillLine", i);
+                trainerSpell.ReqSkillRank = packet.ReadUInt32("ReqSkillRank", i);
 
                 trainerSpell.ReqAbility = new uint[3];
                 for (var j = 0; j < 3; ++j)

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
@@ -332,10 +332,13 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 };
 
                 uint moneyCost = packet.ReadUInt32("MoneyCost", i);
-                uint moneyCostOriginal = (uint)(moneyCost / discount);
+                uint moneyCostOriginal = moneyCost;
 
                 if (Settings.RecalcDiscount)
+                {
+                    moneyCostOriginal = (uint)(Math.Round((moneyCost / discount) / 5)) * 5;
                     packet.WriteLine("[{0}] MoneyCostOriginal: {1}", i, moneyCostOriginal);
+                }
 
                 trainerSpell.MoneyCost = moneyCostOriginal;
                 trainerSpell.ReqSkillLine = packet.ReadUInt32("ReqSkillLine", i);

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/QuestHandler.cs
@@ -295,7 +295,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             quest.AreaGroupID = packet.ReadUInt32("AreaGroupID");
             quest.TimeAllowed = packet.ReadUInt32("TimeAllowed");
             uint int2946 = packet.ReadUInt32("CliQuestInfoObjective");
-            quest.AllowableRacesWod = packet.ReadInt32("AllowableRaces");
+            quest.AllowableRacesWod = (uint)packet.ReadInt32("AllowableRaces");
 
             for (int i = 0; i < int2946; ++i)
             {

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/QuestHandler.cs
@@ -184,6 +184,12 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                         Storage.QuestPOIPoints.Add(questPoiPoint, packet.TimeSpan);
                     }
 
+                    if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
+                    {
+                        packet.ResetBitReader();
+                        questPoi.AlwaysAllowMergingBlobs = packet.ReadBit("AlwaysAllowMergingBlobs", i, j);
+                    }
+
                     Storage.QuestPOIs.Add(questPoi, packet.TimeSpan);
                 }
             }

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/QuestHandler.cs
@@ -184,12 +184,6 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                         Storage.QuestPOIPoints.Add(questPoiPoint, packet.TimeSpan);
                     }
 
-                    if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
-                    {
-                        packet.ResetBitReader();
-                        questPoi.AlwaysAllowMergingBlobs = packet.ReadBit("AlwaysAllowMergingBlobs", i, j);
-                    }
-
                     Storage.QuestPOIs.Add(questPoi, packet.TimeSpan);
                 }
             }

--- a/WowPacketParserModule.V6_0_2_19033/WowPacketParserModule.V6_0_2_19033.csproj
+++ b/WowPacketParserModule.V6_0_2_19033/WowPacketParserModule.V6_0_2_19033.csproj
@@ -169,6 +169,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="DBFilesClient.NET">
+      <HintPath>..\packages\DBFilesClient.NET.1.1.4\lib\net452\DBFilesClient.NET.dll</HintPath>
+    </Reference>
     <Reference Include="Sigil, Version=4.7.0.0, Culture=neutral, PublicKeyToken=2d06c3494341c8ab, processorArchitecture=MSIL">
       <HintPath>..\packages\Sigil.4.7.0\lib\net45\Sigil.dll</HintPath>
       <Private>True</Private>

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/InstanceHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/InstanceHandler.cs
@@ -17,5 +17,60 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ReadBit("Locked");
             packet.ReadBit("Extended");
         }
+
+        [Parser(Opcode.CMSG_SAVE_CUF_PROFILES)]
+        [Parser(Opcode.SMSG_LOAD_CUF_PROFILES)]
+        public static void HandleCUFProfiles(Packet packet)
+        {
+            var count = packet.ReadUInt32("Count");
+
+            for (int i = 0; i < count; ++i)
+            {
+                var strlen = packet.ReadBits(7);
+
+                packet.ReadBit("KeepGroupsTogether", i);
+                packet.ReadBit("DisplayPets", i);
+                packet.ReadBit("DisplayMainTankAndAssist", i);
+                packet.ReadBit("DisplayHealPrediction", i);
+                packet.ReadBit("DisplayAggroHighlight", i);
+                packet.ReadBit("DisplayOnlyDispellableDebuffs", i);
+                packet.ReadBit("DisplayPowerBar", i);
+                packet.ReadBit("DisplayBorder", i);
+                packet.ReadBit("UseClassColors", i);
+                packet.ReadBit("HorizontalGroups", i);
+                packet.ReadBit("DisplayNonBossDebuffs", i);
+                packet.ReadBit("DynamicPosition", i);
+                packet.ReadBit("Locked", i);
+                packet.ReadBit("Shown", i);
+                packet.ReadBit("AutoActivate2Players", i);
+                packet.ReadBit("AutoActivate3Players", i);
+                packet.ReadBit("AutoActivate5Players", i);
+                packet.ReadBit("AutoActivate10Players", i);
+                packet.ReadBit("AutoActivate15Players", i);
+                packet.ReadBit("AutoActivate25Players", i);
+                packet.ReadBit("AutoActivate40Players", i);
+                packet.ReadBit("AutoActivateSpec1", i);
+                packet.ReadBit("AutoActivateSpec2", i);
+                packet.ReadBit("AutoActivateSpec3", i);
+                packet.ReadBit("AutoActivateSpec4", i);
+                packet.ReadBit("AutoActivatePvP", i);
+                packet.ReadBit("AutoActivatePvE", i);
+
+                packet.ReadInt16("FrameHeight", i);
+                packet.ReadInt16("FrameWidth", i);
+
+                packet.ReadByte("SortBy", i);
+                packet.ReadByte("HealthText", i);
+                packet.ReadByte("TopPoint", i);
+                packet.ReadByte("BottomPoint", i);
+                packet.ReadByte("LeftPoint", i);
+
+                packet.ReadInt16("TopOffset", i);
+                packet.ReadInt16("BottomOffset", i);
+                packet.ReadInt16("LeftOffset", i);
+
+                packet.ReadWoWString("Name", strlen, i);
+            }
+        }
     }
 }

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/NpcHandler.cs
@@ -17,13 +17,15 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ReadInt32("QuestID", idx);
             packet.ReadInt32("QuestType", idx);
             packet.ReadInt32("QuestLevel", idx);
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
+                packet.ReadInt32("QuestMaxScalingLevel", idx);
 
             for (int j = 0; j < 2; ++j)
                 packet.ReadInt32("QuestFlags", idx, j);
 
             packet.ResetBitReader();
 
-            packet.ReadBit("Repeatable");
+            packet.ReadBit("Repeatable", idx);
             if (ClientVersion.RemovedInVersion(ClientVersionBuild.V7_2_0_23826))
                 packet.ReadBit("Ignored");
 

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
@@ -207,9 +207,9 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             quest.TimeAllowed = packet.ReadUInt32("TimeAllowed");
             uint int2946 = packet.ReadUInt32("CliQuestInfoObjective");
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
-                quest.AllowableRacesWod = (long)packet.ReadUInt64("AllowableRaces");
+                quest.AllowableRacesWod = packet.ReadUInt64("AllowableRaces");
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_0_3_22248) && ClientVersion.RemovedInVersion(ClientVersionBuild.V7_3_5_25848))
-                quest.AllowableRacesWod = packet.ReadInt32("AllowableRaces");
+                quest.AllowableRacesWod = (uint)packet.ReadInt32("AllowableRaces");
             quest.QuestRewardID = packet.ReadInt32("QuestRewardID");
 
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_2_0_23826))

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
@@ -700,5 +700,63 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 packet.ReadInt32("Amount", i);
             }
         }
+
+        [Parser(Opcode.SMSG_QUEST_POI_QUERY_RESPONSE)]
+        public static void HandleQuestPoiQueryResponse(Packet packet)
+        {
+            packet.ReadInt32("NumPOIs");
+            int int4 = packet.ReadInt32("QuestPOIData");
+
+            for (int i = 0; i < int4; ++i)
+            {
+                int questId = packet.ReadInt32("QuestID", i);
+
+                int int2 = packet.ReadInt32("QuestPOIBlobData", i);
+
+                for (int j = 0; j < int2; ++j)
+                {
+                    QuestPOI questPoi = new QuestPOI
+                    {
+                        QuestID = questId,
+                        ID = j,
+                        BlobIndex = packet.ReadInt32("BlobIndex", i, j),
+                        ObjectiveIndex = packet.ReadInt32("ObjectiveIndex", i, j),
+                        QuestObjectiveID = packet.ReadInt32("QuestObjectiveID", i, j),
+                        QuestObjectID = packet.ReadInt32("QuestObjectID", i, j),
+                        MapID = packet.ReadInt32("MapID", i, j),
+                        WorldMapAreaId = packet.ReadInt32("WorldMapAreaID", i, j),
+                        Floor = packet.ReadInt32("Floor", i, j),
+                        Priority = packet.ReadInt32("Priority", i, j),
+                        Flags = packet.ReadInt32("Flags", i, j),
+                        WorldEffectID = packet.ReadInt32("WorldEffectID", i, j),
+                        PlayerConditionID = packet.ReadInt32("PlayerConditionID", i, j)
+                    };
+
+                    questPoi.WoDUnk1 = packet.ReadInt32("WoDUnk1", i, j);
+
+                    int int13 = packet.ReadInt32("QuestPOIBlobPoint", i, j);
+                    for (int k = 0; k < int13; ++k)
+                    {
+                        QuestPOIPoint questPoiPoint = new QuestPOIPoint
+                        {
+                            QuestID = questId,
+                            Idx1 = j,
+                            Idx2 = k,
+                            X = packet.ReadInt32("X", i, j, k),
+                            Y = packet.ReadInt32("Y", i, j, k)
+                        };
+                        Storage.QuestPOIPoints.Add(questPoiPoint, packet.TimeSpan);
+                    }
+
+                    if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
+                    {
+                        packet.ResetBitReader();
+                        questPoi.AlwaysAllowMergingBlobs = packet.ReadBit("AlwaysAllowMergingBlobs", i, j);
+                    }
+
+                    Storage.QuestPOIs.Add(questPoi, packet.TimeSpan);
+                }
+            }
+        }
     }
 }

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
@@ -734,8 +734,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
                     questPoi.WoDUnk1 = packet.ReadInt32("WoDUnk1", i, j);
 
-                    int int13 = packet.ReadInt32("QuestPOIBlobPoint", i, j);
-                    for (int k = 0; k < int13; ++k)
+                    int questPOIBlobPoint = packet.ReadInt32("QuestPOIBlobPoint", i, j);
+                    for (int k = 0; k < questPOIBlobPoint; ++k)
                     {
                         QuestPOIPoint questPoiPoint = new QuestPOIPoint
                         {

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
@@ -205,7 +205,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             quest.SoundTurnIn = packet.ReadUInt32("CompleteSoundKitID");
             quest.AreaGroupID = packet.ReadUInt32("AreaGroupID");
             quest.TimeAllowed = packet.ReadUInt32("TimeAllowed");
-            uint int2946 = packet.ReadUInt32("CliQuestInfoObjective");
+            uint cliQuestInfoObjective = packet.ReadUInt32("CliQuestInfoObjective");
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
                 quest.AllowableRacesWod = packet.ReadUInt64("AllowableRaces");
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_0_3_22248) && ClientVersion.RemovedInVersion(ClientVersionBuild.V7_3_5_25848))
@@ -227,7 +227,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             uint questTurnTargetNameLen = packet.ReadBits(8);
             uint questCompletionLogLen = packet.ReadBits(11);
 
-            for (uint i = 0; i < int2946; ++i)
+            for (uint i = 0; i < cliQuestInfoObjective; ++i)
             {
                 var objectiveId = packet.ReadEntry("Id", i);
 
@@ -705,15 +705,15 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
         public static void HandleQuestPoiQueryResponse(Packet packet)
         {
             packet.ReadInt32("NumPOIs");
-            int int4 = packet.ReadInt32("QuestPOIData");
+            int questPOIData = packet.ReadInt32("QuestPOIData");
 
-            for (int i = 0; i < int4; ++i)
+            for (int i = 0; i < questPOIData; ++i)
             {
                 int questId = packet.ReadInt32("QuestID", i);
 
-                int int2 = packet.ReadInt32("QuestPOIBlobData", i);
+                int questPOIBlobData = packet.ReadInt32("QuestPOIBlobData", i);
 
-                for (int j = 0; j < int2; ++j)
+                for (int j = 0; j < questPOIBlobData; ++j)
                 {
                     QuestPOI questPoi = new QuestPOI
                     {

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
@@ -72,13 +72,17 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ReadInt32("QuestType", indexes);
             packet.ReadInt32("QuestLevel", indexes);
 
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
+                packet.ReadInt32("QuestMaxScalingLevel", indexes);
+
             for (int i = 0; i < 2; i++)
                 packet.ReadUInt32("QuestFlags", indexes, i);
 
             packet.ResetBitReader();
 
             packet.ReadBit("Repeatable", indexes);
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_2_0_23826))
+
+            if (ClientVersion.RemovedInVersion(ClientVersionBuild.V7_2_0_23826))
                 packet.ReadBit("IsQuestIgnored", indexes);
 
             var guestTitleLen = packet.ReadBits(9);
@@ -104,6 +108,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
             quest.QuestType = packet.ReadInt32E<QuestType>("QuestType");
             quest.QuestLevel = packet.ReadInt32("QuestLevel");
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
+                quest.QuestMaxScalingLevel = packet.ReadInt32("QuestMaxScalingLevel");
             quest.QuestPackageID = packet.ReadUInt32("QuestPackageID");
             quest.MinLevel = packet.ReadInt32("QuestMinLevel");
             quest.QuestSortID = (QuestSort)packet.ReadUInt32("QuestSortID");
@@ -200,7 +206,10 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             quest.AreaGroupID = packet.ReadUInt32("AreaGroupID");
             quest.TimeAllowed = packet.ReadUInt32("TimeAllowed");
             uint int2946 = packet.ReadUInt32("CliQuestInfoObjective");
-            quest.AllowableRacesWod = packet.ReadInt32("AllowableRaces");
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
+                quest.AllowableRacesWod = (long)packet.ReadUInt64("AllowableRaces");
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_0_3_22248) && ClientVersion.RemovedInVersion(ClientVersionBuild.V7_3_5_25848))
+                quest.AllowableRacesWod = packet.ReadInt32("AllowableRaces");
             quest.QuestRewardID = packet.ReadInt32("QuestRewardID");
 
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_2_0_23826))

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/SpellHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/SpellHandler.cs
@@ -588,5 +588,30 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 packet.ReadUInt32("Immunities");
             }
         }
+
+        [Parser(Opcode.SMSG_MIRROR_IMAGE_COMPONENTED_DATA)]
+        public static void HandleMirrorImageData(Packet packet)
+        {
+            packet.ReadPackedGuid128("UnitGUID");
+            packet.ReadInt32("DisplayID");
+
+            packet.ReadByte("RaceID");
+            packet.ReadByte("Gender");
+            packet.ReadByte("ClassID");
+            packet.ReadByte("SkinColor");
+            packet.ReadByte("FaceVariation");
+            packet.ReadByte("HairVariation");
+            packet.ReadByte("HairColor");
+            packet.ReadByte("BeardVariation");
+
+            for (var i = 0; i < 3; i++)
+                packet.ReadByte("CustomDisplayOption", i);
+
+            packet.ReadPackedGuid128("GuildGUID");
+
+            var count = packet.ReadInt32("ItemDisplayCount");
+            for (var i = 0; i < count; i++)
+                packet.ReadInt32("ItemDisplayID", i);
+        }
     }
 }

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/TaxiHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/TaxiHandler.cs
@@ -27,7 +27,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
         }
 
         [Parser(Opcode.CMSG_ACTIVATE_TAXI)]
-        public static void HandleActivateTaxi61x(Packet packet)
+        public static void HandleActivateTaxi(Packet packet)
         {
             packet.ReadPackedGuid128("Vendor");
             packet.ReadUInt32("Node");

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/TaxiHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/TaxiHandler.cs
@@ -25,5 +25,14 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             for (var i = 0u; i < canUseNodesCount; ++i)
                 packet.ReadByte("CanUseNodes", i);
         }
+
+        [Parser(Opcode.CMSG_ACTIVATE_TAXI)]
+        public static void HandleActivateTaxi61x(Packet packet)
+        {
+            packet.ReadPackedGuid128("Vendor");
+            packet.ReadUInt32("Node");
+            packet.ReadUInt32("GroundMountID");
+            packet.ReadUInt32("FlyingMountID");
+        }
     }
 }


### PR DESCRIPTION
Updated some parsings for 7.3.5
Add Option to recalculate reputation discount on moneycost (not working with goblins)

also fixed crash when fusing pkt

Fusion (temp?) fix:
`Parallel.ForEach(groups, WriteGroup);`
to
`Parallel.ForEach(groups, new ParallelOptions { MaxDegreeOfParallelism = 1 }, WriteGroup);`