### PR TITLE
Add support to byte[] type in SQL builder

### DIFF
--- a/WowPacketParser/SQL/QueryBuilder.cs
+++ b/WowPacketParser/SQL/QueryBuilder.cs
@@ -528,7 +528,7 @@ namespace WowPacketParser.SQL
                 }
                 else
                 {
-                    if (value is byte[] byteArray )
+                    if (value is byte[] byteArray)
                     {
                         query.Append(SQLUtil.ToSQLValue("0x" + Utilities.ByteArrayToHexString(byteArray), noQuotes: field.Item3.Any(a => a.NoQuotes)));
                         query.Append(SQLUtil.CommaSeparator);

--- a/WowPacketParser/SQL/QueryBuilder.cs
+++ b/WowPacketParser/SQL/QueryBuilder.cs
@@ -528,8 +528,12 @@ namespace WowPacketParser.SQL
                 }
                 else
                 {
-                    Array arr = value as Array;
-                    if (arr != null)
+                    if (value is byte[] byteArray )
+                    {
+                        query.Append(SQLUtil.ToSQLValue("0x" + Utilities.ByteArrayToHexString(byteArray), noQuotes: field.Item3.Any(a => a.NoQuotes)));
+                        query.Append(SQLUtil.CommaSeparator);
+                    }
+                    else if (value is Array arr)
                     {
                         foreach (object v in arr)
                         {

--- a/WowPacketParser/Store/Objects/HotfixBlob.cs
+++ b/WowPacketParser/Store/Objects/HotfixBlob.cs
@@ -17,7 +17,7 @@ namespace WowPacketParser.Store.Objects
         public string Locale = ClientLocale.PacketLocaleString;
 
         [DBFieldName("Blob", false, true)]
-        public string Blob;
+        public byte[] Blob;
 
         [DBFieldName("VerifiedBuild")]
         public int? VerifiedBuild = ClientVersion.BuildInt;

--- a/WowPacketParser/Store/Objects/HotfixOptionalData.cs
+++ b/WowPacketParser/Store/Objects/HotfixOptionalData.cs
@@ -20,7 +20,7 @@ namespace WowPacketParser.Store.Objects
         public DB2Hash Key;
 
         [DBFieldName("Data", true, true)]
-        public string Data;
+        public byte[] Data;
 
         [DBFieldName("VerifiedBuild")]
         public int? VerifiedBuild = ClientVersion.BuildInt;

--- a/WowPacketParserModule.V1_13_2_31446/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V1_13_2_31446/Parsers/HotfixHandler.cs
@@ -43,7 +43,7 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
                     {
                         TableHash = type,
                         RecordID = entry,
-                        Blob = "0x" + Utilities.ByteArrayToHexString(data)
+                        Blob = data
                     };
 
                     Storage.HotfixBlobs.Add(hotfixBlob);

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/HotfixHandler.cs
@@ -184,7 +184,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                         {
                             TableHash = type,
                             RecordID = entry,
-                            Blob = "0x" + Utilities.ByteArrayToHexString(data)
+                            Blob = data
                         };
 
                         Storage.HotfixBlobs.Add(hotfixBlob);
@@ -306,7 +306,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                     {
                         TableHash = type,
                         RecordID = entry,
-                        Blob = "0x" + Utilities.ByteArrayToHexString(data)
+                        Blob = data
                     };
 
                     Storage.HotfixBlobs.Add(hotfixBlob);

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/HotfixHandler.cs
@@ -127,7 +127,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
                                 {
                                     TableHash = type,
                                     RecordID = entry,
-                                    Blob = "0x" + Utilities.ByteArrayToHexString(data)
+                                    Blob = data
                                 };
 
                                 Storage.HotfixBlobs.Add(hotfixBlob);
@@ -201,7 +201,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
                             RecordID = entry,
                             Key = hash,
 
-                            Data = "0x" + Utilities.ByteArrayToHexString(optionalData)
+                            Data = optionalData
                         };
 
                         Storage.HotfixOptionalDatas.Add(hotfixOptionalData);


### PR DESCRIPTION
Add support to byte[] type in SQL builder to be able to handle MySQL blob type natively, then serializing the result as 0x string in .sql files.