### PR TITLE
Fixed structure of SMSG_PARTY_MEMBER_STATE

### DIFF
--- a/WowPacketParserModule.V6_0_2_19033/Parsers/GroupHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/GroupHandler.cs
@@ -90,6 +90,18 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             }
         }
 
+        public static void ReadPhaseInfos(Packet packet, params object[] index)
+        {
+            packet.ReadInt32("PhaseShiftFlags", index);
+            var int4 = packet.ReadInt32("PhaseCount", index);
+            packet.ReadPackedGuid128("PersonalGUID", index);
+            for (int i = 0; i < int4; i++)
+            {
+                packet.ReadUInt16("PhaseFlags", index, i);
+                packet.ReadUInt16("Id", index, i);
+            }
+        }
+
         [Parser(Opcode.SMSG_PARTY_MEMBER_STATS)]
         public static void HandlePartyMemberStats(Packet packet)
         {
@@ -237,17 +249,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             }
 
             if (bit72) // Phase
-            {
-                // sub_61E155
-                packet.ReadInt32("PhaseShiftFlags");
-                var int4 = packet.ReadInt32("PhaseCount");
-                packet.ReadPackedGuid128("PersonalGUID");
-                for (int i = 0; i < int4; i++)
-                {
-                    packet.ReadInt16("PhaseFlags", i);
-                    packet.ReadInt16("Id", i);
-                }
-            }
+                ReadPhaseInfos(packet, "Phase");
         }
 
         [Parser(Opcode.SMSG_PARTY_MEMBER_STATE)]
@@ -282,14 +284,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadInt32("VehicleSeatRecID");
             var auraCount = packet.ReadInt32("AuraCount");
 
-            packet.ReadInt32("PhaseShiftFlags");
-            var int4 = packet.ReadInt32("PhaseCount");
-            packet.ReadPackedGuid128("PersonalGUID");
-            for (int i = 0; i < int4; i++)
-            {
-                packet.ReadInt16("PhaseFlags", i);
-                packet.ReadInt16("Id", i);
-            }
+            ReadPhaseInfos(packet, "Phase");
 
             for (int i = 0; i < auraCount; i++)
             {


### PR DESCRIPTION
Also simplified some stuff & fixed namespace fail

(Structure fail was that PetDisplayId was read as UInt16, tho its UInt32), definitely valid for >= 7.1.5. Also valid for 7.0.3, but the opcode number in WPP is wrong:
Also I noticed that the Opcode for 7.0.3 is invalid. According to WPP its 0x2799 but in fact its 0x2797. Checked 7.0.3.21989. Didn't fix it, because I do not want to fix followups right now, busy with 801. Or I'm just blind, need someone else to check too. Summon @Shauren. Will create Issue in case I'm right, so we do not forget to fix this someday.