### PR TITLE
LfgHandler/ReadCliRideTicket: read time 64 for newer builds

### DIFF
--- a/WowPacketParserModule.V6_0_2_19033/Parsers/LfgHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/LfgHandler.cs
@@ -11,7 +11,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadPackedGuid128("RequesterGuid", idx);
             packet.ReadInt32("Id", idx);
             packet.ReadInt32("Type", idx);
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_1_0_39185))
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
                 packet.ReadTime64("Time", idx);
             else
                 packet.ReadTime("Time", idx);

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/LfgHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/LfgHandler.cs
@@ -11,7 +11,10 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadPackedGuid128("RequesterGuid", idx);
             packet.ReadInt32("Id", idx);
             packet.ReadInt32("Type", idx);
-            packet.ReadTime("Time", idx);
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_1_0_39185))
+                packet.ReadTime64("Time", idx);
+            else
+                packet.ReadTime("Time", idx);
         }
 
         public static void ReadLFGBlackList(Packet packet, params object[] idx)


### PR DESCRIPTION
I think this was introduced in 9.1.0? correct me if i'm wrong