### PR TITLE
Fixed legacy gameobject flags updatefield parsing for gameobject_temp…

### DIFF
--- a/WowPacketParser/Store/Objects/UpdateFields/IGameObjectData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IGameObjectData.cs
@@ -1,11 +1,12 @@
-﻿using WowPacketParser.Misc;
+﻿using WowPacketParser.Enums;
+using WowPacketParser.Misc;
 
 namespace WowPacketParser.Store.Objects.UpdateFields
 {
     public interface IGameObjectData
     {
         WowGuid CreatedBy { get; }
-        uint Flags { get; }
+        GameObjectFlag? Flags { get; }
         Quaternion ParentRotation { get; }
         int FactionTemplate { get; }
         sbyte State { get; }

--- a/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/GameObjectData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/GameObjectData.cs
@@ -31,7 +31,7 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
             }
         }
 
-        public uint Flags => (uint)UpdateFields.GetEnum<GameObjectField, GameObjectFlag>(GameObjectField.GAMEOBJECT_FLAGS);
+        public GameObjectFlag? Flags => UpdateFields.GetEnum<GameObjectField, GameObjectFlag?>(GameObjectField.GAMEOBJECT_FLAGS);
 
         public Quaternion ParentRotation
         {

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler.cs
@@ -3007,7 +3007,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29495
             }
             data.CreatedBy = packet.ReadPackedGuid128("CreatedBy", indexes);
             data.GuildGUID = packet.ReadPackedGuid128("GuildGUID", indexes);
-            data.Flags = packet.ReadUInt32("Flags", indexes);
+            data.Flags = (GameObjectFlag)packet.ReadUInt32("Flags", indexes);
             data.ParentRotation = packet.ReadQuaternion("ParentRotation", indexes);
             data.FactionTemplate = packet.ReadInt32("FactionTemplate", indexes);
             data.Level = packet.ReadInt32("Level", indexes);
@@ -3099,7 +3099,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29495
                 }
                 if (changesMask[11])
                 {
-                    data.Flags = packet.ReadUInt32("Flags", indexes);
+                    data.Flags = (GameObjectFlag)packet.ReadUInt32("Flags", indexes);
                 }
                 if (changesMask[12])
                 {

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/GameObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/GameObjectData.cs
@@ -1,3 +1,4 @@
+using WowPacketParser.Enums;
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
@@ -14,7 +15,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29495
         public uint[] StateWorldEffectIDs { get; set; }
         public WowGuid CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
+        public GameObjectFlag? Flags { get; set; }
         public Quaternion ParentRotation { get; set; }
         public int FactionTemplate { get; set; }
         public int Level { get; set; }


### PR DESCRIPTION
…late_addon

For some sniffs `typeof(TK).GetGenericArguments` has a size of 0 which results in OutOfBounds errors here: https://github.com/TrinityCore/WowPacketParser/blob/59a886fb1fbd38b3b97a59cc63e1b6954b885ead/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/UpdateFieldExtensions.cs#L164

With declaring the gameobject flags as a nullable type this is fixed.

Alternatively we could use
`Enum.Parse(typeof(TK), [...])`
instead of
`Enum.Parse(typeof(TK).GetGenericArguments()[0], [...]`, but seems like all flags are declared as nullable types. 