### PR TITLE
Fix parsing errors in several packets for classic.

### DIFF
--- a/WowPacketParser/Parsing/Parsers/WorldStateHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/WorldStateHandler.cs
@@ -40,7 +40,8 @@ namespace WowPacketParser.Parsing.Parsers
         [Parser(Opcode.SMSG_SERVER_TIME_OFFSET)]
         public static void HandleUITimer(Packet packet)
         {
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503) &&
+                ClientVersion.Expansion != ClientType.Classic)
                 packet.ReadTime64("Time");
             else
                 packet.ReadTime("Time");

--- a/WowPacketParserModule.V1_13_2_31446/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V1_13_2_31446/Parsers/CharacterHandler.cs
@@ -59,6 +59,9 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
             packet.ReadInt32("InterfaceVersion", idx);
             packet.ReadUInt32("Flags4", idx);
 
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V1_13_7_38386))
+                packet.ReadBool("ExpansionChosen", idx);
+
             packet.ResetBitReader();
 
             var nameLength = packet.ReadBits("Character Name Length", 6, idx);

--- a/WowPacketParserModule.V1_13_2_31446/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParserModule.V1_13_2_31446/Parsers/MiscellaneousHandler.cs
@@ -71,5 +71,53 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
                 packet.ReadWoWString("Action", len2, i);
             }
         }
+
+        [Parser(Opcode.CMSG_WHO)]
+        public static void HandleWhoRequest(Packet packet)
+        {
+            var areaCount = packet.ReadBits(4);
+
+            packet.ReadInt32("MinLevel");
+            packet.ReadInt32("MaxLevel");
+            packet.ReadInt64("RaceFilter");
+            packet.ReadInt32("ClassFilter");
+
+            packet.ResetBitReader();
+
+            var nameLen = packet.ReadBits(6);
+            var virtualRealmNameLen = packet.ReadBits(9);
+            var guildLen = packet.ReadBits(7);
+            var guildVirtualRealmNameLen = packet.ReadBits(9);
+            var wordCount = packet.ReadBits(3);
+
+            packet.ReadBit("ShowEnemies");
+            packet.ReadBit("ShowArenaPlayers");
+            packet.ReadBit("ExactName");
+            var hasServerInfo = packet.ReadBit("HasServerInfo");
+            packet.ResetBitReader();
+
+            for (var i = 0; i < wordCount; ++i)
+            {
+                var bits0 = packet.ReadBits(7);
+                packet.ReadWoWString("Word", bits0, i);
+                packet.ResetBitReader();
+            }
+
+            packet.ReadWoWString("Name", nameLen);
+            packet.ReadWoWString("VirtualRealmName", virtualRealmNameLen);
+            packet.ReadWoWString("Guild", guildLen);
+            packet.ReadWoWString("GuildVirtualRealmName", guildVirtualRealmNameLen);
+
+            // WhoRequestServerInfo
+            if (hasServerInfo)
+            {
+                packet.ReadInt32("FactionGroup");
+                packet.ReadInt32("Locale");
+                packet.ReadInt32("RequesterVirtualRealmAddress");
+            }
+
+            for (var i = 0; i < areaCount; ++i)
+                packet.ReadUInt32<AreaId>("Area", i);
+        }
     }
 }

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/AccountDataHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/AccountDataHandler.cs
@@ -11,14 +11,16 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         {
             packet.ReadPackedGuid128("Guid");
 
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503) &&
+                ClientVersion.Expansion != ClientType.Classic)
                 packet.ReadTime64("ServerTime");
             else
                 packet.ReadTime("ServerTime");
 
             for (var i = 0; i < 8; ++i)
             {
-                if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
+                if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503) &&
+                    ClientVersion.Expansion != ClientType.Classic)
                     packet.ReadTime64($"[{(AccountDataType)i}] Time", i);
                 else
                     packet.ReadTime($"[{(AccountDataType)i}] Time", i);
@@ -30,7 +32,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         {
             packet.ReadPackedGuid128("Guid");
 
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503) &&
+                ClientVersion.Expansion != ClientType.Classic)
                 packet.ReadTime64("Time");
             else
                 packet.ReadTime("Time");
@@ -59,7 +62,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         {
             packet.ReadPackedGuid128("Guid");
 
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503) &&
+                ClientVersion.Expansion != ClientType.Classic)
                 packet.ReadTime64("Time");
             else
                 packet.ReadTime("Time");

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/SessionHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/SessionHandler.cs
@@ -9,7 +9,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
         [Parser(Opcode.SMSG_QUERY_TIME_RESPONSE)]
         public static void HandleQueryTimeResponse(Packet packet)
         {
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503) &&
+                ClientVersion.Expansion != ClientType.Classic)
                 packet.ReadTime64("CurrentTime");
             else
                 packet.ReadTime("CurrentTime");

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/AccountDataHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/AccountDataHandler.cs
@@ -16,7 +16,8 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             packet.ReadByteE<Gender>("Gender", idx);
             packet.ReadByte("Level", idx);
 
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503) &&
+                ClientVersion.Expansion != ClientType.Classic)
                 packet.ReadTime64("LastLogin", idx);
             else
                 packet.ReadTime("LastLogin", idx);

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/AuthenticationHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/AuthenticationHandler.cs
@@ -40,7 +40,8 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 var templates = packet.ReadUInt32("Templates");
                 packet.ReadUInt32("AccountCurrency");
 
-                if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
+                if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503) &&
+                    ClientVersion.Expansion != ClientType.Classic)
                     packet.ReadTime64("Time");
                 else
                     packet.ReadTime("Time");

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/MiscellaneousHandler.cs
@@ -376,7 +376,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
 
             packet.ReadInt32("MinLevel");
             packet.ReadInt32("MaxLevel");
-            packet.ReadUInt64("RaceFilter");
+            packet.ReadInt64("RaceFilter");
             packet.ReadInt32("ClassFilter");
 
             packet.ResetBitReader();


### PR DESCRIPTION
- Fix parsing of time fields for Classic-Era after 95c61f820b4ed8672d7adefd5d03d6723709dd0a. Classic is still using 32 bit time values.
- Add dedicated CMSG_WHO handler for Classic-Era since the structure is not the same as BfA.
- Read RaceFilter in CMSG_WHO as signed Int64, since client sends -1 if not specified.
- Fix parsing of SMSG_ENUM_CHARACTERS_RESULT in 1.13.7. There is a new field added to indicate whether you've selected which expansion you want to play the character on.