### PR TITLE
Changed order of setting the client version

### DIFF
--- a/WowPacketParser/Loading/BinaryPacketReader.cs
+++ b/WowPacketParser/Loading/BinaryPacketReader.cs
@@ -251,7 +251,14 @@ namespace WowPacketParser.Loading
                 direction = (Direction)_reader.ReadByte();
                 data = _reader.ReadBytes(length);
             }
-
+            
+            if (number == 0)
+            {
+                // determine build version based on date of first packet if not specified otherwise
+                if (ClientVersion.IsUndefined())
+                    ClientVersion.SetVersion(time);
+            }
+            
             // ignore opcodes that were not "decrypted" (usually because of
             // a missing session key) (only applicable to 335 or earlier)
             if (opcode >= 1312 && (ClientVersion.Build <= ClientVersionBuild.V3_3_5a_12340 && ClientVersion.Build != ClientVersionBuild.Zero))

--- a/WowPacketParser/Loading/Reader.cs
+++ b/WowPacketParser/Loading/Reader.cs
@@ -36,17 +36,10 @@ namespace WowPacketParser.Loading
         {
             try
             {
-                packet = PacketReader.Read(_packetNum, FileName);
+                packet = PacketReader.Read(_packetNum++, FileName);
                 if (packet == null)
                     return false; // continue
-
-                if (_packetNum++ == 0)
-                {
-                    // determine build version based on date of first packet if not specified otherwise
-                    if (ClientVersion.IsUndefined())
-                        ClientVersion.SetVersion(packet.Time);
-                }
-
+                
                 // check for filters
                 var opcodeName = Opcodes.GetOpcodeName(packet.Opcode, packet.Direction);
 
@@ -89,16 +82,9 @@ namespace WowPacketParser.Loading
                 int packetNum = 0, count = 0;
                 while (reader.CanRead())
                 {
-                    var packet = reader.Read(packetNum, fileName);
+                    var packet = reader.Read(packetNum++, fileName);
                     if (packet == null)
                         continue;
-
-                    if (packetNum++ == 0)
-                    {
-                        // determine build version based on date of first packet if not specified otherwise
-                        if (ClientVersion.IsUndefined())
-                            ClientVersion.SetVersion(packet.Time);
-                    }
 
                     // check for filters
                     var opcodeName = Opcodes.GetOpcodeName(packet.Opcode, packet.Direction);

--- a/WowPacketParser/Loading/SqLitePacketReader.cs
+++ b/WowPacketParser/Loading/SqLitePacketReader.cs
@@ -118,6 +118,13 @@ namespace WowPacketParser.Loading
             if (DBNull.Value.Equals(blob))
                 return null;
 
+            if (number == 0)
+            {
+                // determine build version based on date of first packet if not specified otherwise
+                if (ClientVersion.IsUndefined())
+                    ClientVersion.SetVersion(time);
+            }
+            
             var data = (byte[])blob;
 
             var packet = new Packet(data, opcode, time, direction, number, Path.GetFileName(fileName));


### PR DESCRIPTION
This problem was introduced with the introduction of protobuf parsing, this line:
https://github.com/TrinityCore/WowPacketParser/blob/master/WowPacketParser/Misc/Packet.cs#L48 can be executed before setting the client version in the line https://github.com/TrinityCore/WowPacketParser/blob/master/WowPacketParser/Loading/Reader.cs#L47

However, when the version is not yet set, GetOpcodeName throws an exception, in result nothing is parsed.

The idea is to move setting the client version to https://github.com/TrinityCore/WowPacketParser/blob/master/WowPacketParser/Loading/BinaryPacketReader.cs#L257, just before Packet object is constructed

While this is not perfect, the previous solution wasn't pretty either, so I hope it is acceptable