### PR TITLE
Fixes InvalidCastException during SQL generation for non-string nulla…

### DIFF
--- a/WowPacketParser/SQL/SQLDatabase.cs
+++ b/WowPacketParser/SQL/SQLDatabase.cs
@@ -235,8 +235,13 @@ namespace WowPacketParser.SQL
                     var i = 0;
                     foreach (var field in fields)
                     {
-                        if (values[i] is DBNull && field.Item2.FieldType == typeof(string))
-                            field.Item2.SetValue(instance, string.Empty);
+                        if (values[i] is DBNull)
+                        {
+                            if (field.Item2.FieldType == typeof(string))
+                                field.Item2.SetValue(instance, string.Empty);
+                            else if (field.Item3.Any(a => a.Nullable))
+                                field.Item2.SetValue(instance, null);
+                        }
                         else if (field.Item2.FieldType.BaseType == typeof(Enum))
                             field.Item2.SetValue(instance, Enum.Parse(field.Item2.FieldType, values[i].ToString()));
                         else if (field.Item2.FieldType.BaseType == typeof(Array))
@@ -264,7 +269,7 @@ namespace WowPacketParser.SQL
                             field.Item2.SetValue(instance,
                                 uType.IsEnum
                                     ? Enum.Parse(uType, values[i].ToString())
-                                    : Convert.ChangeType(values[i], Nullable.GetUnderlyingType(field.Item2.FieldType)));
+                                    : Convert.ChangeType(values[i], uType));
                         }
                         else
                             field.Item2.SetValue(instance, values[i]);

--- a/WowPacketParser/Store/Objects/AreaTriggerTemplateVertices.cs
+++ b/WowPacketParser/Store/Objects/AreaTriggerTemplateVertices.cs
@@ -19,10 +19,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("VerticeY")]
         public float? VerticeY;
 
-        [DBFieldName("VerticeTargetX")]
+        [DBFieldName("VerticeTargetX", false, false, true)]
         public float? VerticeTargetX;
 
-        [DBFieldName("VerticeTargetY")]
+        [DBFieldName("VerticeTargetY", false, false, true)]
         public float? VerticeTargetY;
 
         [DBFieldName("VerifiedBuild")]


### PR DESCRIPTION
…ble field types
* also sets VerticeTargetX and VerticeTargetY to nullable fields

Closes #455 

This is required due to values of DBNull type being unable to be casted to float (and int aswell, whyever).

Exact problem of #455 was that the value of `float? VerticeTargetX` and `float? VerticeTargetY` were of DBNull type. DBNull => Single/float is not possible => during the execution of `Convert.ChangeType(values[i], uType)` an InvalidCastException gets thrown.