### PR TITLE
added spell handler for 4.3.4 module, moved spell_start and spell_go over there and updated some random field names

### DIFF
--- a/WowPacketParser/Enums/PlayerLogXPReason.cs
+++ b/WowPacketParser/Enums/PlayerLogXPReason.cs
@@ -1,0 +1,8 @@
+namespace WowPacketParser.Enums
+{
+    public enum PlayerLogXPReason
+    {
+        Kill = 0,
+        NoKill = 1
+    }
+}

--- a/WowPacketParser/Enums/ReferAFriendBonusType.cs
+++ b/WowPacketParser/Enums/ReferAFriendBonusType.cs
@@ -1,0 +1,8 @@
+namespace WowPacketParser.Enums
+{
+    public enum ReferAFriendBonusType
+    {
+        None = 0,
+        RecruitAFriend = 1 // 150% of normal xp
+    }
+}

--- a/WowPacketParser/Parsing/Parsers/CharacterHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/CharacterHandler.cs
@@ -1053,17 +1053,17 @@ namespace WowPacketParser.Parsing.Parsers
         [Parser(Opcode.SMSG_LOG_XP_GAIN)]
         public static void HandleLogXPGain(Packet packet)
         {
-            packet.ReadGuid("GUID");
-            packet.ReadUInt32("Total XP");
-            var type = packet.ReadByte("XP type"); // Need enum
+            packet.ReadGuid("VictimGUID");
+            packet.ReadUInt32("Original");
+            var type = packet.ReadByteE<PlayerLogXPReason>("Reason");
 
-            if (type == 0) // kill
+            if (type == PlayerLogXPReason.Kill)
             {
-                packet.ReadUInt32("Base XP");
-                packet.ReadSingle("Group rate (unk)");
+                packet.ReadUInt32("Amount");
+                packet.ReadSingle("GroupBonus");
             }
 
-            packet.ReadBool("RAF Bonus");
+            packet.ReadByteE<ReferAFriendBonusType>("ReferAFriendBonusType");
         }
 
         [Parser(Opcode.SMSG_TITLE_EARNED)]

--- a/WowPacketParser/Parsing/Parsers/CombatHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/CombatHandler.cs
@@ -64,7 +64,7 @@ namespace WowPacketParser.Parsing.Parsers
         public static void HandlePvPCredit(Packet packet)
         {
             packet.ReadUInt32("Honor");
-            packet.ReadGuid("GUID");
+            packet.ReadGuid("TargetGUID");
             packet.ReadInt32("Rank");
         }
 
@@ -114,17 +114,17 @@ namespace WowPacketParser.Parsing.Parsers
         [Parser(Opcode.SMSG_ATTACK_START)]
         public static void HandleAttackStartStart(Packet packet)
         {
-            packet.ReadGuid("GUID");
-            packet.ReadGuid("Victim GUID");
+            packet.ReadGuid("AttackerGUID");
+            packet.ReadGuid("VictimGUID");
         }
 
         [Parser(Opcode.SMSG_ATTACK_STOP)]
         [Parser(Opcode.SMSG_COMBAT_EVENT_FAILED)]
         public static void HandleAttackStartStop(Packet packet)
         {
-            packet.ReadPackedGuid("GUID");
-            packet.ReadPackedGuid("Victim GUID");
-            packet.ReadInt32("Unk int"); // Has something to do with facing?
+            packet.ReadPackedGuid("AttackerGUID");
+            packet.ReadPackedGuid("VictimGUID");
+            packet.ReadInt32("NowDead"); // Blocks clientside facing when set to 1
         }
 
         [Parser(Opcode.SMSG_ATTACKER_STATE_UPDATE, ClientVersionBuild.V4_0_6_13596)]
@@ -136,32 +136,32 @@ namespace WowPacketParser.Parsing.Parsers
             packet.ReadInt32("Damage");
             packet.ReadInt32("OverDamage");
 
-            var subDmgCount = packet.ReadByte("Count");
+            var subDmgCount = packet.ReadByte("SubDmg");
             for (var i = 0; i < subDmgCount; ++i)
             {
                 packet.ReadInt32("SchoolMask", i);
-                packet.ReadSingle("Float Damage", i);
-                packet.ReadInt32("Int Damage", i);
+                packet.ReadSingle("FDamage", i);
+                packet.ReadInt32("Damage", i);
             }
 
             if (hitInfo.HasAnyFlag(SpellHitInfo.HITINFO_PARTIAL_ABSORB | SpellHitInfo.HITINFO_FULL_ABSORB))
                 for (var i = 0; i < subDmgCount; ++i)
-                    packet.ReadInt32("Damage Absorbed", i);
+                    packet.ReadInt32("Absorbed", i);
 
                 if (hitInfo.HasAnyFlag(SpellHitInfo.HITINFO_PARTIAL_RESIST | SpellHitInfo.HITINFO_FULL_RESIST))
                     for (var i = 0; i < subDmgCount; ++i)
-                        packet.ReadInt32("Damage Resisted", i);
+                        packet.ReadInt32("Resisted", i);
 
             packet.ReadByteE<VictimStates>("VictimState");
-            packet.ReadInt32("Unk Attacker State 0");
+            packet.ReadInt32("AttackerState");
 
-            packet.ReadInt32<SpellId>("Melee Spell Id");
+            packet.ReadInt32<SpellId>("MeleeSpellID");
 
             if (hitInfo.HasAnyFlag(SpellHitInfo.HITINFO_BLOCK))
-                packet.ReadInt32("Block Amount");
+                packet.ReadInt32("BlockAmount");
 
             if (hitInfo.HasAnyFlag(SpellHitInfo.HITINFO_RAGE_GAIN))
-                packet.ReadInt32("Rage Gained");
+                packet.ReadInt32("RageGained");
 
             if (hitInfo.HasAnyFlag(SpellHitInfo.HITINFO_UNK0))
             {

--- a/WowPacketParserModule.V4_3_4_15595/Parsers/SpellHandler.cs
+++ b/WowPacketParserModule.V4_3_4_15595/Parsers/SpellHandler.cs
@@ -1,0 +1,184 @@
+using System.Collections.Generic;
+using WowPacketParser.Enums;
+using WowPacketParser.Enums.Version;
+using WowPacketParser.Misc;
+using WowPacketParser.Parsing;
+using WowPacketParser.Store;
+using WowPacketParser.Store.Objects;
+
+namespace WowPacketParserModule.V4_3_4_15595.Parsers
+{
+    public static class SpellHandler
+    {
+        [Parser(Opcode.SMSG_SPELL_START)]
+        public static void HandleSpellStart(Packet packet)
+        {
+            ReadSpellCastData(packet, "Cast");
+        }
+        [Parser(Opcode.SMSG_SPELL_GO)]
+        public static void HandleSpellGo(Packet packet)
+        {
+            ReadSpellCastData(packet, "Cast");
+        }
+
+        public static void ReadSpellCastData(Packet packet, params object[] idx)
+        {
+            bool isSpellGo = packet.Opcode == Opcodes.GetOpcode(Opcode.SMSG_SPELL_GO, Direction.ServerToClient);
+            WowGuid targetGUID = new WowGuid64();
+
+            var casterGUID = packet.ReadPackedGuid("CasterGUID", idx);
+            packet.ReadPackedGuid("CasterUnit", idx);
+            packet.ReadByte("CastID", idx);
+            var spellId = packet.ReadInt32<SpellId>("SpellID", idx);
+            CastFlag flags = packet.ReadInt32E<CastFlag>("CastFlags", idx);
+            packet.ReadUInt32("CastFlagsEx", idx);
+            packet.ReadUInt32("CastTime", idx);
+
+            if (isSpellGo)
+            {
+                var hitTargetsCount = packet.ReadByte("HitTargetsCount", idx);
+                for (var i = 0; i < hitTargetsCount; ++i)
+                    packet.ReadGuid("HitTarget", idx, i);
+
+                var missCount = packet.ReadByte("MissStatusCount", idx);
+                for (var i = 0; i < missCount; ++i)
+                    ReadSpellMissStatus(packet, idx, "MissStatus", i);
+            }
+
+            TargetFlag targetFlags = TargetFlag.Self;
+            ReadSpellTargetData(packet, ref targetFlags, targetGUID, idx, "Target");
+
+            if (flags.HasAnyFlag(CastFlag.PredictedPower))
+                packet.ReadUInt32("RemainingPower");
+
+            if (flags.HasAnyFlag(CastFlag.RuneInfo))
+                ReadRuneData(packet, idx, "RemainingRunes");
+
+            if (isSpellGo)
+                if (flags.HasAnyFlag(CastFlag.AdjustMissile))
+                    ReadMissileTrajectoryResult(packet, idx, "MissileTrajectory");
+
+            if (flags.HasAnyFlag(CastFlag.Projectile))
+                ReadSpellAmmo(packet, idx, "Ammo");
+
+            if (isSpellGo)
+            {
+                if (flags.HasAnyFlag(CastFlag.VisualChain))
+                    ReadProjectileVisual(packet, idx, "ProjectileVisual");
+
+                if (targetFlags.HasAnyFlag(TargetFlag.DestinationLocation))
+                    packet.ReadByte("DestLocSpellCastIndex", idx);
+
+                if (targetFlags.HasAnyFlag(TargetFlag.ExtraTargets))
+                {
+                    var targetPointsCount = packet.ReadInt32("TargetPointsCount", idx);
+                    for (var i = 0; i < targetPointsCount; ++i)
+                        ReadTargetLocation(packet, idx, "TargetPoints", i);
+                }
+            }
+            else
+            {
+                if (flags.HasAnyFlag(CastFlag.Immunity))
+                    ReadCreatureImmunities(packet, idx, "Immunities");
+
+                if (flags.HasAnyFlag(CastFlag.HealPrediction))
+                    ReadSpellHealPrediction(packet, idx, "Predict");
+            }
+
+            if (flags.HasAnyFlag(CastFlag.Unknown21) && !isSpellGo)
+            {
+                NpcSpellClick spellClick = new NpcSpellClick
+                {
+                    SpellID = (uint)spellId,
+                    CasterGUID = casterGUID,
+                    TargetGUID = targetGUID
+                };
+
+                Storage.SpellClicks.Add(spellClick, packet.TimeSpan);
+            }
+
+            if (isSpellGo)
+                packet.AddSniffData(StoreNameType.Spell, spellId, "SPELL_GO");
+        }
+
+        public static void ReadSpellMissStatus(Packet packet, params object[] idx)
+        {
+            packet.ReadGuid("MissTarget", idx);
+
+            var missType = packet.ReadByteE<SpellMissType>("Reason", idx);
+            if (missType == SpellMissType.Reflect)
+                packet.ReadByteE<SpellMissType>("ReflectStatus", idx);
+        }
+
+        public static void ReadSpellTargetData(Packet packet, ref TargetFlag targetFlags, WowGuid targetGUID, params object[] idx)
+        {
+            targetFlags = packet.ReadInt32E<TargetFlag>("Flags", idx);
+
+            if (targetFlags.HasAnyFlag(TargetFlag.Unit | TargetFlag.CorpseEnemy | TargetFlag.GameObject | TargetFlag.CorpseAlly | TargetFlag.UnitMinipet))
+                targetGUID = packet.ReadPackedGuid("Unit", idx);
+
+            if (targetFlags.HasAnyFlag(TargetFlag.Item | TargetFlag.TradeItem))
+                packet.ReadPackedGuid("Item", idx);
+
+            if (targetFlags.HasAnyFlag(TargetFlag.SourceLocation))
+                ReadLocation(packet, "SrcLocation");
+
+            if (targetFlags.HasAnyFlag(TargetFlag.DestinationLocation))
+                ReadLocation(packet, "DstLocation");
+
+            if (targetFlags.HasAnyFlag(TargetFlag.NameString))
+                packet.ReadCString("Name", idx);
+        }
+
+        public static Vector3 ReadLocation(Packet packet, params object[] idx)
+        {
+            packet.ReadPackedGuid("Transport", idx);
+            return packet.ReadVector3("Location", idx);
+        }
+
+        public static void ReadTargetLocation(Packet packet, params object[] idx)
+        {
+            packet.ReadVector3("Location", idx);
+            packet.ReadPackedGuid("Transport", idx);
+        }
+
+        public static void ReadRuneData(Packet packet, params object[] idx)
+        {
+            packet.ReadByte("Start", idx);
+            packet.ReadByte("Count", idx);
+            for (var i = 0; i < 6; ++i)
+                packet.ReadByte("Cooldowns", idx, i);
+        }
+
+        public static void ReadMissileTrajectoryResult(Packet packet, params object[] idx)
+        {
+            packet.ReadSingle("Pitch", idx);
+            packet.ReadUInt32("TravelTime", idx);
+        }
+
+        public static void ReadSpellAmmo(Packet packet, params object[] idx)
+        {
+            packet.ReadUInt32("DisplayID", idx);
+            packet.ReadByteE<InventoryType>("InventoryType", idx);
+        }
+
+        public static void ReadProjectileVisual(Packet packet, params object[] idx)
+        {
+            for (var i = 0; i < 2; ++i)
+                packet.ReadInt32("Id", idx, i);
+        }
+
+        public static void ReadCreatureImmunities(Packet packet, params object[] idx)
+        {
+            packet.ReadUInt32("School", idx);
+            packet.ReadUInt32("Value", idx);
+        }
+
+        public static void ReadSpellHealPrediction(Packet packet, params object[] idx)
+        {
+            packet.ReadInt32("Points", idx);
+            packet.ReadByte("Type", idx);
+            packet.ReadPackedGuid("BeaconGUID", idx);
+        }
+    }
+}


### PR DESCRIPTION
- the 4.3.4 module has a spell handler now and serves as future base for 4.3.4 spell packets
- spell_start and spell_go have been moved over there and got a updated parsing to reflect the output of >= 6.x builds
- added a few enums and updated field names of some random opcodes