### PR TITLE
Player choice Implementation

### DIFF
--- a/WowPacketParser/App.config
+++ b/WowPacketParser/App.config
@@ -138,6 +138,8 @@
         <add key="npc_vendor"                             value="false"/>
         <add key="page_text"                              value="false"/>
         <add key="page_text_locale"                       value="false"/>
+        <add key="playerchoice"                           value="false"/>
+        <add key="playerchoice_locale"                    value="false"/>
         <add key="playercreateinfo"                       value="false"/>
         <add key="playercreateinfo_action"                value="false"/>
         <add key="points_of_interest"                     value="false"/>

--- a/WowPacketParser/Enums/SQLOutput.cs
+++ b/WowPacketParser/Enums/SQLOutput.cs
@@ -36,6 +36,8 @@
         ObjectNames,
         page_text,
         page_text_locale,
+        playerchoice,
+        playerchoice_locale,
         playercreateinfo,
         playercreateinfo_action,
         points_of_interest,

--- a/WowPacketParser/SQL/Builders/Locales.cs
+++ b/WowPacketParser/SQL/Builders/Locales.cs
@@ -113,5 +113,35 @@ namespace WowPacketParser.SQL.Builders
 
             return "SET NAMES 'utf8';" + Environment.NewLine + SQLUtil.Compare(Storage.LocalesPageText, pagetextDb, StoreNameType.None) + Environment.NewLine + "SET NAMES 'latin1';";
         }
+
+        [BuilderMethod]
+        public static string PlayerChoiceLocale()
+        {
+            if (Storage.PlayerChoiceLocales.IsEmpty())
+                return string.Empty;
+
+            if (!Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.playerchoice_locale))
+                return string.Empty;
+
+            // pass empty list, because we want to select the whole db table (faster than select only needed columns)
+            var playerChoiceDb = SQLDatabase.Get(new RowList<Store.Objects.PlayerChoiceLocaleTemplate>());
+
+            return "SET NAMES 'utf8';" + Environment.NewLine + SQLUtil.Compare(Storage.PlayerChoiceLocales, playerChoiceDb, StoreNameType.None) + Environment.NewLine + "SET NAMES 'latin1';";
+        }
+
+        [BuilderMethod]
+        public static string PlayerChoiceResponseLocale()
+        {
+            if (Storage.PlayerChoiceResponseLocales.IsEmpty())
+                return string.Empty;
+
+            if (!Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.playerchoice_locale))
+                return string.Empty;
+
+            // pass empty list, because we want to select the whole db table (faster than select only needed columns)
+            var playerChoiceResponseDb = SQLDatabase.Get(new RowList<Store.Objects.PlayerChoiceResponseLocaleTemplate>());
+
+            return "SET NAMES 'utf8';" + Environment.NewLine + SQLUtil.Compare(Storage.PlayerChoiceResponseLocales, playerChoiceResponseDb, StoreNameType.None) + Environment.NewLine + "SET NAMES 'latin1';";
+        }
     }
 }

--- a/WowPacketParser/SQL/Builders/WDBTemplates.cs
+++ b/WowPacketParser/SQL/Builders/WDBTemplates.cs
@@ -185,6 +185,90 @@ namespace WowPacketParser.SQL.Builders
             return SQLUtil.Compare(Storage.ItemTemplates, templatesDb, StoreNameType.Item);
         }
 
+        [BuilderMethod]
+        public static string PlayerChoice()
+        {
+            if (!Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.playerchoice))
+                return string.Empty;
+
+            if (Storage.PlayerChoices.IsEmpty())
+                return string.Empty;
+
+            var templatesDb = SQLDatabase.Get(Storage.PlayerChoices);
+
+            return SQLUtil.Compare(Storage.PlayerChoices, templatesDb, StoreNameType.None);
+        }
+
+        [BuilderMethod]
+        public static string PlayerChoiceResponse()
+        {
+            if (!Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.playerchoice))
+                return string.Empty;
+
+            if (Storage.PlayerChoiceResponses.IsEmpty())
+                return string.Empty;
+
+            var templatesDb = SQLDatabase.Get(Storage.PlayerChoiceResponses);
+
+            return SQLUtil.Compare(Storage.PlayerChoiceResponses, templatesDb, StoreNameType.None);
+        }
+
+        [BuilderMethod]
+        public static string PlayerChoiceResponseReward()
+        {
+            if (!Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.playerchoice))
+                return string.Empty;
+
+            if (Storage.PlayerChoiceResponseRewards.IsEmpty())
+                return string.Empty;
+
+            var templatesDb = SQLDatabase.Get(Storage.PlayerChoiceResponseRewards);
+
+            return SQLUtil.Compare(Storage.PlayerChoiceResponseRewards, templatesDb, StoreNameType.None);
+        }
+
+        [BuilderMethod]
+        public static string PlayerChoiceResponseRewardCurrency()
+        {
+            if (!Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.playerchoice))
+                return string.Empty;
+
+            if (Storage.PlayerChoiceResponseRewardCurrencies.IsEmpty())
+                return string.Empty;
+
+            var templatesDb = SQLDatabase.Get(Storage.PlayerChoiceResponseRewardCurrencies);
+
+            return SQLUtil.Compare(Storage.PlayerChoiceResponseRewardCurrencies, templatesDb, StoreNameType.None);
+        }
+
+        [BuilderMethod]
+        public static string PlayerChoiceResponseRewardFaction()
+        {
+            if (!Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.playerchoice))
+                return string.Empty;
+
+            if (Storage.PlayerChoiceResponseRewardFactions.IsEmpty())
+                return string.Empty;
+
+            var templatesDb = SQLDatabase.Get(Storage.PlayerChoiceResponseRewardFactions);
+
+            return SQLUtil.Compare(Storage.PlayerChoiceResponseRewardFactions, templatesDb, StoreNameType.None);
+        }
+
+        [BuilderMethod]
+        public static string PlayerChoiceResponseRewardItem()
+        {
+            if (!Settings.SQLOutputFlag.HasAnyFlagBit(SQLOutput.playerchoice))
+                return string.Empty;
+
+            if (Storage.PlayerChoiceResponseRewardItems.IsEmpty())
+                return string.Empty;
+
+            var templatesDb = SQLDatabase.Get(Storage.PlayerChoiceResponseRewardItems);
+
+            return SQLUtil.Compare(Storage.PlayerChoiceResponseRewardItems, templatesDb, StoreNameType.None);
+        }
+
         [BuilderMethod(true)]
         public static string PageText()
         {

--- a/WowPacketParser/Store/Objects/PlayerChoice.cs
+++ b/WowPacketParser/Store/Objects/PlayerChoice.cs
@@ -1,0 +1,192 @@
+﻿using WowPacketParser.Enums;
+using WowPacketParser.Misc;
+using WowPacketParser.SQL;
+
+namespace WowPacketParser.Store.Objects
+{
+    [DBTableName("playerchoice")]
+    public sealed class PlayerChoiceTemplate : IDataModel
+    {
+        [DBFieldName("ChoiceId", true)]
+        public int? ChoiceId;
+
+        [DBFieldName("UiTextureKitId", TargetedDatabase.Legion)]
+        public int? UiTextureKitId;
+
+        [DBFieldName("SoundKitId", TargetedDatabase.BattleForAzeroth)]
+        public uint? SoundKitId;
+
+        [DBFieldName("Question")]
+        public string Question;
+
+        [DBFieldName("HideWarboardHeader", TargetedDatabase.Legion)]
+        public int HideWarboardHeader;
+
+        [DBFieldName("KeepOpenAfterChoice", TargetedDatabase.BattleForAzeroth)]
+        public int KeepOpenAfterChoice;
+
+        [DBFieldName("VerifiedBuild")]
+        public int? VerifiedBuild = ClientVersion.BuildInt;
+    }
+
+    [DBTableName("playerchoice_response")]
+    public sealed class PlayerChoiceResponseTemplate : IDataModel
+    {
+        [DBFieldName("ChoiceId", true)]
+        public int? ChoiceId;
+
+        [DBFieldName("ResponseId", true)]
+        public int? ResponseId;
+
+        [DBFieldName("Index", true)]
+        public uint? Index;
+
+        [DBFieldName("ChoiceArtFileId")]
+        public int? ChoiceArtFileId;
+
+        [DBFieldName("Flags", TargetedDatabase.BattleForAzeroth)]
+        public int? Flags;
+
+        [DBFieldName("WidgetSetId", TargetedDatabase.BattleForAzeroth)]
+        public uint? WidgetSetId;
+
+        [DBFieldName("UiTextureAtlasElementID", TargetedDatabase.BattleForAzeroth)]
+        public uint? UiTextureAtlasElementID;
+
+        [DBFieldName("SoundKitId", TargetedDatabase.BattleForAzeroth)]
+        public uint? SoundKitId;
+
+        [DBFieldName("GroupId", TargetedDatabase.BattleForAzeroth)]
+        public int? GroupId;
+
+        [DBFieldName("Header", TargetedDatabase.Legion)]
+        public string Header;
+
+        [DBFieldName("Subheader", TargetedDatabase.BattleForAzeroth)]
+        public string Subheader;
+
+        [DBFieldName("ButtonTooltip", TargetedDatabase.BattleForAzeroth)]
+        public string ButtonTooltip;
+
+        [DBFieldName("Answer")]
+        public string Answer;
+
+        [DBFieldName("Description")]
+        public string Description;
+
+        [DBFieldName("Confirmation", TargetedDatabase.Legion)]
+        public string Confirmation;
+
+        [DBFieldName("RewardQuestID", TargetedDatabase.BattleForAzeroth)]
+        public uint? RewardQuestID;
+
+        [DBFieldName("VerifiedBuild")]
+        public int? VerifiedBuild = ClientVersion.BuildInt;
+    }
+
+    [DBTableName("playerchoice_response_reward")]
+    public sealed class PlayerChoiceResponseRewardTemplate : IDataModel
+    {
+        [DBFieldName("ChoiceId", true)]
+        public int? ChoiceId;
+
+        [DBFieldName("ResponseId", true)]
+        public int? ResponseId;
+
+        [DBFieldName("TitleId")]
+        public int? TitleId;
+
+        [DBFieldName("PackageId")]
+        public int? PackageId;
+
+        [DBFieldName("SkillLineId")]
+        public int? SkillLineId;
+
+        [DBFieldName("SkillPointCount")]
+        public uint? SkillPointCount;
+
+        [DBFieldName("ArenaPointCount")]
+        public uint? ArenaPointCount;
+
+        [DBFieldName("HonorPointCount")]
+        public uint? HonorPointCount;
+
+        [DBFieldName("Money")]
+        public ulong? Money;
+
+        [DBFieldName("Xp")]
+        public uint? Xp;
+
+        [DBFieldName("VerifiedBuild")]
+        public int? VerifiedBuild = ClientVersion.BuildInt;
+    }
+
+    [DBTableName("playerchoice_response_reward_currency")]
+    public sealed class PlayerChoiceResponseRewardCurrencyTemplate : IDataModel
+    {
+        [DBFieldName("ChoiceId", true)]
+        public int? ChoiceId;
+
+        [DBFieldName("ResponseId", true)]
+        public int? ResponseId;
+
+        [DBFieldName("Index", true)]
+        public uint? Index;
+
+        [DBFieldName("CurrencyId")]
+        public int? CurrencyId;
+
+        [DBFieldName("Quantity")]
+        public int? Quantity;
+
+        [DBFieldName("VerifiedBuild")]
+        public int? VerifiedBuild = ClientVersion.BuildInt;
+    }
+
+    [DBTableName("playerchoice_response_reward_faction")]
+    public sealed class PlayerChoiceResponseRewardFactionTemplate : IDataModel
+    {
+        [DBFieldName("ChoiceId", true)]
+        public int? ChoiceId;
+
+        [DBFieldName("ResponseId", true)]
+        public int? ResponseId;
+
+        [DBFieldName("Index", true)]
+        public uint? Index;
+
+        [DBFieldName("FactionId")]
+        public int? FactionId;
+
+        [DBFieldName("Quantity")]
+        public int? Quantity;
+
+        [DBFieldName("VerifiedBuild")]
+        public int? VerifiedBuild = ClientVersion.BuildInt;
+    }
+
+    [DBTableName("playerchoice_response_reward_item")]
+    public sealed class PlayerChoiceResponseRewardItemTemplate : IDataModel
+    {
+        [DBFieldName("ChoiceId", true)]
+        public int? ChoiceId;
+
+        [DBFieldName("ResponseId", true)]
+        public int? ResponseId;
+
+        [DBFieldName("Index", true)]
+        public uint? Index;
+
+        [DBFieldName("ItemId")]
+        public int? ItemId;
+
+        [DBFieldName("BonusListIDs")]
+        public string BonusListIDs;
+
+        [DBFieldName("Quantity")]
+        public int? Quantity;
+
+        [DBFieldName("VerifiedBuild")]
+        public int? VerifiedBuild = ClientVersion.BuildInt;
+    }
+}

--- a/WowPacketParser/Store/Objects/PlayerChoiceLocale.cs
+++ b/WowPacketParser/Store/Objects/PlayerChoiceLocale.cs
@@ -1,0 +1,56 @@
+﻿using WowPacketParser.Enums;
+using WowPacketParser.Misc;
+using WowPacketParser.SQL;
+
+namespace WowPacketParser.Store.Objects
+{
+    [DBTableName("playerchoice_locale")]
+    public sealed class PlayerChoiceLocaleTemplate : IDataModel
+    {
+        [DBFieldName("ChoiceId", true)]
+        public int? ChoiceId;
+
+        [DBFieldName("Locale")]
+        public string Locale;
+
+        [DBFieldName("Question")]
+        public string Question;
+
+        [DBFieldName("VerifiedBuild")]
+        public int? VerifiedBuild = ClientVersion.BuildInt;
+    }
+
+    [DBTableName("playerchoice_response_locale")]
+    public sealed class PlayerChoiceResponseLocaleTemplate : IDataModel
+    {
+        [DBFieldName("ChoiceId", true)]
+        public int? ChoiceId;
+
+        [DBFieldName("ResponseId", true)]
+        public int? ResponseId;
+
+        [DBFieldName("Locale")]
+        public string Locale;
+
+        [DBFieldName("Header", TargetedDatabase.Legion)]
+        public string Header;
+
+        [DBFieldName("Subheader", TargetedDatabase.BattleForAzeroth)]
+        public string Subheader;
+
+        [DBFieldName("ButtonTooltip", TargetedDatabase.BattleForAzeroth)]
+        public string ButtonTooltip;
+
+        [DBFieldName("Answer")]
+        public string Answer;
+
+        [DBFieldName("Description")]
+        public string Description;
+
+        [DBFieldName("Confirmation", TargetedDatabase.Legion)]
+        public string Confirmation;
+
+        [DBFieldName("VerifiedBuild")]
+        public int? VerifiedBuild = ClientVersion.BuildInt;
+    }
+}

--- a/WowPacketParser/Store/Storage.cs
+++ b/WowPacketParser/Store/Storage.cs
@@ -123,6 +123,16 @@ namespace WowPacketParser.Store
         public static readonly DataBag<BroadcastText> BroadcastTexts = new DataBag<BroadcastText>(new List<SQLOutput> { SQLOutput.broadcast_text });
         public static readonly DataBag<BroadcastTextLocale> BroadcastTextLocales = new DataBag<BroadcastTextLocale>(new List<SQLOutput> { SQLOutput.broadcast_text_locale });
 
+        //Player Choice
+        public static readonly DataBag<PlayerChoiceTemplate> PlayerChoices = new DataBag<PlayerChoiceTemplate>(new List<SQLOutput> { SQLOutput.playerchoice });
+        public static readonly DataBag<PlayerChoiceLocaleTemplate> PlayerChoiceLocales = new DataBag<PlayerChoiceLocaleTemplate>(new List<SQLOutput> { SQLOutput.playerchoice });
+        public static readonly DataBag<PlayerChoiceResponseTemplate> PlayerChoiceResponses = new DataBag<PlayerChoiceResponseTemplate>(new List<SQLOutput> { SQLOutput.playerchoice });
+        public static readonly DataBag<PlayerChoiceResponseLocaleTemplate> PlayerChoiceResponseLocales = new DataBag<PlayerChoiceResponseLocaleTemplate>(new List<SQLOutput> { SQLOutput.playerchoice });
+        public static readonly DataBag<PlayerChoiceResponseRewardTemplate> PlayerChoiceResponseRewards = new DataBag<PlayerChoiceResponseRewardTemplate>(new List<SQLOutput> { SQLOutput.playerchoice });
+        public static readonly DataBag<PlayerChoiceResponseRewardCurrencyTemplate> PlayerChoiceResponseRewardCurrencies = new DataBag<PlayerChoiceResponseRewardCurrencyTemplate>(new List<SQLOutput> { SQLOutput.playerchoice });
+        public static readonly DataBag<PlayerChoiceResponseRewardFactionTemplate> PlayerChoiceResponseRewardFactions = new DataBag<PlayerChoiceResponseRewardFactionTemplate>(new List<SQLOutput> { SQLOutput.playerchoice });
+        public static readonly DataBag<PlayerChoiceResponseRewardItemTemplate> PlayerChoiceResponseRewardItems = new DataBag<PlayerChoiceResponseRewardItemTemplate>(new List<SQLOutput> { SQLOutput.playerchoice });
+
         public static void ClearContainers()
         {
             SniffData.Clear();

--- a/WowPacketParser/WowPacketParser.csproj
+++ b/WowPacketParser/WowPacketParser.csproj
@@ -672,6 +672,8 @@
     <Compile Include="Store\Objects\ScenarioPOIPoints.cs" />
     <Compile Include="Store\Objects\SceneTemplate.cs" />
     <Compile Include="Store\Objects\SniffData.cs" />
+    <Compile Include="Store\Objects\PlayerChoice.cs" />
+    <Compile Include="Store\Objects\PlayerChoiceLocale.cs" />
     <Compile Include="Store\Objects\PlayerCreateInfoAction.cs" />
     <Compile Include="Store\Objects\PlayerCreateInfo.cs" />
     <Compile Include="Store\Objects\SpellTargetPosition.cs" />

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/QuestHandler.cs
@@ -597,38 +597,61 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         [Parser(Opcode.SMSG_DISPLAY_PLAYER_CHOICE)]
         public static void HandleDisplayPlayerChoice(Packet packet)
         {
-            packet.ReadInt32("ChoiceID");
+            var choiceId = packet.ReadInt32("ChoiceID");
             var responseCount = packet.ReadUInt32();
             packet.ReadPackedGuid128("SenderGUID");
-            packet.ReadInt32("UiTextureKitID");
+            var uiTextureKitId = packet.ReadInt32("UiTextureKitID");
+            var soundKitId = 0u;
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V8_1_0_28724))
-                packet.ReadUInt32("SoundKitID");
+                soundKitId = packet.ReadUInt32("SoundKitID");
             packet.ResetBitReader();
             var questionLength = packet.ReadBits(8);
             packet.ReadBit("CloseChoiceFrame");
-            packet.ReadBit("HideWarboardHeader");
-            packet.ReadBit("KeepOpenAfterChoice");
+            var hideWarboardHeader = packet.ReadBit("HideWarboardHeader");
+            var keepOpenAfterChoice = packet.ReadBit("KeepOpenAfterChoice");
 
             for (var i = 0u; i < responseCount; ++i)
-                ReadPlayerChoiceResponse(packet, "PlayerChoiceResponse", i);
+                ReadPlayerChoiceResponse(packet, choiceId, i, "PlayerChoiceResponse", i);
 
-            packet.ReadWoWString("Question", questionLength);
+            var question = packet.ReadWoWString("Question", questionLength);
+
+            Storage.PlayerChoices.Add(new PlayerChoiceTemplate
+            {
+                ChoiceId = choiceId,
+                UiTextureKitId = uiTextureKitId,
+                SoundKitId = soundKitId,
+                Question = question,
+                HideWarboardHeader = hideWarboardHeader,
+                KeepOpenAfterChoice = keepOpenAfterChoice
+            }, packet.TimeSpan);
+
+            if (ClientLocale.PacketLocale != LocaleConstant.enUS)
+            {
+                Storage.PlayerChoiceLocales.Add(new PlayerChoiceLocaleTemplate
+                {
+                    ChoiceId = choiceId,
+                    Locale = ClientLocale.PacketLocaleString,
+                    Question = question
+                }, packet.TimeSpan);
+            }
         }
 
-        public static void ReadPlayerChoiceResponse(Packet packet, params object[] indexes)
+        public static void ReadPlayerChoiceResponse(Packet packet, int choiceId, uint index, params object[] indexes)
         {
-            packet.ReadInt32("ResponseID", indexes);
-            packet.ReadInt32("ChoiceArtFileID", indexes);
-            packet.ReadInt32("Flags", indexes);
-            packet.ReadUInt32("WidgetSetID", indexes);
+            var responseId = packet.ReadInt32("ResponseID", indexes);
+            var choiceArtFileId = packet.ReadInt32("ChoiceArtFileID", indexes);
+            var flags = packet.ReadInt32("Flags", indexes);
+            var widgetSetId = packet.ReadUInt32("WidgetSetID", indexes);
+            var uiTextureAtlasElementID = 0u;
+            var soundKitId = 0u;
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V8_1_5_29683))
             {
-                packet.ReadUInt32("UiTextureAtlasElementID");
-                packet.ReadUInt32("SoundKitID");
+                uiTextureAtlasElementID = packet.ReadUInt32("UiTextureAtlasElementID", indexes);
+                soundKitId = packet.ReadUInt32("SoundKitID", indexes);
                 if (ClientVersion.RemovedInVersion(ClientVersionBuild.V8_1_5_29683))
-                    packet.ReadUInt32("Unk801");
+                    packet.ReadUInt32("Unk801", indexes);
             }
-            packet.ReadByte("GroupID", indexes);
+            var groupID = packet.ReadByte("GroupID", indexes);
             packet.ResetBitReader();
             var answerLength = packet.ReadBits(9);
             var headerLength = packet.ReadBits(9);
@@ -646,50 +669,57 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 hasRewardQuestID = packet.ReadBit();
             var hasReward = packet.ReadBit();
             if (hasReward)
-                ReadPlayerChoiceResponseReward(packet, "PlayerChoiceResponseReward", indexes);
+                V6_0_2_19033.Parsers.QuestHandler.ReadPlayerChoiceResponseReward(packet, choiceId, responseId, "PlayerChoiceResponseReward", indexes);
 
-            packet.ReadWoWString("Answer", answerLength, indexes);
-            packet.ReadWoWString("Header", headerLength, indexes);
-            packet.ReadWoWString("SubHeader", subHeaderLength, indexes);
-            packet.ReadWoWString("ButtonTooltip", buttonTooltipLength, indexes);
-            packet.ReadWoWString("Description", descriptionLength, indexes);
-            packet.ReadWoWString("ConfirmationText", confirmationTextLength, indexes);
+            var answer = packet.ReadWoWString("Answer", answerLength, indexes);
+            var header = packet.ReadWoWString("Header", headerLength, indexes);
+            var subheader = packet.ReadWoWString("SubHeader", subHeaderLength, indexes);
+            var buttonTooltip = packet.ReadWoWString("ButtonTooltip", buttonTooltipLength, indexes);
+            var description = packet.ReadWoWString("Description", descriptionLength, indexes);
+            var confirmation = packet.ReadWoWString("ConfirmationText", confirmationTextLength, indexes);
 
+            var rewardQuestID = 0u;
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V8_1_5_29683))
             {
                 if (hasRewardQuestID)
-                    packet.ReadUInt32("RewardQuestID");
+                    rewardQuestID = packet.ReadUInt32("RewardQuestID", indexes);
             }
-        }
 
-        public static void ReadPlayerChoiceResponseReward(Packet packet, params object[] indexes)
-        {
-            packet.ResetBitReader();
-            packet.ReadInt32("TitleID", indexes);
-            packet.ReadInt32("PackageID", indexes);
-            packet.ReadInt32("SkillLineID", indexes);
-            packet.ReadUInt32("SkillPointCount", indexes);
-            packet.ReadUInt32("ArenaPointCount", indexes);
-            packet.ReadUInt32("HonorPointCount", indexes);
-            packet.ReadUInt64("Money", indexes);
-            packet.ReadUInt32("Xp", indexes);
+            Storage.PlayerChoiceResponses.Add(new PlayerChoiceResponseTemplate
+            {
+                ChoiceId = choiceId,
+                ResponseId = responseId,
+                Index = index,
+                ChoiceArtFileId = choiceArtFileId,
+                Flags = flags,
+                WidgetSetId = widgetSetId,
+                UiTextureAtlasElementID = uiTextureAtlasElementID,
+                SoundKitId = soundKitId,
+                GroupId = groupID,
+                Header = header,
+                Subheader = subheader,
+                ButtonTooltip = buttonTooltip,
+                Answer = answer,
+                Description = description,
+                Confirmation = confirmation,
+                RewardQuestID = rewardQuestID
+            }, packet.TimeSpan);
 
-            var itemCount = packet.ReadUInt32();
-            var currencyCount = packet.ReadUInt32();
-            var factionCount = packet.ReadUInt32();
-            var itemChoiceCount = packet.ReadUInt32();
-
-            for (var i = 0u; i < itemCount; ++i)
-                ReadRewardItem(packet, "Item", i);
-
-            for (var i = 0u; i < currencyCount; ++i)
-                ReadRewardItem(packet, "Currency", i);
-
-            for (var i = 0u; i < factionCount; ++i)
-                ReadRewardItem(packet, "Faction", i);
-
-            for (var i = 0u; i < itemChoiceCount; ++i)
-                ReadRewardItem(packet, "ItemChoice", i);
+            if (ClientLocale.PacketLocale != LocaleConstant.enUS)
+            {
+                Storage.PlayerChoiceResponseLocales.Add(new PlayerChoiceResponseLocaleTemplate
+                {
+                    ChoiceId = choiceId,
+                    ResponseId = responseId,
+                    Locale = ClientLocale.PacketLocaleString,
+                    Header = header,
+                    Subheader = subheader,
+                    ButtonTooltip = buttonTooltip,
+                    Description = description,
+                    Answer = answer,
+                    Confirmation = confirmation
+                }, packet.TimeSpan);
+            }
         }
 
         [Parser(Opcode.CMSG_CLOSE_QUEST_CHOICE)]


### PR DESCRIPTION
Implement playerchoice sql generation, with base of data base for 8.0.1, I don´t have any other data base for check the structure, if someone want to help me to fix for all structure is welcome. Righ now read all handle but was forced the structure to 8.0.1.

Tested with sniff of WoD, Legion and BFA expansion

ToDo:
- Check for change into structure of packet in version higher than 8.0.1
- Complete for estructure of Data Base of WoD and Legion