### PR TITLE
Implement attributes for UpdateFields

### DIFF
--- a/WowPacketParser.Tests/Misc/UpdateFieldTest.cs
+++ b/WowPacketParser.Tests/Misc/UpdateFieldTest.cs
@@ -22,11 +22,11 @@ namespace WowPacketParser.Tests.Misc
             var updateField = new UpdateField(uint.MaxValue);
 
             Assert.AreEqual(uint.MaxValue, updateField.UInt32Value);
-            Assert.AreEqual(Int32ToFloatBits(uint.MaxValue), updateField.SingleValue, float.Epsilon);
+            Assert.AreEqual(Int32ToFloatBits(uint.MaxValue), updateField.FloatValue, float.Epsilon);
 
             updateField = new UpdateField(float.MaxValue);
 
-            Assert.AreEqual(float.MaxValue, updateField.SingleValue);
+            Assert.AreEqual(float.MaxValue, updateField.FloatValue);
             Assert.AreEqual(FloatToInt32Bits(float.MaxValue), updateField.UInt32Value);
         }
 

--- a/WowPacketParser/Enums/UpdateFields.cs
+++ b/WowPacketParser/Enums/UpdateFields.cs
@@ -1,11 +1,17 @@
+using WowPacketParser.Parsing;
+
 namespace WowPacketParser.Enums
 {
     // ReSharper disable InconsistentNaming, UnusedMember.Global
     public enum ObjectField
     {
+        [UpdateField(UpdateFieldType.Guid)]
         OBJECT_FIELD_GUID,
+        [UpdateField(UpdateFieldType.Uint)]
         OBJECT_FIELD_TYPE,
+        [UpdateField(UpdateFieldType.Uint)]
         OBJECT_FIELD_ENTRY,
+        [UpdateField(UpdateFieldType.Float)]
         OBJECT_FIELD_SCALE_X,
         OBJECT_FIELD_PADDING,
         OBJECT_DYNAMIC_FLAGS,
@@ -142,30 +148,45 @@ namespace WowPacketParser.Enums
         UNIT_FIELD_BATTLE_PET_COMPANION_GUID,
         UNIT_FIELD_BATTLE_PET_DB_ID,
         UNIT_FIELD_BONUS_RESISTANCE_MODS,
+        [UpdateField(UpdateFieldType.Float)]
         UNIT_FIELD_BOUNDINGRADIUS,
+        [UpdateField(UpdateFieldType.Bytes)]
         UNIT_FIELD_BYTES_0,
+        [UpdateField(UpdateFieldType.Bytes)]
         UNIT_FIELD_BYTES_1,
+        [UpdateField(UpdateFieldType.Bytes)]
         UNIT_FIELD_BYTES_2,
         UNIT_FIELD_CHANNEL_DATA,
+        [UpdateField(UpdateFieldType.Guid)]
         UNIT_FIELD_CHANNEL_OBJECT,
         UNIT_FIELD_CHARM,
+        [UpdateField(UpdateFieldType.Guid)]
         UNIT_FIELD_CHARMEDBY,
         UNIT_FIELD_CONTENT_TUNING_ID,
+        [UpdateField(UpdateFieldType.Float)]
         UNIT_FIELD_COMBATREACH,
+        [UpdateField(UpdateFieldType.Guid)]
         UNIT_FIELD_CREATEDBY,
         UNIT_FIELD_CRITTER,
+        [UpdateField(UpdateFieldType.Guid)]
         UNIT_FIELD_DEMON_CREATOR,
         UNIT_FIELD_DISPLAYID,
         UNIT_FIELD_DISPLAY_POWER,
         UNIT_FIELD_DISPLAY_SCALE,
         UNIT_FIELD_EFFECTIVE_LEVEL,
         UNIT_FIELD_END,
+        [UpdateField(UpdateFieldType.Custom)]
         UNIT_FIELD_FACTIONTEMPLATE,
+        [UpdateField(UpdateFieldType.Uint)]
         UNIT_FIELD_FLAGS,
+        [UpdateField(UpdateFieldType.Uint)]
         UNIT_FIELD_FLAGS_2,
+        [UpdateField(UpdateFieldType.Uint)]
         UNIT_FIELD_FLAGS_3,
         UNIT_FIELD_GUILD_GUID,
+        [UpdateField(UpdateFieldType.Uint)]
         UNIT_FIELD_HEALTH,
+        [UpdateField(UpdateFieldType.Float)]
         UNIT_FIELD_HOVERHEIGHT,
         UNIT_FIELD_INTERACT_SPELLID,
         UNIT_FIELD_LEVEL,
@@ -286,6 +307,7 @@ namespace WowPacketParser.Enums
         UNIT_FIELD_SCALING_HEALTH_ITEM_LEVEL_CURVE_ID,
         UNIT_FIELD_SCALING_LEVEL_MIN,
         UNIT_FIELD_SCALING_LEVEL_MAX,
+        [UpdateField(UpdateFieldType.Int)]
         UNIT_FIELD_SCALING_LEVEL_DELTA,
         UNIT_FIELD_STAT,
         UNIT_FIELD_STAT0,
@@ -298,8 +320,10 @@ namespace WowPacketParser.Enums
         UNIT_FIELD_STATE_SPELL_VISUAL_ID,
         UNIT_FIELD_STATE_WORLD_EFFECT_ID,
         UNIT_FIELD_SUMMON,
+        [UpdateField(UpdateFieldType.Guid)]
         UNIT_FIELD_SUMMONEDBY,
         UNIT_FIELD_SUMMONED_BY_HOME_REALM,
+        [UpdateField(UpdateFieldType.Guid)]
         UNIT_FIELD_TARGET,
         UNIT_FIELD_UNK63,
         UNIT_FIELD_WILD_BATTLEPET_LEVEL,
@@ -324,9 +348,13 @@ namespace WowPacketParser.Enums
         PLAYER_AMPLIFY,
         PLAYER_AVOIDANCE,
         PLAYER_BLOCK_PERCENTAGE,
+        [UpdateField(UpdateFieldType.Bytes)]
         PLAYER_BYTES,
+        [UpdateField(UpdateFieldType.Bytes)]
         PLAYER_BYTES_2,
+        [UpdateField(UpdateFieldType.Bytes)]
         PLAYER_BYTES_3,
+        [UpdateField(UpdateFieldType.Bytes)]
         PLAYER_BYTES_4,
         PLAYER_CHARACTER_POINTS,
         PLAYER_CHARACTER_POINTS1,
@@ -377,8 +405,11 @@ namespace WowPacketParser.Enums
         PLAYER_FIELD_BUYBACK_TIMESTAMP_7,
         PLAYER_FIELD_BUYBACK_TIMESTAMP_8,
         PLAYER_FIELD_BUYBACK_TIMESTAMP_9,
+        [UpdateField(UpdateFieldType.Bytes)]
         PLAYER_FIELD_BYTES,
+        [UpdateField(UpdateFieldType.Bytes)]
         PLAYER_FIELD_BYTES2,
+        [UpdateField(UpdateFieldType.Bytes)]
         PLAYER_FIELD_BYTES3,
         PLAYER_FIELD_COINAGE,
         PLAYER_FIELD_COMBAT_RATING_1,
@@ -815,8 +846,11 @@ namespace WowPacketParser.Enums
         ACTIVE_PLAYER_FIELD_BLOCK_PERCENTAGE,
         ACTIVE_PLAYER_FIELD_BUYBACK_PRICE,
         ACTIVE_PLAYER_FIELD_BUYBACK_TIMESTAMP,
+        [UpdateField(UpdateFieldType.Bytes)]
         ACTIVE_PLAYER_FIELD_BYTES,
+        [UpdateField(UpdateFieldType.Bytes)]
         ACTIVE_PLAYER_FIELD_BYTES2,
+        [UpdateField(UpdateFieldType.Bytes)]
         ACTIVE_PLAYER_FIELD_BYTES3,
         ACTIVE_PLAYER_FIELD_CHARACTER_POINTS,
         ACTIVE_PLAYER_FIELD_COINAGE,
@@ -917,16 +951,21 @@ namespace WowPacketParser.Enums
 
     public enum GameObjectField
     {
+        [UpdateField(UpdateFieldType.Bytes)]
         GAMEOBJECT_BYTES_1,
         GAMEOBJECT_DISPLAYID,
         GAMEOBJECT_DYNAMIC,
         GAMEOBJECT_END,
+        [UpdateField(UpdateFieldType.Int)]
         GAMEOBJECT_FACTION,
+        [UpdateField(UpdateFieldType.Guid)]
         GAMEOBJECT_FIELD_CREATED_BY,
         GAMEOBJECT_FIELD_CUSTOM_PARAM,
         GAMEOBJECT_FIELD_GUILD_GUID,
         GAMEOBJECT_FLAGS,
         GAMEOBJECT_LEVEL,
+        [UpdateField(UpdateFieldType.Quaternion)]
+        [UpdateField(UpdateFieldType.PackedQuaternion, ClientVersionBuild.V3_0_2_9056)]
         GAMEOBJECT_ROTATION,
         GAMEOBJECT_PARENTROTATION,
         GAMEOBJECT_POS_X,
@@ -950,6 +989,7 @@ namespace WowPacketParser.Enums
 
     public enum DynamicObjectField
     {
+        [UpdateField(UpdateFieldType.Bytes)]
         DYNAMICOBJECT_BYTES,
         DYNAMICOBJECT_CASTER,
         DYNAMICOBJECT_CASTTIME,
@@ -968,7 +1008,9 @@ namespace WowPacketParser.Enums
     public enum CorpseField
     {
         CORPSE_END,
+        [UpdateField(UpdateFieldType.Bytes)]
         CORPSE_FIELD_BYTES_1,
+        [UpdateField(UpdateFieldType.Bytes)]
         CORPSE_FIELD_BYTES_2,
         CORPSE_FIELD_CUSTOM_DISPLAY_OPTION,
         CORPSE_FIELD_DISPLAY_ID,
@@ -978,6 +1020,7 @@ namespace WowPacketParser.Enums
         CORPSE_FIELD_GUILD,
         CORPSE_FIELD_GUILD_GUID,
         CORPSE_FIELD_ITEM,
+        [UpdateField(UpdateFieldType.Guid)]
         CORPSE_FIELD_OWNER,
         CORPSE_FIELD_PAD,
         CORPSE_FIELD_PARTY

--- a/WowPacketParser/Enums/UpdateFields.cs
+++ b/WowPacketParser/Enums/UpdateFields.cs
@@ -94,6 +94,7 @@ namespace WowPacketParser.Enums
         CONTAINER_ALIGN_PAD,
         CONTAINER_END,
         CONTAINER_FIELD_NUM_SLOTS,
+        [UpdateField(UpdateFieldType.Guid)]
         CONTAINER_FIELD_SLOT_1
     }
 

--- a/WowPacketParser/Enums/Version/UpdateFields.cs
+++ b/WowPacketParser/Enums/Version/UpdateFields.cs
@@ -138,7 +138,7 @@ namespace WowPacketParser.Enums.Version
                 case ClientVersionBuild.V3_0_8_9464:
                 case ClientVersionBuild.V3_0_8a_9506:
                 case ClientVersionBuild.V3_0_9_9551:
-                    return "V3_0_2_9056";
+                    return "V3_0_9_9551";
                 case ClientVersionBuild.V3_1_0_9767:
                 case ClientVersionBuild.V3_1_1_9806:
                 case ClientVersionBuild.V3_1_1a_9835:

--- a/WowPacketParser/Enums/Version/UpdateFields.cs
+++ b/WowPacketParser/Enums/Version/UpdateFields.cs
@@ -110,6 +110,31 @@ namespace WowPacketParser.Enums.Version
             return field.ToString(CultureInfo.InvariantCulture);
         }
 
+        public static Tuple<string, int, int> GetUpdateFieldNameTuple<T>(int field)
+        {
+            if (UpdateFieldDictionaries.ContainsKey(typeof(T)))
+            {
+                int start = field; // find start of field
+                do
+                {
+                    if (UpdateFieldDictionaries[typeof(T)].ContainsValue(start))
+                        break;
+                    start--;
+                }
+                while (start < field);
+                int diff = 1; // find next field
+                do
+                {
+                    if (UpdateFieldDictionaries[typeof(T)].ContainsValue(start + diff))
+                        return Tuple.Create(UpdateFieldDictionaries[typeof(T)][start], diff, start);
+                    ++diff;
+                }
+                while (diff <= 8);
+            }
+
+            return Tuple.Create("", 0, field);
+        }
+
         private static string GetUpdateFieldDictionaryBuildName(ClientVersionBuild build)
         {
             switch (build)

--- a/WowPacketParser/Enums/Version/V3_0_9_9551/UpdateFields.cs
+++ b/WowPacketParser/Enums/Version/V3_0_9_9551/UpdateFields.cs
@@ -1,4 +1,4 @@
-﻿namespace WowPacketParser.Enums.Version.V3_0_2_9056
+﻿namespace WowPacketParser.Enums.Version.V3_0_9_9551
 {
     // ReSharper disable InconsistentNaming
     // 3.0.2

--- a/WowPacketParser/Loading/SqLitePacketReader.cs
+++ b/WowPacketParser/Loading/SqLitePacketReader.cs
@@ -111,7 +111,10 @@ namespace WowPacketParser.Loading
                         {
                             int build;
                             if (int.TryParse(value.ToString(), out build))
+                            {
                                 ClientVersion.SetVersion((ClientVersionBuild)build);
+                                ClientLocale.SetLocale("enUS");
+                            }
 
                             break;
                         }

--- a/WowPacketParser/Misc/ClientVersion.cs
+++ b/WowPacketParser/Misc/ClientVersion.cs
@@ -279,6 +279,7 @@ namespace WowPacketParser.Misc
                     case ClientVersionBuild.V3_0_8_9464:
                     case ClientVersionBuild.V3_0_8a_9506:
                     case ClientVersionBuild.V3_0_9_9551:
+                        return ClientVersionBuild.V3_0_9_9551;
                     case ClientVersionBuild.V3_1_0_9767:
                     case ClientVersionBuild.V3_1_1_9806:
                     case ClientVersionBuild.V3_1_1a_9835:

--- a/WowPacketParser/Misc/Extensions.cs
+++ b/WowPacketParser/Misc/Extensions.cs
@@ -183,5 +183,30 @@ namespace WowPacketParser.Misc
 
             return FileCompression.None;
         }
+
+        public static int BinarySearch<TKey, TValue>(this SortedList<TKey, TValue> sortedList, TKey key)
+        {
+            if (key == null)
+                throw new ArgumentNullException(nameof(key));
+
+            var array = sortedList.Keys;
+            var comparer = sortedList.Comparer;
+            var lo = 0;
+            var hi = sortedList.Count - 1;
+            while (lo <= hi)
+            {
+                var i = lo + ((hi - lo) >> 1);
+                var order = comparer.Compare(array[i], key);
+                if (order == 0)
+                    return i;
+
+                if (order < 0)
+                    lo = i + 1;
+                else
+                    hi = i - 1;
+            }
+
+            return ~lo;
+        }
     }
 }

--- a/WowPacketParser/Misc/UpdateField.cs
+++ b/WowPacketParser/Misc/UpdateField.cs
@@ -6,23 +6,19 @@ namespace WowPacketParser.Misc
     [StructLayout(LayoutKind.Explicit)]
     public struct UpdateField
     {
-        public UpdateField(uint val)
+        public UpdateField(uint val) : this()
         {
-            SingleValue = 0; // CS0171
             UInt32Value = val;
         }
 
-        public UpdateField(float val)
+        public UpdateField(float val) : this()
         {
-            UInt32Value = 0; // CS0171
-            SingleValue = val;
+            FloatValue = val;
         }
 
-        [FieldOffset(0)]
-        public readonly uint UInt32Value;
-
-        [FieldOffset(0)]
-        public readonly float SingleValue;
+        [FieldOffset(0)] public readonly uint UInt32Value;
+        [FieldOffset(0)] public readonly int Int32Value;
+        [FieldOffset(0)] public readonly float FloatValue;
 
         public override bool Equals(object obj)
         {
@@ -36,7 +32,7 @@ namespace WowPacketParser.Misc
             if (UInt32Value == other.UInt32Value)
                 return true;
 
-            if (Math.Abs(SingleValue - other.SingleValue) < float.Epsilon)
+            if (Math.Abs(FloatValue - other.FloatValue) < float.Epsilon)
                 return true;
 
             return false;

--- a/WowPacketParser/Parsing/Parsers/CharacterHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/CharacterHandler.cs
@@ -1044,7 +1044,10 @@ namespace WowPacketParser.Parsing.Parsers
                 packet.ReadInt32("Time Played");
                 packet.ReadInt32("Total");
             }
-            packet.ReadBool("Print in chat");
+            if (packet.CanRead())
+            {
+                packet.ReadBool("Print in chat");
+            }
         }
 
         [Parser(Opcode.SMSG_LOG_XP_GAIN)]

--- a/WowPacketParser/Parsing/Parsers/CombatLogHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/CombatLogHandler.cs
@@ -352,7 +352,7 @@ namespace WowPacketParser.Parsing.Parsers
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V3_0_3_9183))
                 packet.ReadUInt32("Overheal", index);
 
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V3_0_3_9183)) // no idea when this was added exactly
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V3_2_0_10192)) // no idea when this was added exactly
                 packet.ReadUInt32("Absorb", index);
 
             packet.ReadBool("Critical", index);

--- a/WowPacketParser/Parsing/Parsers/ItemHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/ItemHandler.cs
@@ -496,7 +496,7 @@ namespace WowPacketParser.Parsing.Parsers
 
             item.AllowedClasses = packet.ReadInt32E<ClassMask>("Allowed Classes");
 
-            item.AllowedRaces = packet.ReadInt32E<RaceMask>("Allowed Races");
+            item.AllowedRaces = packet.ReadUInt32E<RaceMask>("Allowed Races");
 
             item.ItemLevel = packet.ReadUInt32("Item Level");
 

--- a/WowPacketParser/Parsing/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/MiscellaneousHandler.cs
@@ -631,7 +631,7 @@ namespace WowPacketParser.Parsing.Parsers
         {
             packet.ReadUInt32("Unk time"); // Time online?
 
-            if (ClientVersion.AddedInVersion(ClientType.WrathOfTheLichKing)) // no idea when this was added exactly, doesn't exist in 2.4.0
+            if (packet.CanRead()) // no idea when this was added exactly, doesn't exist in 2.4.0
                 packet.ReadUInt32("Unk int32");
         }
 

--- a/WowPacketParser/Parsing/Parsers/QueryHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/QueryHandler.cs
@@ -143,7 +143,8 @@ namespace WowPacketParser.Parsing.Parsers
             }
             else // Did they stop sending pet spell data after 3.1?
             {
-                packet.ReadInt32("Unk Int");
+                if (ClientVersion.RemovedInVersion(ClientType.WrathOfTheLichKing))
+                    packet.ReadInt32("Unk Int");
                 creature.PetSpellDataID = packet.ReadUInt32("Pet Spell Data Id");
             }
 

--- a/WowPacketParser/Parsing/Parsers/QuestHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/QuestHandler.cs
@@ -303,7 +303,11 @@ namespace WowPacketParser.Parsing.Parsers
             quest.RequiredNpcOrGoCount = new uint?[4];
             quest.RequiredItemID = new uint?[4];
             quest.RequiredItemCount = new uint?[4];
-            int reqItemFieldCount = ClientVersion.AddedInVersion(ClientVersionBuild.V3_0_8_9464) ? 6 : 4;
+            var reqItemFieldCount = 4;
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V3_0_8_9464))
+                reqItemFieldCount = 5;
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V3_2_0_10192))
+                reqItemFieldCount = 6;
             quest.RequiredItemID = new uint?[reqItemFieldCount];
             quest.RequiredItemCount = new uint?[reqItemFieldCount];
 

--- a/WowPacketParser/Parsing/UpdateFieldAttributes.cs
+++ b/WowPacketParser/Parsing/UpdateFieldAttributes.cs
@@ -1,0 +1,36 @@
+using System;
+using WowPacketParser.Enums;
+
+namespace WowPacketParser.Parsing
+{
+    public enum UpdateFieldType
+    {
+        Default, // Old formatting - Uint/Float - Supports variable length
+        Guid, // Must be 64-bit or 128-bit
+        Quaternion, // 4x float
+        PackedQuaternion, // ulong
+        Uint, // Supports variable length
+        Int, // Supports variable length
+        Float, // Supports variable length
+        Bytes,  // Supports variable length
+        Custom
+    }
+
+    [AttributeUsage(AttributeTargets.Field, AllowMultiple = true, Inherited = false)]
+    public sealed class UpdateFieldAttribute : Attribute
+    {
+        public UpdateFieldAttribute(UpdateFieldType attrib)
+        {
+            UFAttribute = attrib;
+            Version = ClientVersionBuild.Zero;
+        }
+        public UpdateFieldAttribute(UpdateFieldType attrib, ClientVersionBuild fromVersion)
+        {
+            UFAttribute = attrib;
+            Version = fromVersion;
+        }
+
+        public UpdateFieldType UFAttribute { get; private set; }
+        public ClientVersionBuild Version { get; private set; }
+    }
+}

--- a/WowPacketParser/Store/Objects/Unit.cs
+++ b/WowPacketParser/Store/Objects/Unit.cs
@@ -236,9 +236,9 @@ namespace WowPacketParser.Store.Objects
                     case TypeCode.Int32:
                         return (TK)(object)(int)uf.UInt32Value;
                     case TypeCode.Single:
-                        return (TK)(object)uf.SingleValue;
+                        return (TK)(object)uf.FloatValue;
                     case TypeCode.Double:
-                        return (TK)(object)(double)uf.SingleValue;
+                        return (TK)(object)(double)uf.FloatValue;
                     default:
                         break;
                 }
@@ -274,10 +274,10 @@ namespace WowPacketParser.Store.Objects
                             result[i] = (TK)(object)(int)uf.UInt32Value;
                             break;
                         case TypeCode.Single:
-                            result[i] = (TK)(object)uf.SingleValue;
+                            result[i] = (TK)(object)uf.FloatValue;
                             break;
                         case TypeCode.Double:
-                            result[i] = (TK)(object)(double)uf.SingleValue;
+                            result[i] = (TK)(object)(double)uf.FloatValue;
                             break;
                         default:
                             break;

--- a/WowPacketParser/Store/Objects/WoWObject.cs
+++ b/WowPacketParser/Store/Objects/WoWObject.cs
@@ -1,9 +1,6 @@
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using WowPacketParser.Enums;
 using WowPacketParser.Misc;
-using WowPacketParser.SQL;
-using CoreParsers = WowPacketParser.Parsing.Parsers;
 
 namespace WowPacketParser.Store.Objects
 {
@@ -20,8 +17,6 @@ namespace WowPacketParser.Store.Objects
 
         public Dictionary<int, UpdateField> UpdateFields; // SMSG_UPDATE_OBJECT - CreateObject
         public Dictionary<int, List<UpdateField>> DynamicUpdateFields; // SMSG_UPDATE_OBJECT - CreateObject
-
-        public ICollection<Dictionary<int, UpdateField>> ChangedUpdateFieldsList; // SMSG_UPDATE_OBJECT - Values
 
         public uint PhaseMask;
 

--- a/WowPacketParser/WowPacketParser.csproj
+++ b/WowPacketParser/WowPacketParser.csproj
@@ -543,6 +543,7 @@
     <Compile Include="Parsing\Parsers\WardenHandler.cs" />
     <Compile Include="Parsing\Parsers\WorldStateHandler.cs" />
     <Compile Include="Enums\PetStableResult.cs" />
+    <Compile Include="Parsing\UpdateFieldAttributes.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Saving\BinaryPacketWriter.cs" />

--- a/WowPacketParser/WowPacketParser.csproj
+++ b/WowPacketParser/WowPacketParser.csproj
@@ -385,7 +385,7 @@
     <Compile Include="Enums\UpdateType.cs" />
     <Compile Include="Enums\VehicleFlags.cs" />
     <Compile Include="Enums\Version\V2_4_3_8606\UpdateFields.cs" />
-    <Compile Include="Enums\Version\V3_0_2_9056\UpdateFields.cs" />
+    <Compile Include="Enums\Version\V3_0_9_9551\UpdateFields.cs" />
     <Compile Include="Enums\Version\V5_0_5_16048\Opcodes.cs" />
     <Compile Include="Enums\Version\V5_0_5_16048\UpdateFields.cs" />
     <Compile Include="Enums\Version\Opcodes.cs" />

--- a/WowPacketParserModule.V4_3_4_15595/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V4_3_4_15595/Parsers/UpdateHandler.cs
@@ -29,17 +29,7 @@ namespace WowPacketParserModule.V4_3_4_15595.Parsers
                     case "Values":
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-
-                        WoWObject obj;
-                        var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
-
-                        if (Storage.Objects.TryGetValue(guid, out obj))
-                        {
-                            if (obj.ChangedUpdateFieldsList == null)
-                                obj.ChangedUpdateFieldsList = new List<Dictionary<int, UpdateField>>();
-                            obj.ChangedUpdateFieldsList.Add(updates);
-                        }
-
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid, i);
                         break;
                     }
                     case "CreateObject1":
@@ -62,7 +52,7 @@ namespace WowPacketParserModule.V4_3_4_15595.Parsers
         {
             ObjectType objType = ObjectTypeConverter.Convert(packet.ReadByteE<ObjectTypeLegacy>("Object Type", index));
             var moves = ReadMovementUpdateBlock434(packet, guid, index);
-            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, objType, index, true);
+            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, objType, index);
 
             WoWObject obj;
             switch (objType)

--- a/WowPacketParserModule.V5_3_0_16981/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_3_0_16981/Parsers/UpdateHandler.cs
@@ -29,17 +29,7 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
                     case "Values":
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-
-                        WoWObject obj;
-                        var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
-
-                        if (Storage.Objects.TryGetValue(guid, out obj))
-                        {
-                            if (obj.ChangedUpdateFieldsList == null)
-                                obj.ChangedUpdateFieldsList = new List<Dictionary<int, UpdateField>>();
-                            obj.ChangedUpdateFieldsList.Add(updates);
-                        }
-
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid, i);
                         break;
                     }
                     case "CreateObject1":
@@ -62,7 +52,8 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
         {
             ObjectType objType = ObjectTypeConverter.Convert(packet.ReadByteE<ObjectTypeLegacy>("Object Type", index));
             var moves = ReadMovementUpdateBlock(packet, guid, index);
-            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, objType, index, true);
+            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, objType, index);
+            var dynamicUpdates = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             WoWObject obj;
             switch (objType)
@@ -87,6 +78,7 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
             obj.Type = objType;
             obj.Movement = moves;
             obj.UpdateFields = updates;
+            obj.DynamicUpdateFields = dynamicUpdates;
             obj.Map = map;
             obj.Area = CoreParsers.WorldStateHandler.CurrentAreaId;
             obj.Zone = CoreParsers.WorldStateHandler.CurrentZoneId;

--- a/WowPacketParserModule.V5_4_0_17359/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_0_17359/Parsers/UpdateHandler.cs
@@ -29,17 +29,7 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
                     case "Values":
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-
-                        WoWObject obj;
-                        var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
-
-                        if (Storage.Objects.TryGetValue(guid, out obj))
-                        {
-                            if (obj.ChangedUpdateFieldsList == null)
-                                obj.ChangedUpdateFieldsList = new List<Dictionary<int, UpdateField>>();
-                            obj.ChangedUpdateFieldsList.Add(updates);
-                        }
-
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid, i);
                         break;
                     }
                     case "CreateObject1":
@@ -62,7 +52,8 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
         {
             ObjectType objType = ObjectTypeConverter.Convert(packet.ReadByteE<ObjectTypeLegacy>("Object Type", index));
             var moves = ReadMovementUpdateBlock(packet, guid, index);
-            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, objType, index, true);
+            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, objType, index);
+            var dynamicUpdates = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             WoWObject obj;
             switch (objType)
@@ -87,6 +78,7 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
             obj.Type = objType;
             obj.Movement = moves;
             obj.UpdateFields = updates;
+            obj.DynamicUpdateFields = dynamicUpdates;
             obj.Map = map;
             obj.Area = CoreParsers.WorldStateHandler.CurrentAreaId;
             obj.Zone = CoreParsers.WorldStateHandler.CurrentZoneId;

--- a/WowPacketParserModule.V5_4_1_17538/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_1_17538/Parsers/UpdateHandler.cs
@@ -29,17 +29,7 @@ namespace WowPacketParserModule.V5_4_1_17538.Parsers
                     case "Values":
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-
-                        WoWObject obj;
-                        var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
-
-                        if (Storage.Objects.TryGetValue(guid, out obj))
-                        {
-                            if (obj.ChangedUpdateFieldsList == null)
-                                obj.ChangedUpdateFieldsList = new List<Dictionary<int, UpdateField>>();
-                            obj.ChangedUpdateFieldsList.Add(updates);
-                        }
-
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid, i);
                         break;
                     }
                     case "CreateObject1":
@@ -62,7 +52,8 @@ namespace WowPacketParserModule.V5_4_1_17538.Parsers
         {
             ObjectType objType = ObjectTypeConverter.Convert(packet.ReadByteE<ObjectTypeLegacy>("Object Type", index));
             var moves = ReadMovementUpdateBlock(packet, guid, index);
-            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, objType, index, true);
+            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, objType, index);
+            var dynamicUpdates = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             WoWObject obj;
             switch (objType)
@@ -87,6 +78,7 @@ namespace WowPacketParserModule.V5_4_1_17538.Parsers
             obj.Type = objType;
             obj.Movement = moves;
             obj.UpdateFields = updates;
+            obj.DynamicUpdateFields = dynamicUpdates;
             obj.Map = map;
             obj.Area = CoreParsers.WorldStateHandler.CurrentAreaId;
             obj.Zone = CoreParsers.WorldStateHandler.CurrentZoneId;

--- a/WowPacketParserModule.V5_4_2_17658/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_2_17658/Parsers/UpdateHandler.cs
@@ -27,33 +27,23 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
                 switch (typeString)
                 {
                     case "Values":
-                        {
-                            var guid = packet.ReadPackedGuid("GUID", i);
-
-                            WoWObject obj;
-                            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
-
-                            if (Storage.Objects.TryGetValue(guid, out obj))
-                            {
-                                if (obj.ChangedUpdateFieldsList == null)
-                                    obj.ChangedUpdateFieldsList = new List<Dictionary<int, UpdateField>>();
-                                obj.ChangedUpdateFieldsList.Add(updates);
-                            }
-
-                            break;
-                        }
+                    {
+                        var guid = packet.ReadPackedGuid("GUID", i);
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid, i);
+                        break;
+                    }
                     case "CreateObject1":
                     case "CreateObject2": // Might != CreateObject1 on Cata
-                        {
-                            var guid = packet.ReadPackedGuid("GUID", i);
-                            ReadCreateObjectBlock(packet, guid, map, i);
-                            break;
-                        }
+                    {
+                        var guid = packet.ReadPackedGuid("GUID", i);
+                        ReadCreateObjectBlock(packet, guid, map, i);
+                        break;
+                    }
                     case "DestroyObjects":
-                        {
-                            CoreParsers.UpdateHandler.ReadObjectsBlock(packet, i);
-                            break;
-                        }
+                    {
+                        CoreParsers.UpdateHandler.ReadObjectsBlock(packet, i);
+                        break;
+                    }
                 }
             }
         }
@@ -62,7 +52,8 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
         {
             ObjectType objType = ObjectTypeConverter.Convert(packet.ReadByteE<ObjectTypeLegacy>("Object Type", index));
             var moves = ReadMovementUpdateBlock(packet, guid, index);
-            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, objType, index, true);
+            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, objType, index);
+            var dynamicUpdates = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             WoWObject obj;
             switch (objType)
@@ -87,6 +78,7 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
             obj.Type = objType;
             obj.Movement = moves;
             obj.UpdateFields = updates;
+            obj.DynamicUpdateFields = dynamicUpdates;
             obj.Map = map;
             obj.Area = CoreParsers.WorldStateHandler.CurrentAreaId;
             obj.Zone = CoreParsers.WorldStateHandler.CurrentZoneId;

--- a/WowPacketParserModule.V5_4_7_17898/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_7_17898/Parsers/UpdateHandler.cs
@@ -56,33 +56,23 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
                 switch (typeString)
                 {
                     case "Values":
-                        {
-                            var guid = packet.ReadPackedGuid("GUID", i);
-
-                            WoWObject obj;
-                            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
-
-                            if (Storage.Objects.TryGetValue(guid, out obj))
-                            {
-                                if (obj.ChangedUpdateFieldsList == null)
-                                    obj.ChangedUpdateFieldsList = new List<Dictionary<int, UpdateField>>();
-                                obj.ChangedUpdateFieldsList.Add(updates);
-                            }
-
-                            break;
-                        }
+                    {
+                        var guid = packet.ReadPackedGuid("GUID", i);
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid, i);
+                        break;
+                    }
                     case "CreateObject1":
                     case "CreateObject2": // Might != CreateObject1 on Cata
-                        {
-                            var guid = packet.ReadPackedGuid("GUID", i);
-                            ReadCreateObjectBlock(packet, guid, map, i);
-                            break;
-                        }
+                    {
+                        var guid = packet.ReadPackedGuid("GUID", i);
+                        ReadCreateObjectBlock(packet, guid, map, i);
+                        break;
+                    }
                     case "DestroyObjects":
-                        {
-                            CoreParsers.UpdateHandler.ReadObjectsBlock(packet, i);
-                            break;
-                        }
+                    {
+                        CoreParsers.UpdateHandler.ReadObjectsBlock(packet, i);
+                        break;
+                    }
                 }
             }
         }
@@ -91,7 +81,8 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
         {
             ObjectType objType = ObjectTypeConverter.Convert(packet.ReadByteE<ObjectTypeLegacy>("Object Type", index));
             var moves = ReadMovementUpdateBlock(packet, guid, index);
-            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, objType, index, true);
+            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, objType, index);
+            var dynamicUpdates = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             WoWObject obj;
             switch (objType)
@@ -116,6 +107,7 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
             obj.Type = objType;
             obj.Movement = moves;
             obj.UpdateFields = updates;
+            obj.DynamicUpdateFields = dynamicUpdates;
             obj.Map = map;
             obj.Area = CoreParsers.WorldStateHandler.CurrentAreaId;
             obj.Zone = CoreParsers.WorldStateHandler.CurrentZoneId;

--- a/WowPacketParserModule.V5_4_8_18291/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_8_18291/Parsers/UpdateHandler.cs
@@ -47,33 +47,23 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
                 switch (typeString)
                 {
                     case "Values":
-                        {
-                            var guid = packet.ReadPackedGuid("GUID", i);
-
-                            WoWObject obj;
-                            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
-
-                            if (Storage.Objects.TryGetValue(guid, out obj))
-                            {
-                                if (obj.ChangedUpdateFieldsList == null)
-                                    obj.ChangedUpdateFieldsList = new List<Dictionary<int, UpdateField>>();
-                                obj.ChangedUpdateFieldsList.Add(updates);
-                            }
-
-                            break;
-                        }
+                    {
+                        var guid = packet.ReadPackedGuid("GUID", i);
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid, i);
+                        break;
+                    }
                     case "CreateObject1":
                     case "CreateObject2": // Might != CreateObject1 on Cata
-                        {
-                            var guid = packet.ReadPackedGuid("GUID", i);
-                            ReadCreateObjectBlock(packet, guid, map, i);
-                            break;
-                        }
+                    {
+                        var guid = packet.ReadPackedGuid("GUID", i);
+                        ReadCreateObjectBlock(packet, guid, map, i);
+                        break;
+                    }
                     case "DestroyObjects":
-                        {
-                            CoreParsers.UpdateHandler.ReadObjectsBlock(packet, i);
-                            break;
-                        }
+                    {
+                        CoreParsers.UpdateHandler.ReadObjectsBlock(packet, i);
+                        break;
+                    }
                 }
             }
         }
@@ -82,7 +72,8 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
         {
             ObjectType objType = ObjectTypeConverter.Convert(packet.ReadByteE<ObjectTypeLegacy>("Object Type", index));
             var moves = ReadMovementUpdateBlock(packet, guid, index);
-            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, objType, index, true);
+            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, objType, index);
+            var dynamicUpdates = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             WoWObject obj;
             switch (objType)
@@ -107,6 +98,7 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
             obj.Type = objType;
             obj.Movement = moves;
             obj.UpdateFields = updates;
+            obj.DynamicUpdateFields = dynamicUpdates;
             obj.Map = map;
             obj.Area = CoreParsers.WorldStateHandler.CurrentAreaId;
             obj.Zone = CoreParsers.WorldStateHandler.CurrentZoneId;

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/UpdateHandler.cs
@@ -36,28 +36,18 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 switch (typeString)
                 {
                     case "Values":
-                        {
-                            var guid = packet.ReadPackedGuid128("Object Guid", i);
-
-                            WoWObject obj;
-                            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
-
-                            if (Storage.Objects.TryGetValue(guid, out obj))
-                            {
-                                if (obj.ChangedUpdateFieldsList == null)
-                                    obj.ChangedUpdateFieldsList = new List<Dictionary<int, UpdateField>>();
-                                obj.ChangedUpdateFieldsList.Add(updates);
-                            }
-
-                            break;
-                        }
+                    {
+                        var guid = packet.ReadPackedGuid128("Object Guid", i);
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid, i);
+                        break;
+                    }
                     case "CreateObject1":
                     case "CreateObject2": // Might != CreateObject1 on Cata
-                        {
-                            var guid = packet.ReadPackedGuid128("Object Guid", i);
-                            ReadCreateObjectBlock(packet, guid, map, i);
-                            break;
-                        }
+                    {
+                        var guid = packet.ReadPackedGuid128("Object Guid", i);
+                        ReadCreateObjectBlock(packet, guid, map, i);
+                        break;
+                    }
                 }
             }
         }
@@ -66,7 +56,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         {
             ObjectType objType = ObjectTypeConverter.Convert(packet.ReadByteE<ObjectTypeLegacy>("Object Type", index));
             var moves = ReadMovementUpdateBlock(packet, guid, index);
-            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, objType, index, true);
+            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, objType, index);
+            var dynamicUpdates = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             WoWObject obj;
             switch (objType)
@@ -91,6 +82,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             obj.Type = objType;
             obj.Movement = moves;
             obj.UpdateFields = updates;
+            obj.DynamicUpdateFields = dynamicUpdates;
             obj.Map = map;
             obj.Area = CoreParsers.WorldStateHandler.CurrentAreaId;
             obj.Zone = CoreParsers.WorldStateHandler.CurrentZoneId;

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/UpdateHandler.cs
@@ -42,18 +42,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                     case "Values":
                     {
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
-
-                        WoWObject obj;
-                        var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
-                        var dynamicUpdates = ReadDynamicValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
-
-                        if (Storage.Objects.TryGetValue(guid, out obj))
-                        {
-                            if (obj.ChangedUpdateFieldsList == null)
-                                obj.ChangedUpdateFieldsList = new List<Dictionary<int, UpdateField>>();
-                            obj.ChangedUpdateFieldsList.Add(updates);
-                        }
-
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid, i);
                         break;
                     }
                     case "CreateObject1":
@@ -98,8 +87,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             }
 
             var moves = ReadMovementUpdateBlock(packet, guid, obj, index);
-            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, objType, index, true);
-            var dynamicUpdates = ReadDynamicValuesUpdateBlock(packet, objType, index, true);
+            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, objType, index);
+            var dynamicUpdates = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             obj.Type = objType;
             obj.Movement = moves;
@@ -641,120 +630,6 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             }
 
             return moveInfo;
-        }
-
-        private static Dictionary<int, List<UpdateField>> ReadDynamicValuesUpdateBlock(Packet packet, ObjectType type, object index, bool isCreating)
-        {
-            var dict = new Dictionary<int, List<UpdateField>>();
-
-            if (!ClientVersion.AddedInVersion(ClientVersionBuild.V5_0_4_16016))
-                return dict;
-
-            int objectEnd = UpdateFields.GetUpdateField(ObjectDynamicField.OBJECT_DYNAMIC_END);
-            var maskSize = packet.ReadByte();
-            var updateMask = new int[maskSize];
-            for (var i = 0; i < maskSize; i++)
-                updateMask[i] = packet.ReadInt32();
-
-            var mask = new BitArray(updateMask);
-            for (var i = 0; i < mask.Count; ++i)
-            {
-                if (!mask[i])
-                    continue;
-
-                string key = "Dynamic Block Value " + i;
-                if (i < objectEnd)
-                    key = UpdateFields.GetUpdateFieldName<ObjectDynamicField>(i);
-                else
-                {
-                    switch (type)
-                    {
-                        case ObjectType.Container:
-                        {
-                            if (i < UpdateFields.GetUpdateField(ItemDynamicField.ITEM_DYNAMIC_END))
-                                goto case ObjectType.Item;
-
-                            key = UpdateFields.GetUpdateFieldName<ContainerDynamicField>(i);
-                            break;
-                        }
-                        case ObjectType.Item:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<ItemDynamicField>(i);
-                            break;
-                        }
-                        case ObjectType.Player:
-                        {
-                            if (i < UpdateFields.GetUpdateField(UnitDynamicField.UNIT_DYNAMIC_END))
-                                goto case ObjectType.Unit;
-
-                            key = UpdateFields.GetUpdateFieldName<PlayerDynamicField>(i);
-                            break;
-                        }
-                        case ObjectType.Unit:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<UnitDynamicField>(i);
-                            break;
-                        }
-                        case ObjectType.GameObject:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<GameObjectDynamicField>(i);
-                            break;
-                        }
-                        case ObjectType.DynamicObject:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<DynamicObjectDynamicField>(i);
-                            break;
-                        }
-                        case ObjectType.Corpse:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<CorpseDynamicField>(i);
-                            break;
-                        }
-                        case ObjectType.AreaTrigger:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<AreaTriggerDynamicField>(i);
-                            break;
-                        }
-                        case ObjectType.SceneObject:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<SceneObjectDynamicField>(i);
-                            break;
-                        }
-                        case ObjectType.Conversation:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<ConversationDynamicField>(i);
-                            break;
-                        }
-                    }
-                }
-
-                var flag = packet.ReadUInt16();
-                var cnt = flag & 0x7FFF;
-                if ((flag & 0x8000) != 0)
-                    packet.ReadUInt32(key + " Size", index);
-
-                var vals = new int[cnt];
-                for (var j = 0; j < cnt; ++j)
-                    vals[j] = packet.ReadInt32();
-
-                var values = new List<UpdateField>();
-                var fieldMask = new BitArray(vals);
-                for (var j = 0; j < fieldMask.Count; ++j)
-                {
-                    if (!fieldMask[j])
-                        continue;
-
-                    var blockVal = packet.ReadUpdateField();
-                    string value = blockVal.UInt32Value + "/" + blockVal.FloatValue;
-                    packet.AddValue(key, value, index, j);
-
-                    values.Add(blockVal);
-                }
-
-                dict.Add(i, values);
-            }
-
-            return dict;
         }
     }
 }

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateHandler.cs
@@ -44,7 +44,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
 
                         WoWObject obj;
-                        var updates = ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
+                        var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
                         var dynamicUpdates = ReadDynamicValuesUpdateBlock(packet, guid.GetObjectType(), i, false);
 
                         if (Storage.Objects.TryGetValue(guid, out obj))
@@ -98,7 +98,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             }
 
             var moves = ReadMovementUpdateBlock(packet, guid, obj, index);
-            var updates = ReadValuesUpdateBlock(packet, objType, index, true);
+            var updates = CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, objType, index, true);
             var dynamicUpdates = ReadDynamicValuesUpdateBlock(packet, objType, index, true);
 
             obj.Type = objType;
@@ -632,133 +632,6 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             return moveInfo;
         }
 
-        private static Dictionary<int, UpdateField> ReadValuesUpdateBlock(Packet packet, ObjectType type, object index, bool isCreating)
-        {
-            var maskSize = packet.ReadByte();
-
-            var updateMask = new int[maskSize];
-            for (var i = 0; i < maskSize; i++)
-                updateMask[i] = packet.ReadInt32();
-
-            var mask = new BitArray(updateMask);
-            var dict = new Dictionary<int, UpdateField>();
-
-            int objectEnd = UpdateFields.GetUpdateField(ObjectField.OBJECT_END);
-            for (var i = 0; i < mask.Count; ++i)
-            {
-                if (!mask[i])
-                    continue;
-
-                var blockVal = packet.ReadUpdateField();
-
-                // Don't spam 0 values at create
-                if (isCreating && blockVal.UInt32Value == 0)
-                    continue;
-
-                string key = "Block Value " + i;
-                string value = blockVal.UInt32Value + "/" + blockVal.SingleValue;
-
-                if (i < objectEnd)
-                    key = UpdateFields.GetUpdateFieldName<ObjectField>(i);
-                else
-                {
-                    switch (type)
-                    {
-                        case ObjectType.Container:
-                        {
-                            if (i < UpdateFields.GetUpdateField(ItemField.ITEM_END))
-                                goto case ObjectType.Item;
-
-                            key = UpdateFields.GetUpdateFieldName<ContainerField>(i);
-                            break;
-                        }
-                        case ObjectType.Item:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<ItemField>(i);
-                            break;
-                        }
-                        case ObjectType.AzeriteEmpoweredItem:
-                        {
-                            if (i < UpdateFields.GetUpdateField(ItemField.ITEM_END))
-                                goto case ObjectType.Item;
-                            key = UpdateFields.GetUpdateFieldName<AzeriteEmpoweredItemField>(i);
-                            break;
-                        }
-                        case ObjectType.AzeriteItem:
-                        {
-                            if (i < UpdateFields.GetUpdateField(ItemField.ITEM_END))
-                                goto case ObjectType.Item;
-                            key = UpdateFields.GetUpdateFieldName<AzeriteItemField>(i);
-                            break;
-                        }
-                        case ObjectType.Player:
-                        {
-                            if (i < UpdateFields.GetUpdateField(UnitField.UNIT_END) || i < UpdateFields.GetUpdateField(UnitField.UNIT_FIELD_END))
-                                goto case ObjectType.Unit;
-
-                            key = UpdateFields.GetUpdateFieldName<PlayerField>(i);
-                            break;
-                        }
-                        case ObjectType.ActivePlayer:
-                        {
-                            if (i < UpdateFields.GetUpdateField(PlayerField.PLAYER_END))
-                                goto case ObjectType.Player;
-                            key = UpdateFields.GetUpdateFieldName<ActivePlayerField>(i);
-                            break;
-                        }
-                        case ObjectType.Unit:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<UnitField>(i);
-                            break;
-                        }
-                        case ObjectType.GameObject:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<GameObjectField>(i);
-                            break;
-                        }
-                        case ObjectType.DynamicObject:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<DynamicObjectField>(i);
-                            break;
-                        }
-                        case ObjectType.Corpse:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<CorpseField>(i);
-                            break;
-                        }
-                        case ObjectType.AreaTrigger:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<AreaTriggerField>(i);
-                            break;
-                        }
-                        case ObjectType.SceneObject:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<SceneObjectField>(i);
-                            break;
-                        }
-                        case ObjectType.Conversation:
-                        {
-                            key = UpdateFields.GetUpdateFieldName<ConversationField>(i);
-                            break;
-                        }
-                    }
-                }
-
-                // HACK...
-                if (key == UnitField.UNIT_FIELD_SCALING_LEVEL_DELTA.ToString())
-                    value = (int)blockVal.UInt32Value + "/" + blockVal.SingleValue;
-
-                if (key == UnitField.UNIT_FIELD_FACTIONTEMPLATE.ToString())
-                    packet.AddValue(key, value + $" ({ StoreGetters.GetName(StoreNameType.Faction, (int)blockVal.UInt32Value, false) })", index);
-                else
-                    packet.AddValue(key, value, index);
-
-                dict.Add(i, blockVal);
-            }
-
-            return dict;
-        }
-
         private static Dictionary<int, List<UpdateField>> ReadDynamicValuesUpdateBlock(Packet packet, ObjectType type, object index, bool isCreating)
         {
             var dict = new Dictionary<int, List<UpdateField>>();
@@ -879,7 +752,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                         continue;
 
                     var blockVal = packet.ReadUpdateField();
-                    string value = blockVal.UInt32Value + "/" + blockVal.SingleValue;
+                    string value = blockVal.UInt32Value + "/" + blockVal.FloatValue;
                     packet.AddValue(key, value, index, j);
 
                     values.Add(blockVal);


### PR DESCRIPTION
Prototype for improving parsing of update fields. Initial addition of enum attributes for the most used ones. Improves readability of the actual sniff. Gets rid of some duplicate code and enables future extensibility for stuff like unitflags or other enum based fields.