### PR TITLE
Improve the performances of creature_template_model by building WHERE condition using IN keyword instead of chaining AND and OR.

### DIFF
--- a/WowPacketParser.Tests/SQL/QueryBuilderTest.cs
+++ b/WowPacketParser.Tests/SQL/QueryBuilderTest.cs
@@ -64,13 +64,18 @@ namespace WowPacketParser.Tests.SQL
             _conditionsTwoPk = new RowList<TestDataTwoPK>
             {
                 new TestDataTwoPK {ID = 10, TestInt1 = 20, TestString1 = "string10"},
-                new TestDataTwoPK {ID = 20, TestInt1 = 30}
+                new TestDataTwoPK {ID = 20, TestInt1 = 30},
+                new TestDataTwoPK {ID = 30, TestInt1 = 40},
+                new TestDataTwoPK {ID = 30, TestInt1 = 50}
+
             };
 
             _valuesTwoPk = new RowList<TestDataTwoPK>
             {
-                new TestDataTwoPK {ID = 40, TestInt1 = 50, TestString1 = "string20"},
-                new TestDataTwoPK {ID = 60, TestInt1 = 70}
+                new TestDataTwoPK {ID = 60, TestInt1 = 70, TestString1 = "string20"},
+                new TestDataTwoPK {ID = 80, TestInt1 = 90},
+                new TestDataTwoPK {ID = 100, TestInt1 = 110},
+                new TestDataTwoPK {ID = 100, TestInt1 = 120}
             };
         }
 
@@ -115,11 +120,17 @@ namespace WowPacketParser.Tests.SQL
         [Test]
         public void TestSQLWhere()
         {
-            var where = new SQLWhere<TestDataOnePK>(_conditionsOnePk);
+            var whereOnePk = new SQLWhere<TestDataOnePK>(_conditionsOnePk);
 
             Assert.AreEqual(
                 "(`ID`=1 AND `TestInt1`=2 AND `TestString1`='string1') OR (`ID`=2 AND `TestInt1`=3)",
-                where.Build());
+                whereOnePk.Build());
+
+            var whereTwoPk = new SQLWhere<TestDataTwoPK>(_conditionsTwoPk);
+
+            Assert.AreEqual(
+                "(`ID`=10 AND `TestInt1`=20 AND `TestString1`='string10') OR (`ID`=20 AND `TestInt1`=30) OR (`ID`=30 AND `TestInt1`=40) OR (`ID`=30 AND `TestInt1`=50)",
+                whereTwoPk.Build());
         }
 
         [Test]
@@ -129,7 +140,7 @@ namespace WowPacketParser.Tests.SQL
             Assert.AreEqual("`ID` IN (1, 2)", whereOnePk.Build());
 
             var whereTwoPk = new SQLWhere<TestDataTwoPK>(_conditionsTwoPk, true);
-            Assert.AreEqual("(`ID`=10 AND `TestInt1`=20) OR (`ID`=20 AND `TestInt1`=30)", whereTwoPk.Build());
+            Assert.AreEqual("(`ID`=10 AND `TestInt1`=20) OR (`ID`=20 AND `TestInt1`=30) OR (`ID`=30 AND `TestInt1` IN (40,50))", whereTwoPk.Build());
         }
 
         [Test]

--- a/WowPacketParser/SQL/QueryBuilder.cs
+++ b/WowPacketParser/SQL/QueryBuilder.cs
@@ -165,9 +165,17 @@ namespace WowPacketParser.SQL
                 whereClause.Append(" AND ");
 
                 whereClause.Append(secondField);
-                whereClause.Append(" IN (");
-                whereClause.Append(string.Join(',', pair.Value.Select(cond => cond.FieldValuePairs[secondField])));
-                whereClause.Append(")");
+                if (pair.Value.Select(cond => cond.FieldValuePairs[secondField]).Count() == 1)
+                {
+                    whereClause.Append("=");
+                    whereClause.Append(pair.Value.Select(cond => cond.FieldValuePairs[secondField]).First());
+                }
+                else
+                {
+                    whereClause.Append(" IN (");
+                    whereClause.Append(string.Join(',', pair.Value.Select(cond => cond.FieldValuePairs[secondField])));
+                    whereClause.Append(")");
+                }
 
                 whereClause.Append(")");
 

--- a/WowPacketParser/SQL/QueryBuilder.cs
+++ b/WowPacketParser/SQL/QueryBuilder.cs
@@ -62,6 +62,15 @@ namespace WowPacketParser.SQL
             }
             else
             {
+                if (_conditions.Count > 100)
+                {
+                    var result = BuildDistinct();
+                    if (result != null)
+                        return result;
+
+                    // Fallback to standard AND where clauses if the distinct one failed
+                }
+
                 foreach (Row<T> condition in _conditions)
                 {
                     whereClause.Append("(");
@@ -89,6 +98,97 @@ namespace WowPacketParser.SQL
             }
 
             return whereClause.ToString();
+        }
+
+        private string BuildDistinct()
+        {
+            // 1. Get a list of all conditions as list of field/value pairs
+            List<WhereCondition> whereConditions = new List<WhereCondition>();
+            foreach (Row<T> condition in _conditions)
+            {
+                var whereCondition = new WhereCondition();
+
+                foreach (var field in _databaseFields)
+                {
+                    object value = field.Item2.GetValue(condition.Data);
+
+                    if (value == null ||
+                        (_onlyPrimaryKeys &&
+                         field.Item3.Any(a => !a.IsPrimaryKey)))
+                        continue;
+
+                    whereCondition.Add(field.Item1, SQLUtil.ToSQLValue(value));
+                }
+
+                if (!whereCondition.IsEmpty)
+                    whereConditions.Add(whereCondition);
+            }
+
+            // 2. Check if all conditions share the same fields
+            bool allShareSameFields = true;
+            var baselineConditionFields = whereConditions.First().FieldValuePairs.Keys;
+            foreach (var condition in whereConditions)
+                if (!condition.FieldValuePairs.Keys.SequenceEqual(baselineConditionFields))
+                    allShareSameFields = false;
+
+            if (!allShareSameFields)
+                return null;
+
+            // ToDo: support the case with more than 2 fields
+            if (baselineConditionFields.Count != 2)
+                return null;
+
+            // 3. Get a distinct of values for each field
+            var fieldsWithDistinctValues = (from condition in whereConditions
+                                            from fieldValuePair in condition.FieldValuePairs
+                                            group fieldValuePair by fieldValuePair.Key into byField
+                                            select new { Field = byField.Key, Values = byField.ToList().Select(pair => pair.Value).Distinct().ToList() }
+                                            ).OrderBy(field => field.Values.Count()).ToList();
+
+            // 4. Get the field with lowest different values
+            var fieldWithLowestDifferentValues = fieldsWithDistinctValues.First().Field;
+            // ToDo: support the case with more than 2 fields
+            var secondField = fieldsWithDistinctValues.Skip(1).First().Field;
+
+            // 5. Group conditions by the field with lowest different values
+            var conditionsByFieldWithLowestDifferentValues = whereConditions.GroupBy(cond => cond.FieldValuePairs[fieldWithLowestDifferentValues])
+                                                            .ToDictionary(g => g.Key, g => g.ToList());
+
+            // 6. Build the where clause using the field with lowest different values for the first condition
+            StringBuilder whereClause = new StringBuilder();
+            foreach(var pair in conditionsByFieldWithLowestDifferentValues)
+            {
+                whereClause.Append("(");
+                whereClause.Append(fieldWithLowestDifferentValues);
+                whereClause.Append("=");
+                whereClause.Append(pair.Key);
+                whereClause.Append(" AND ");
+
+                whereClause.Append(secondField);
+                whereClause.Append(" IN (");
+                whereClause.Append(string.Join(',', pair.Value.Select(cond => cond.FieldValuePairs[secondField])));
+                whereClause.Append(")");
+
+                whereClause.Append(")");
+
+                whereClause.Append(" OR ");
+            }
+
+            whereClause.Length -= 4; // remove last " OR ";
+
+            return whereClause.ToString();
+        }
+
+        private class WhereCondition
+        {
+            internal readonly Dictionary<string, object> FieldValuePairs = new Dictionary<string, object>();
+
+            internal bool IsEmpty => FieldValuePairs.Count == 0;
+
+            internal void Add(string fieldName, object value)
+            {
+                FieldValuePairs.Add(fieldName, value);
+            }
         }
     }
 

--- a/WowPacketParser/SQL/QueryBuilder.cs
+++ b/WowPacketParser/SQL/QueryBuilder.cs
@@ -62,7 +62,7 @@ namespace WowPacketParser.SQL
             }
             else
             {
-                if (_conditions.Count > 100)
+                if (_conditions.Count > 1)
                 {
                     var result = BuildDistinct();
                     if (result != null)


### PR DESCRIPTION
Improve the performances of creature_template_model by building WHERE condition using IN keyword instead of chaining AND and OR.

Using a test sniff the total query length went from 7M to 1.2M characters (194'000 conditions), reducing the time to for MySQL to process the query from hours to seconds (the first 1000 results of 194'000 took 45 seconds with the old quey, they new one returned all 194'000 in 0.2 seconds)

Old query: https://gist.github.com/jackpoz/6f12da2744a5f330a3157e3d35b05ae8
New query: https://gist.github.com/jackpoz/8e10ce9c2e3ef98b9876fb469c356f82