### PR TITLE
Fix wrong computation of waypoints

### DIFF
--- a/WowPacketParser/Parsing/Parsers/MovementHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/MovementHandler.cs
@@ -286,7 +286,7 @@ namespace WowPacketParser.Parsing.Parsers
                 for (var i = 1; i < waypoints; i++)
                 {
                     var vec = packet.ReadPackedVector3();
-                    vec = mid - vec;
+                    vec = mid + vec;
                     packet.AddValue("Waypoint", vec, i);
                 }
             }


### PR DESCRIPTION
Offset should be added to get back the point.
Not removed as it was already did in [server MovementPacketBuilder.cpp#L110 ](https://github.com/TrinityCore/TrinityCore/blob/3.3.5/src/server/game/Movement/Spline/MovementPacketBuilder.cpp#L110).