### PR TITLE
Added NUnitTestAdapter for NUnit2 Test Running in VS2017

### DIFF
--- a/WowPacketParser.Tests/WowPacketParser.Tests.csproj
+++ b/WowPacketParser.Tests/WowPacketParser.Tests.csproj
@@ -72,6 +72,9 @@
       <Name>WowPacketParser</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/WowPacketParser.Tests/packages.config
+++ b/WowPacketParser.Tests/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Not sure if this is Visual Studio specific but the test runner in VS2017 will not run the NUnit tests, but can locate them.

Adding the old NUnitTestAdapter for NUnit2 seemed to solve the problem. Meaning you could now run tests in VS2017.

![](https://i.gyazo.com/38bd55d8039f2c787a7eb373770c4a2c.png)
