### PR TITLE
Fix Field Parsing

### DIFF
--- a/WowPacketParser/Parsing/Parsers/UpdateHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/UpdateHandler.cs
@@ -427,7 +427,12 @@ namespace WowPacketParser.Parsing.Parsers
                 }
 
                 for (int k = 0; k < fieldData.Count; ++k)
-                    dict.Add(start + k, fieldData[k]);
+                {
+                    if (dict.ContainsKey(start + k))
+                        dict[start + k] = fieldData[k];
+                    else
+                        dict.Add(start + k, fieldData[k]);
+                }
             }
 
             return dict;


### PR DESCRIPTION
Blizzard used to use Fields twice in 1 update block.

Causing dictionary to error because element already exists.

```
[1] UpdateType: Values
[1] GUID: Full: 0x4300000306F8B19C Type: Item Low: 13001863580
[1] ITEM_END + 18: 0/0
[1] ITEM_END + 18: 208645095/1.846362E-31
[1] ITEM_END + 19: 0/0
```

First Set it to 0 (to clean it up)
Then set it to correct value.

prolly client is retarded and needs that behavior?

Checked Field enums and they seem to be correct