### PR TITLE
Protobuf: fallback to empty string instead of null, because protobuf doesn't accept nulls

### DIFF
--- a/WowPacketParser/Misc/StringBuilderProtoPart.cs
+++ b/WowPacketParser/Misc/StringBuilderProtoPart.cs
@@ -19,8 +19,8 @@ namespace WowPacketParser.Misc
             get
             {
                 if (Settings.DumpFormat == DumpFormatType.UniversalProtoWithText)
-                    return stringBuilder?.ToString(startLength, stringBuilder.Length - startLength);
-                return null;
+                    return stringBuilder?.ToString(startLength, stringBuilder.Length - startLength) ?? "";
+                return "";
             }
         }
     }


### PR DESCRIPTION
Protobuf doesn't like NULL values, therefore instead of null we should fallback to empty string