### PR TITLE
Update to .NET 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ solution: WowPacketParser.sln
 
 matrix:
   include:
-    - dotnet: 3.1
+    - dotnet: 5.0.102
       mono: none
 
 before_script:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ WowPacketParser (WPP)
 Usage
 -----
 
-* Compile WowPacketParser using Visual Studio 2019 (with .NET Core SDK 3.1) or .NET Core SDK 3.1 (Linux/OSX).
+* Compile WowPacketParser using Visual Studio 2019 (with .NET 5.0 SDK) or .NET 5.0 SDK (Linux/OSX).
   Alternatively you can download compiled binaries from the links [below](#nightly-builds).
 * Edit `WowPacketParser.dll.config` to fit your needs.
 * Drag one or more files (.pkt or .bin) to `WowPacketParser.exe`.
@@ -40,9 +40,9 @@ and `wpp_data_objectnames.sql` has some data to fill the database.
 
 Nightly Builds
 --------------
-.NET Core SDK 3.1 (3.1.100 or higher) or .NET Core Runtime 3.1 (3.1.100 or higher) is needed!
+.NET 5.0 SDK (5.0.102 or higher) or .NET 5.0 Runtime(5.0.102 or higher) is needed!
 
-[Download .NET Core 3.1 here!](https://dotnet.microsoft.com/download/dotnet-core/3.1)
+[Download .NET 5.0 here!](https://dotnet.microsoft.com/download/dotnet/5.0)
 
 ##### Windows
 - Visual Studio 2019
@@ -91,4 +91,4 @@ Copyright information of third party libraries provided through NuGet can be obt
 
 ###### Provided third party libraries:
 
-DBFileReaderLib, 2019-2020 wowdev, located at https://github.com/wowdev/DBCD
+DBFileReaderLib, 2019-2021 wowdev, located at https://github.com/wowdev/DBCD

--- a/WowPacketParser.Tests/WowPacketParser.Tests.csproj
+++ b/WowPacketParser.Tests/WowPacketParser.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 
@@ -34,9 +34,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="nunit" Version="3.12.0" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="nunit" Version="3.13.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WowPacketParser/WowPacketParser.csproj
+++ b/WowPacketParser/WowPacketParser.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Company>TrinityCore</Company>
     <Copyright>Copyright © 2010-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>
@@ -34,12 +34,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DotNetZip" Version="1.13.5" />
-    <PackageReference Include="MySql.Data" Version="8.0.19" />
+    <PackageReference Include="DotNetZip" Version="1.15.0" />
+    <PackageReference Include="MySql.Data" Version="8.0.23" />
     <PackageReference Include="RawScape.Wintellect.PowerCollections" Version="1.0.1" />
     <PackageReference Include="Sigil" Version="5.0.0" />
-    <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.7.0" />
-    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.112" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />
+    <PackageReference Include="System.Data.SQLite.Core" Version="1.0.113.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WowPacketParserModule.BattleNet.V37165/WowPacketParserModule.BattleNet.V37165.csproj
+++ b/WowPacketParserModule.BattleNet.V37165/WowPacketParserModule.BattleNet.V37165.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Company>TrinityCore</Company>
     <Copyright>Copyright © 2015-2020</Copyright>

--- a/WowPacketParserModule.Substructures/WowPacketParserModule.Substructures.csproj
+++ b/WowPacketParserModule.Substructures/WowPacketParserModule.Substructures.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
 	<Company>TrinityCore</Company>
     <Copyright>Copyright © 2014-2020</Copyright>

--- a/WowPacketParserModule.V1_13_2_31446/WowPacketParserModule.V1_13_2_31446.csproj
+++ b/WowPacketParserModule.V1_13_2_31446/WowPacketParserModule.V1_13_2_31446.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Copyright>Copyright © 2015-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V2_4_3_8606/WowPacketParserModule.V2_4_3_8606.csproj
+++ b/WowPacketParserModule.V2_4_3_8606/WowPacketParserModule.V2_4_3_8606.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Company>TrinityCore</Company>
     <Copyright>Copyright © 2013-2020</Copyright>

--- a/WowPacketParserModule.V4_3_4_15595/WowPacketParserModule.V4_3_4_15595.csproj
+++ b/WowPacketParserModule.V4_3_4_15595/WowPacketParserModule.V4_3_4_15595.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Copyright>Copyright © 2013-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V5_3_0_16981/WowPacketParserModule.V5_3_0_16981.csproj
+++ b/WowPacketParserModule.V5_3_0_16981/WowPacketParserModule.V5_3_0_16981.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Copyright>Copyright © 2013-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V5_4_0_17359/WowPacketParserModule.V5_4_0_17359.csproj
+++ b/WowPacketParserModule.V5_4_0_17359/WowPacketParserModule.V5_4_0_17359.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Copyright>Copyright © 2013-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V5_4_1_17538/WowPacketParserModule.V5_4_1_17538.csproj
+++ b/WowPacketParserModule.V5_4_1_17538/WowPacketParserModule.V5_4_1_17538.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Copyright>Copyright © 2013-2020</Copyright>
     <Authors>TrinityCore</Authors>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V5_4_2_17658/WowPacketParserModule.V5_4_2_17658.csproj
+++ b/WowPacketParserModule.V5_4_2_17658/WowPacketParserModule.V5_4_2_17658.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Copyright>Copyright © 2013-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V5_4_7_17898/WowPacketParserModule.V5_4_7_17898.csproj
+++ b/WowPacketParserModule.V5_4_7_17898/WowPacketParserModule.V5_4_7_17898.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Copyright>Copyright © 2014-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V5_4_8_18291/WowPacketParserModule.V5_4_8_18291.csproj
+++ b/WowPacketParserModule.V5_4_8_18291/WowPacketParserModule.V5_4_8_18291.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Copyright>Copyright © 2014-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V6_0_2_19033/WowPacketParserModule.V6_0_2_19033.csproj
+++ b/WowPacketParserModule.V6_0_2_19033/WowPacketParserModule.V6_0_2_19033.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Copyright>Copyright © 2014-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V7_0_3_22248/WowPacketParserModule.V7_0_3_22248.csproj
+++ b/WowPacketParserModule.V7_0_3_22248/WowPacketParserModule.V7_0_3_22248.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Copyright>Copyright © 2014-2020</Copyright>
     <Authors>TrinityCore</Authors>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V8_0_1_27101/WowPacketParserModule.V8_0_1_27101.csproj
+++ b/WowPacketParserModule.V8_0_1_27101/WowPacketParserModule.V8_0_1_27101.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Copyright>Copyright © 2014-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>

--- a/WowPacketParserModule.V9_0_1_36216/WowPacketParserModule.V9_0_1_36216.csproj
+++ b/WowPacketParserModule.V9_0_1_36216/WowPacketParserModule.V9_0_1_36216.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Authors>TrinityCore</Authors>
     <Copyright>Copyright © 2014-2020</Copyright>
     <PackageProjectUrl>https://www.trinitycore.org/</PackageProjectUrl>


### PR DESCRIPTION
Updating WPP to NET 5.
Core 3.1 is LTS and only receives bug fixes and security fixes.