### PR TITLE
Do not dump rows with no data for quest_details table

### DIFF
--- a/WowPacketParserModule.V6_0_2_19033/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/QuestHandler.cs
@@ -424,21 +424,21 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             ReadQuestRewards(packet);
 
-            int int2584 = packet.ReadInt32("DescEmotesCount");
-            int int5876 = packet.ReadInt32("ObjectivesCount");
+            int descEmotesCount = packet.ReadInt32("DescEmotesCount");
+            int objectivesCount = packet.ReadInt32("ObjectivesCount");
 
             for (int i = 0; i < int5860; i++)
                 packet.ReadInt32("LearnSpells", i);
 
             questDetails.Emote = new uint?[] {0, 0, 0, 0};
             questDetails.EmoteDelay = new uint?[] {0, 0, 0, 0};
-            for (int i = 0; i < int2584; i++)
+            for (int i = 0; i < descEmotesCount; i++)
             {
                 questDetails.Emote[i] = (uint)packet.ReadInt32("Type", i);
                 questDetails.EmoteDelay[i] = packet.ReadUInt32("Delay", i);
             }
 
-            for (int i = 0; i < int5876; i++)
+            for (int i = 0; i < objectivesCount; i++)
             {
                 packet.ReadInt32("ObjectID", i);
                 packet.ReadInt32("ObjectID", i);
@@ -468,7 +468,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadWoWString("PortraitTurnInText", bits4);
             packet.ReadWoWString("PortraitTurnInName", bits1532);
 
-            Storage.QuestDetails.Add(questDetails, packet.TimeSpan);
+            if (descEmotesCount > 0)
+                Storage.QuestDetails.Add(questDetails, packet.TimeSpan);
         }
 
         [Parser(Opcode.CMSG_QUEST_GIVER_STATUS_QUERY)]

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
@@ -459,7 +459,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ReadWoWString("PortraitTurnInText", portraitTurnInTextLen);
             packet.ReadWoWString("PortraitTurnInName", portraitTurnInNameLen);
 
-            Storage.QuestDetails.Add(questDetails, packet.TimeSpan);
+            if (descEmotesCount > 0)
+                Storage.QuestDetails.Add(questDetails, packet.TimeSpan);
         }
 
         [Parser(Opcode.SMSG_QUEST_GIVER_REQUEST_ITEMS)]

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/QuestHandler.cs
@@ -152,7 +152,8 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             packet.ReadWoWString("PortraitTurnInText", portraitTurnInTextLen);
             packet.ReadWoWString("PortraitTurnInName", portraitTurnInNameLen);
 
-            Storage.QuestDetails.Add(questDetails, packet.TimeSpan);
+            if (descEmotesCount > 0)
+                Storage.QuestDetails.Add(questDetails, packet.TimeSpan);
         }
 
         [HasSniffData]


### PR DESCRIPTION
Closes #470

Should be fine as is -for now- as long as we do not need more data from SMSG_QUEST_GIVER_QUEST_DETAILS