### PR TITLE
Updated Dockerfile for .NET 5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app/src
 COPY . .
-RUN dotnet build "WowPacketParser.sln" -c Release -o /app/build
+RUN dotnet build "WowPacketParser.sln" -c Release
 
 FROM mcr.microsoft.com/dotnet/runtime:5.0 AS final
 WORKDIR /usr/src/app/build
-COPY --from=build /app/build .
+COPY --from=build /app/src/WowPacketParser/bin/Release .
 ENTRYPOINT ["dotnet", "WowPacketParser.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-FROM mono:5.0.1.1
+FROM mcr.microsoft.com/dotnet/sdk:5.0 as build
+WORKDIR /app/src
+COPY . .
+RUN dotnet build "WowPacketParser.sln" -c Release -o /app/build
 
-RUN mkdir -p /usr/src/app/source /usr/src/app/build
-WORKDIR /usr/src/app/source
-
-COPY . /usr/src/app/source
-RUN nuget restore -NonInteractive
-RUN xbuild /property:Configuration=Release /property:OutDir=/usr/src/app/build/
+FROM mcr.microsoft.com/dotnet/runtime:5.0 as final
 WORKDIR /usr/src/app/build
-
-ENTRYPOINT [ "mono", "WowPacketParser.exe" ]
+COPY --from=build /app/build .
+ENTRYPOINT ["dotnet", "WowPacketParser.dll"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
 WORKDIR /app/src
 COPY . .
 RUN dotnet build "WowPacketParser.sln" -c Release -o /app/build
 
-FROM mcr.microsoft.com/dotnet/runtime:5.0 as final
+FROM mcr.microsoft.com/dotnet/runtime:5.0 AS final
 WORKDIR /usr/src/app/build
 COPY --from=build /app/build .
 ENTRYPOINT ["dotnet", "WowPacketParser.dll"]


### PR DESCRIPTION
Someone with permissions @ dockerhub should test this first. I have no idea how the caching of multistage docker images behave @ dockerhub. Only used them locally so far.

Note: I kept using the old path `/usr/src/app/build` for compatibility purposes.

Example usage (after building image):
```sh
docker run \
        -v "$PWD":/usr/src/app/build/sniffs \
        -v /home/programs/wpp/WowPacketParser.dll.config:/usr/src/app/build/WowPacketParser.dll.config \
        -v /home/programs/wpp/dbc/:/usr/src/app/build/dbc/ \
        --rm \
        wpp "sniffs/<filename>"
```