### PR TITLE
Sync 4.3.4 monster move packet output naming with newer parsers and updated spline flags

### DIFF
--- a/WowPacketParserModule.V4_3_4_15595/Enums/SplineFlag.cs
+++ b/WowPacketParserModule.V4_3_4_15595/Enums/SplineFlag.cs
@@ -26,9 +26,9 @@ namespace WowPacketParserModule.V4_3_4_15595.Enums
         TransportExit       = 0x00010000,
         Unknown3            = 0x00020000,           // NOT VERIFIED
         Unknown4            = 0x00040000,           // NOT VERIFIED
-        OrientationInversed = 0x00080000,
+        Backward            = 0x00080000,
         SmoothGroundPath    = 0x00100000,
-        Walkmode            = 0x00200000,
+        CanSwim             = 0x00200000,
         UncompressedPath    = 0x00400000,
         Unknown6            = 0x00800000,           // NOT VERIFIED
         Animation           = 0x01000000,           // Plays animation after some time passed


### PR DESCRIPTION
Just to keep the output format synch with modern parsers so dev tools can be built easier (aside from the fact that this output is better anyways)