### PR TITLE
Define Classic as a different number than Expansion of BFA

### DIFF
--- a/WowPacketParser/Enums/ClientType.cs
+++ b/WowPacketParser/Enums/ClientType.cs
@@ -10,6 +10,6 @@ namespace WowPacketParser.Enums
         WarlordsOfDraenor  = 5,
         Legion             = 6,
         BattleForAzeroth   = 7,
-        Classic            = 7,
+        Classic            = -1,
     }
 }


### PR DESCRIPTION
, this fix parser SMSG_AURA_UPDATE and maybe other packet where use Client Type Classic as reference