### PR TITLE
Fix QueryBuilder

### DIFF
--- a/WowPacketParser/SQL/QueryBuilder.cs
+++ b/WowPacketParser/SQL/QueryBuilder.cs
@@ -220,6 +220,8 @@ namespace WowPacketParser.SQL
                         query.Append("=");
                         query.Append(SQLUtil.ToSQLValue(v, noQuotes: field.Item3.Any(a => a.NoQuotes)));
                         query.Append(SQLUtil.CommaSeparator);
+
+                        hasValues = true;
                     }
                     continue;
                 }


### PR DESCRIPTION
Fixes QueryBuilder building queries of array data when SkipOnlyVerifiedBuildUpdateRows is set true.

Currently data of arrays is skipped on update queries, because `hasValues`  has always been false and never been set true on array building.

No Check like `if (field.Item3.First().Name != "VerifiedBuild" || !Settings.SkipOnlyVerifiedBuildUpdateRows)` needed, because VerifiedBuild is never an array