### PR TITLE
Change UpdateFields properties to be nullable

### DIFF
--- a/WowPacketParser.Proto/PacketStructures/StructureVersion.cs
+++ b/WowPacketParser.Proto/PacketStructures/StructureVersion.cs
@@ -6,6 +6,6 @@ namespace WowPacketParser.PacketStructures
          * Everytime you change structures.proto, please increment this version
          * so that user could know if one needs to reparse the sniff
          */
-        public static readonly ulong ProtobufStructureVersion = 8;
+        public static readonly ulong ProtobufStructureVersion = 9;
     }
 }

--- a/WowPacketParser.Proto/PacketStructures/structures.proto
+++ b/WowPacketParser.Proto/PacketStructures/structures.proto
@@ -1,6 +1,7 @@
 syntax = "proto3";
 package wpp;
 import "google/protobuf/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 option csharp_namespace = "WowPacketParser.Proto";
 
 /*
@@ -469,11 +470,116 @@ message PacketDbReply {
   };
 }
 
-message UpdateValues {
+message UpdateValuesLegacy {
   map<string, int64> ints = 1;
   map<string, float> floats = 2;
   map<string, UniversalGuid> guids = 3;
   map<string, Quat> quaternions = 4;
+}
+
+message VisibleItemFields {
+  int32 itemID = 1;
+  uint32 itemAppearanceModID = 2;
+  uint32 itemVisual = 3;
+}
+
+message UInt32ValueWrapper {
+  google.protobuf.UInt32Value value = 1;
+}
+
+message Int32ValueWrapper {
+  google.protobuf.Int32Value value = 1;
+}
+
+message UpdateValuesUnitDataFields {
+  google.protobuf.Int32Value displayID = 1;
+  repeated UInt32ValueWrapper npcFlags = 2;
+  optional UniversalGuid summonedBy = 3;
+  optional UniversalGuid createdBy = 4;
+  google.protobuf.UInt32Value classId = 5;
+  google.protobuf.UInt32Value sex = 6;
+  google.protobuf.Int64Value health = 7;
+  repeated Int32ValueWrapper power = 8;
+  repeated Int32ValueWrapper maxPower = 9;
+  google.protobuf.Int64Value maxHealth = 10;
+  google.protobuf.Int32Value level = 11;
+  google.protobuf.Int32Value contentTuningID = 12;
+  google.protobuf.Int32Value scalingLevelMin = 13;
+  google.protobuf.Int32Value scalingLevelMax = 14;
+  google.protobuf.Int32Value scalingLevelDelta = 15;
+  google.protobuf.Int32Value factionTemplate = 16;
+  repeated VisibleItemFields virtualItems = 17;
+  google.protobuf.UInt32Value flags = 18;
+  google.protobuf.UInt32Value flags2 = 19;
+  google.protobuf.UInt32Value flags3 = 20;
+  repeated UInt32ValueWrapper attackRoundBaseTime = 21;
+  google.protobuf.UInt32Value rangedAttackRoundBaseTime = 22;
+  google.protobuf.FloatValue boundingRadius = 23;
+  google.protobuf.FloatValue combatReach = 24;
+  google.protobuf.Int32Value mountDisplayID = 25;
+  google.protobuf.UInt32Value standState = 26;
+  google.protobuf.UInt32Value petTalentPoints = 27;
+  google.protobuf.UInt32Value visFlags = 28;
+  google.protobuf.UInt32Value animTier = 29;
+  google.protobuf.Int32Value createdBySpell = 30;
+  google.protobuf.Int32Value emoteState = 31;
+  google.protobuf.UInt32Value sheatheState = 32;
+  google.protobuf.UInt32Value pvpFlags = 33;
+  google.protobuf.UInt32Value petFlags = 34;
+  google.protobuf.UInt32Value shapeshiftForm = 35;
+  google.protobuf.FloatValue hoverHeight = 36;
+  google.protobuf.Int32Value interactSpellID = 37;
+  google.protobuf.UInt32Value stateSpellVisualID = 38;
+  google.protobuf.UInt32Value stateAnimID = 39;
+  google.protobuf.UInt32Value stateAnimKitID = 40;
+  optional UniversalGuid charm = 41;
+  optional UniversalGuid summon = 42;
+  optional UniversalGuid critter = 43;
+  optional UniversalGuid demonCreator = 44;
+  optional UniversalGuid lookAtControllerTarget = 45;
+  optional UniversalGuid target = 46;
+  google.protobuf.UInt32Value race = 47;
+  google.protobuf.UInt32Value displayPower = 48;
+  google.protobuf.Int32Value effectiveLevel = 49;
+  google.protobuf.UInt32Value auraState = 50;
+  google.protobuf.FloatValue displayScale = 51;
+  google.protobuf.Int32Value creatureFamily = 52;
+  google.protobuf.Int32Value creatureType = 53;
+  google.protobuf.Int32Value nativeDisplayID = 54;
+  google.protobuf.FloatValue nativeXDisplayScale = 55;
+  repeated Int32ValueWrapper resistances = 56;
+  google.protobuf.Int32Value baseMana = 57;
+  google.protobuf.Int32Value baseHealth = 58;
+  optional UniversalGuid charmedBy = 59;
+}
+ 
+message UpdateValuesGameObjectDataFields
+{
+  optional UniversalGuid createdBy = 1;
+  google.protobuf.UInt32Value flags = 2;
+  optional Quat parentRotation = 3;
+  google.protobuf.Int32Value factionTemplate = 4;
+  google.protobuf.Int32Value state = 5;
+  google.protobuf.Int32Value typeID = 6;
+  google.protobuf.UInt32Value percentHealth = 7;
+  google.protobuf.Int32Value displayID = 8;
+  google.protobuf.UInt32Value artKit = 9;
+  google.protobuf.Int32Value level = 10;
+}
+  
+message UpdateValuesObjectDataFields {
+  google.protobuf.Int32Value entryID = 1;
+  google.protobuf.UInt32Value dynamicFlags = 2;
+  google.protobuf.FloatValue scale = 3;
+  optional UpdateValuesUnitDataFields unit = 4;
+  optional UpdateValuesGameObjectDataFields gameobject = 5;
+}
+
+message UpdateValues {
+  oneof values {
+    UpdateValuesLegacy legacy = 1;
+    UpdateValuesObjectDataFields fields = 2;
+  }
 }
 
 message MovementUpdateTransport {

--- a/WowPacketParser/Misc/Extensions.cs
+++ b/WowPacketParser/Misc/Extensions.cs
@@ -5,7 +5,10 @@ using System.Diagnostics.Contracts;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
+using Google.Protobuf.Collections;
 using WowPacketParser.Enums;
+using WowPacketParser.Proto;
+using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParser.Misc
 {
@@ -205,6 +208,147 @@ namespace WowPacketParser.Misc
             }
 
             return ~lo;
+        }
+
+        public static void Reserve<T>(this RepeatedField<T> field, int count) where T : new()
+        {
+            while (field.Count < count)
+                field.Add(new T());
+        }
+
+        public static void UpdateData(this UpdateValuesObjectDataFields fields, IObjectData data)
+        {
+            fields.EntryID = data.EntryID;
+            fields.Scale = data.Scale;
+            fields.DynamicFlags = data.DynamicFlags;
+        }
+        
+        public static void UpdateData(this UpdateValuesObjectDataFields fields, IGameObjectData data)
+        {
+            var go = fields.Gameobject ??= new();
+            if (data.CreatedBy != null)
+                go.CreatedBy = data.CreatedBy;
+            go.Flags = data.Flags;
+            if (data.ParentRotation.HasValue)
+                go.ParentRotation = data.ParentRotation;
+            go.FactionTemplate = data.FactionTemplate;
+            go.State = data.State;
+            go.TypeID = data.TypeID;
+            go.PercentHealth = data.PercentHealth;
+            go.DisplayID = data.DisplayID;
+            go.ArtKit = data.ArtKit;
+            go.Level = data.Level;
+        }
+
+        public static void UpdateData(this UpdateValuesObjectDataFields fields, IUnitData data)
+        {
+            var unit = fields.Unit ??= new();
+            unit.DisplayID = data.DisplayID;
+            unit.ClassId = data.ClassId;
+            unit.Sex = data.Sex;
+            unit.Health = data.Health;
+            unit.MaxHealth = data.MaxHealth;
+            unit.Level = data.Level;
+            unit.ContentTuningID = data.ContentTuningID;
+            unit.ScalingLevelMin = data.ScalingLevelMin;
+            unit.ScalingLevelMax = data.ScalingLevelMax;
+            unit.ScalingLevelDelta = data.ScalingLevelDelta;
+            unit.FactionTemplate = data.FactionTemplate;
+            unit.Flags = data.Flags;
+            unit.Flags2 = data.Flags2;
+            unit.Flags3 = data.Flags3;
+            unit.RangedAttackRoundBaseTime = data.RangedAttackRoundBaseTime;
+            unit.BoundingRadius = data.BoundingRadius;
+            unit.CombatReach = data.CombatReach;
+            unit.MountDisplayID = data.MountDisplayID;
+            unit.StandState = data.StandState;
+            unit.PetTalentPoints = data.PetTalentPoints;
+            unit.VisFlags = data.VisFlags;
+            unit.AnimTier = data.AnimTier;
+            unit.CreatedBySpell = data.CreatedBySpell;
+            unit.EmoteState = data.EmoteState;
+            unit.SheatheState = data.SheatheState;
+            unit.PvpFlags = data.PvpFlags;
+            unit.PetFlags = data.PetFlags;
+            unit.ShapeshiftForm = data.ShapeshiftForm;
+            unit.HoverHeight = data.HoverHeight;
+            unit.InteractSpellID = data.InteractSpellID;
+            unit.StateSpellVisualID = data.StateSpellVisualID;
+            unit.StateAnimID = data.StateAnimID;
+            unit.StateAnimKitID = data.StateAnimKitID;
+            unit.Race = data.Race;
+            unit.DisplayPower = data.DisplayPower;
+            unit.EffectiveLevel = data.EffectiveLevel;
+            unit.AuraState = data.AuraState;
+            unit.DisplayScale = data.DisplayScale;
+            unit.CreatureFamily = data.CreatureFamily;
+            unit.CreatureType = data.CreatureType;
+            unit.NativeDisplayID = data.NativeDisplayID;
+            unit.NativeXDisplayScale = data.NativeXDisplayScale;
+            unit.BaseMana = data.BaseMana;
+            unit.BaseHealth = data.BaseHealth;
+            if (data.Charm != null)
+                unit.Charm = data.Charm;
+            if (data.Summon != null)
+                unit.Summon = data.Summon;
+            if (data.Critter != null)
+                unit.Critter = data.Critter;
+            if (data.CharmedBy != null)
+                unit.CharmedBy = data.CharmedBy;
+            if (data.DemonCreator != null)
+                unit.DemonCreator = data.DemonCreator;
+            if (data.LookAtControllerTarget != null)
+                unit.LookAtControllerTarget = data.LookAtControllerTarget;
+            if (data.Target != null)
+                unit.Target = data.Target;
+            if (data.SummonedBy != null)
+                unit.SummonedBy = data.SummonedBy;
+            if (data.CreatedBy != null)
+                unit.CreatedBy = data.CreatedBy;
+            unit.NpcFlags.Reserve(data.NpcFlags.Length);
+            for (int i = 0; i < data.NpcFlags.Length; ++i)
+                unit.NpcFlags[i] = data.NpcFlags[i].ToProto();
+            
+            unit.Power.Reserve(data.Power.Length);
+            for (int i = 0; i < data.Power.Length; ++i)
+                unit.Power[i] = data.Power[i].ToProto();
+            
+            unit.MaxPower.Reserve(data.MaxPower.Length);
+            for (int i = 0; i < data.MaxPower.Length; ++i)
+                unit.MaxPower[i] = data.MaxPower[i].ToProto();
+            
+            unit.AttackRoundBaseTime.Reserve(data.AttackRoundBaseTime.Length);
+            for (int i = 0; i < data.AttackRoundBaseTime.Length; ++i)
+                unit.AttackRoundBaseTime[i] = data.AttackRoundBaseTime[i].ToProto();
+            
+            unit.Resistances.Reserve(data.Resistances.Length);
+            for (int i = 0; i < data.Resistances.Length; ++i)
+                unit.Resistances[i] = data.Resistances[i].ToProto();
+            
+            unit.VirtualItems.Reserve(data.VirtualItems.Length);
+            for (int i = 0; i < data.VirtualItems.Length; ++i)
+                if (data.VirtualItems[i] != null)
+                    unit.VirtualItems[i] = data.VirtualItems[i].ToProto();
+        }
+        
+        public static UInt32ValueWrapper ToProto(this uint? value)
+        {
+            return new UInt32ValueWrapper() { Value = value };
+        }
+        
+        public static Int32ValueWrapper ToProto(this int? value)
+        {
+            return new Int32ValueWrapper() { Value = value };
+        }
+
+        public static VisibleItemFields ToProto(this IVisibleItem item)
+        {
+            return new()
+            {
+                ItemID = item.ItemID ?? 0,
+                ItemVisual = item.ItemVisual ?? 0,
+                ItemAppearanceModID = item.ItemAppearanceModID ?? 0
+            };
         }
     }
 }

--- a/WowPacketParser/Parsing/Parsers/UpdateFieldsHandlerBase.cs
+++ b/WowPacketParser/Parsing/Parsers/UpdateFieldsHandlerBase.cs
@@ -11,9 +11,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public virtual IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IItemData ReadCreateItemData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -21,9 +21,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public virtual IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IContainerData ReadCreateContainerData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -31,9 +31,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public virtual IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IAzeriteEmpoweredItemData ReadCreateAzeriteEmpoweredItemData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -41,9 +41,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public virtual IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IAzeriteItemData ReadCreateAzeriteItemData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -51,9 +51,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public virtual IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IUnitData ReadCreateUnitData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -61,9 +61,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public virtual IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IPlayerData ReadCreatePlayerData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -71,9 +71,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public virtual IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IActivePlayerData ReadCreateActivePlayerData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -81,9 +81,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public virtual IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IGameObjectData ReadCreateGameObjectData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -91,9 +91,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public virtual IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IDynamicObjectData ReadCreateDynamicObjectData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -101,9 +101,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public virtual IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual ICorpseData ReadCreateCorpseData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -111,9 +111,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public virtual ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IAreaTriggerData ReadCreateAreaTriggerData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -121,9 +121,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public virtual IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual ISceneObjectData ReadCreateSceneObjectData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -131,9 +131,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public virtual ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
 
         public virtual IConversationData ReadCreateConversationData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
@@ -141,9 +141,9 @@ namespace WowPacketParser.Parsing.Parsers
             return null;
         }
 
-        public virtual IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public virtual IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            return existingData;
+            return null;
         }
     }
 }

--- a/WowPacketParser/Parsing/Parsers/UpdateHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/UpdateHandler.cs
@@ -38,8 +38,8 @@ namespace WowPacketParser.Parsing.Parsers
                     case "Values":
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var updateValues = new UpdateValues();
-                        ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues(){Legacy = new()};
+                        ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text});
                         break;
                     }
@@ -55,7 +55,7 @@ namespace WowPacketParser.Parsing.Parsers
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
                         var createType = typeString == "CreateObject1" ? CreateObjectType.InRange : CreateObjectType.Spawn;
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = createType };
+                        var createObject = new CreateObject() { Guid = guid, Values = new() {Legacy = new()}, CreateType = createType };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -82,7 +82,7 @@ namespace WowPacketParser.Parsing.Parsers
             WoWObject obj = CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, guid, index);
-            obj.UpdateFields = ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,
@@ -124,7 +124,7 @@ namespace WowPacketParser.Parsing.Parsers
             return obj;
         }
 
-        public static Dictionary<int, UpdateField> ReadValuesUpdateBlockOnCreate(Packet packet, UpdateValues updateValues, ObjectType type, object index)
+        public static Dictionary<int, UpdateField> ReadValuesUpdateBlockOnCreate(Packet packet, UpdateValuesLegacy updateValues, ObjectType type, object index)
         {
             return ReadValuesUpdateBlock(packet, updateValues, type, index, true, null);
         }
@@ -164,7 +164,7 @@ namespace WowPacketParser.Parsing.Parsers
             }
         }
 
-        public static void ReadValuesUpdateBlock(Packet packet, UpdateValues updateValues, WowGuid guid, int index)
+        public static void ReadValuesUpdateBlock(Packet packet, UpdateValuesLegacy updateValues, WowGuid guid, int index)
         {
             WoWObject obj;
             if (Storage.Objects.TryGetValue(guid, out obj))
@@ -180,7 +180,7 @@ namespace WowPacketParser.Parsing.Parsers
             }
         }
 
-        private static Dictionary<int, UpdateField> ReadValuesUpdateBlock(Packet packet, UpdateValues updateValues, ObjectType type, object index, bool isCreating, Dictionary<int, UpdateField> oldValues)
+        private static Dictionary<int, UpdateField> ReadValuesUpdateBlock(Packet packet, UpdateValuesLegacy updateValues, ObjectType type, object index, bool isCreating, Dictionary<int, UpdateField> oldValues)
         {
             bool skipDictionary = false;
             bool missingCreateObject = !isCreating && oldValues == null;

--- a/WowPacketParser/SQL/Builders/GameObjectMisc.cs
+++ b/WowPacketParser/SQL/Builders/GameObjectMisc.cs
@@ -42,11 +42,11 @@ namespace WowPacketParser.SQL.Builders
                 };
 
                 HashSet<int> playerFactions = new HashSet<int> { 1, 2, 3, 4, 5, 6, 115, 116, 1610, 1629, 2203, 2204, 2395, 2401, 2402 };
-                addon.Faction = (uint)go.GameObjectData.FactionTemplate;
-                if (playerFactions.Contains(go.GameObjectData.FactionTemplate))
+                addon.Faction = (uint)(go.GameObjectData.FactionTemplate ?? 0);
+                if (playerFactions.Contains(go.GameObjectData.FactionTemplate ?? 0))
                     addon.Faction = 0;
 
-                addon.Flags = (GameObjectFlag)go.GameObjectData.Flags;
+                addon.Flags = (GameObjectFlag)(go.GameObjectData.Flags ?? 0);
                 addon.Flags &= ~GameObjectFlag.Triggered;
                 addon.Flags &= ~GameObjectFlag.Damaged;
                 addon.Flags &= ~GameObjectFlag.Destroyed;

--- a/WowPacketParser/SQL/Builders/UnitMisc.cs
+++ b/WowPacketParser/SQL/Builders/UnitMisc.cs
@@ -97,9 +97,9 @@ namespace WowPacketParser.SQL.Builders
             foreach (var pair in entries.SelectMany(entry => entry))
             {
                 if (list.ContainsKey(pair.Key.GetEntry()))
-                    list[pair.Key.GetEntry()].Add(pair.Value.UnitData.ScalingLevelDelta);
+                    list[pair.Key.GetEntry()].Add(pair.Value.UnitData.ScalingLevelDelta ?? 0);
                 else
-                    list.Add(pair.Key.GetEntry(), new List<int> { pair.Value.UnitData.ScalingLevelDelta });
+                    list.Add(pair.Key.GetEntry(), new List<int> { pair.Value.UnitData.ScalingLevelDelta ?? 0 });
             }
 
             var result = list.ToDictionary(pair => pair.Key, pair => Tuple.Create(pair.Value.Min(), pair.Value.Max()));
@@ -415,9 +415,9 @@ namespace WowPacketParser.SQL.Builders
             foreach (var pair in entries.SelectMany(entry => entry))
             {
                 if (list.ContainsKey(pair.Key.GetEntry()))
-                    list[pair.Key.GetEntry()].Add(pair.Value.UnitData.Level);
+                    list[pair.Key.GetEntry()].Add(pair.Value.UnitData.Level ?? 0);
                 else
-                    list.Add(pair.Key.GetEntry(), new List<int> { pair.Value.UnitData.Level });
+                    list.Add(pair.Key.GetEntry(), new List<int> { pair.Value.UnitData.Level ?? 0 });
             }
 
             var result = list.ToDictionary(pair => pair.Key, pair => ValueTuple.Create(pair.Value.Min(), pair.Value.Max()));
@@ -545,7 +545,7 @@ namespace WowPacketParser.SQL.Builders
                     MinLevel = minMaxLevel.MinLevel,
                     MaxLevel = minMaxLevel.MaxLevel,
                     Faction = (uint)npc.UnitData.FactionTemplate,
-                    NpcFlag = (NPCFlags)Utilities.MAKE_PAIR64(npc.UnitData.NpcFlags[0], npc.UnitData.NpcFlags[1]),
+                    NpcFlag = (NPCFlags)Utilities.MAKE_PAIR64(npc.UnitData.NpcFlags[0] ?? 0, npc.UnitData.NpcFlags[1] ?? 0),
                     SpeedRun = npc.Movement.RunSpeed,
                     SpeedWalk = npc.Movement.WalkSpeed,
                     BaseAttackTime = npc.UnitData.AttackRoundBaseTime[0],

--- a/WowPacketParser/Store/Objects/AreaTriggerCreateProperties.cs
+++ b/WowPacketParser/Store/Objects/AreaTriggerCreateProperties.cs
@@ -37,13 +37,13 @@ namespace WowPacketParser.Store.Objects
         public int? AnimKitId = 0;
 
         [DBFieldName("DecalPropertiesId")]
-        public uint DecalPropertiesId = 0;
+        public uint? DecalPropertiesId = 0;
 
         [DBFieldName("TimeToTarget")]
-        public uint TimeToTarget = 0;
+        public uint? TimeToTarget = 0;
 
         [DBFieldName("TimeToTargetScale")]
-        public uint TimeToTargetScale = 0;
+        public uint? TimeToTargetScale = 0;
 
         [DBFieldName("Shape", TargetedDatabase.Shadowlands)]
         public byte? Shape;

--- a/WowPacketParser/Store/Objects/Unit.cs
+++ b/WowPacketParser/Store/Objects/Unit.cs
@@ -45,8 +45,8 @@ namespace WowPacketParser.Store.Objects
 
         public override void LoadValuesFromUpdateFields()
         {
-            Bytes1 = BitConverter.ToUInt32(new byte[] { UnitData.StandState, UnitData.PetTalentPoints, UnitData.VisFlags, UnitData.AnimTier }, 0);
-            Bytes2 = BitConverter.ToUInt32(new byte[] { UnitData.SheatheState, UnitData.PvpFlags, UnitData.PetFlags, UnitData.ShapeshiftForm }, 0);
+            Bytes1 = BitConverter.ToUInt32(new byte[] { UnitData.StandState ?? 0, UnitData.PetTalentPoints ?? 0, UnitData.VisFlags ?? 0, UnitData.AnimTier  ?? 0}, 0);
+            Bytes2 = BitConverter.ToUInt32(new byte[] { UnitData.SheatheState ?? 0, UnitData.PvpFlags ?? 0, UnitData.PetFlags ?? 0, UnitData.ShapeshiftForm  ?? 0}, 0);
             if (ClientVersion.AddedInVersion(ClientType.WarlordsOfDraenor))
                 DynamicFlagsWod = (UnitDynamicFlagsWOD)ObjectData.DynamicFlags;
             else

--- a/WowPacketParser/Store/Objects/UpdateFields/IAreaTriggerData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IAreaTriggerData.cs
@@ -1,12 +1,14 @@
-﻿namespace WowPacketParser.Store.Objects.UpdateFields
+﻿#nullable enable
+
+namespace WowPacketParser.Store.Objects.UpdateFields
 {
     public interface IAreaTriggerData
     {
-        int SpellID { get; }
-        uint TimeToTarget { get; }
-        uint TimeToTargetScale { get; }
-        uint DecalPropertiesID { get; }
+        int? SpellID { get; }
+        uint? TimeToTarget { get; }
+        uint? TimeToTargetScale { get; }
+        uint? DecalPropertiesID { get; }
 
-        IVisualAnim VisualAnim { get { return null; } }
+        IVisualAnim? VisualAnim { get { return null; } }
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/IConversationData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IConversationData.cs
@@ -1,11 +1,33 @@
-﻿using WowPacketParser.Misc;
+﻿using System;
+using WowPacketParser.Misc;
 
 namespace WowPacketParser.Store.Objects.UpdateFields
 {
     public interface IConversationData
     {
         IConversationLine[] Lines { get; }
-        int LastLineEndTime { get; }
+        int? LastLineEndTime { get; }
         DynamicUpdateField<IConversationActor> Actors { get; }
+    }
+    
+    public interface IMutableConversationData : IConversationData
+    {
+        IConversationLine[] Lines { get; set; }
+        int? LastLineEndTime { get; set; }
+    }
+    
+    public static partial class Extensions
+    {
+        public static void UpdateData(this IMutableConversationData data, IConversationData update)
+        {
+            data.LastLineEndTime = update.LastLineEndTime ?? data.LastLineEndTime;
+            data.Lines = update.Lines ?? data.Lines;
+
+            if (update.Actors.Count > data.Actors.Count)
+                data.Actors.Resize((uint)update.Actors.Count);
+            
+            for (int i = 0; i < update.Actors.Count; ++i)
+                data.Actors[i] = update.Actors[i] ?? data.Actors[i];
+        }
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/IConversationLine.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IConversationLine.cs
@@ -1,4 +1,6 @@
-﻿namespace WowPacketParser.Store.Objects.UpdateFields
+﻿#nullable enable
+
+namespace WowPacketParser.Store.Objects.UpdateFields
 {
     public interface IConversationLine
     {

--- a/WowPacketParser/Store/Objects/UpdateFields/IGameObjectData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IGameObjectData.cs
@@ -1,15 +1,51 @@
-﻿using WowPacketParser.Misc;
+﻿#nullable enable
+
+using WowPacketParser.Misc;
 
 namespace WowPacketParser.Store.Objects.UpdateFields
 {
     public interface IGameObjectData
     {
-        WowGuid CreatedBy { get; }
-        uint Flags { get; }
-        Quaternion ParentRotation { get; }
-        int FactionTemplate { get; }
-        sbyte State { get; }
-        sbyte TypeID { get; }
-        byte PercentHealth { get; }
+        WowGuid? CreatedBy { get; }
+        uint? Flags { get; }
+        Quaternion? ParentRotation { get; }
+        int? FactionTemplate { get; }
+        sbyte? State { get; }
+        sbyte? TypeID { get; }
+        byte? PercentHealth { get; }
+        int? DisplayID { get; }
+        uint? ArtKit { get; }
+        int? Level { get; }
+    }
+    
+    public interface IMutableGameObjectData : IGameObjectData
+    {
+        WowGuid? CreatedBy { get; set; }
+        uint? Flags { get; set; }
+        Quaternion? ParentRotation { get; set; }
+        int? FactionTemplate { get; set; }
+        sbyte? State { get; set; }
+        sbyte? TypeID { get; set; }
+        byte? PercentHealth { get; set; }
+        int? DisplayID { get; set; }
+        uint? ArtKit { get; set; }
+        int? Level { get; set; }
+    }
+    
+    public static partial class Extensions
+    {
+        public static void UpdateData(this IMutableGameObjectData data, IGameObjectData update)
+        {
+            data.CreatedBy = update.CreatedBy ?? data.CreatedBy;
+            data.Flags = update.Flags ?? data.Flags;
+            data.ParentRotation = update.ParentRotation ?? data.ParentRotation;
+            data.FactionTemplate = update.FactionTemplate ?? data.FactionTemplate;
+            data.State = update.State ?? data.State;
+            data.TypeID = update.TypeID ?? data.TypeID;
+            data.PercentHealth = update.PercentHealth ?? data.PercentHealth;
+            data.DisplayID = update.DisplayID ?? data.DisplayID;
+            data.ArtKit = update.ArtKit ?? data.ArtKit;
+            data.Level = update.Level ?? data.Level;
+        }
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/IGameObjectData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IGameObjectData.cs
@@ -4,6 +4,8 @@ using WowPacketParser.Misc;
 
 namespace WowPacketParser.Store.Objects.UpdateFields
 {
+    // when adding new properties, remember to include them in 
+    // IMutableGameObjectData and in Extensions.UpdateData
     public interface IGameObjectData
     {
         WowGuid? CreatedBy { get; }

--- a/WowPacketParser/Store/Objects/UpdateFields/IObjectData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IObjectData.cs
@@ -1,9 +1,28 @@
-﻿namespace WowPacketParser.Store.Objects.UpdateFields
+﻿#nullable enable
+
+namespace WowPacketParser.Store.Objects.UpdateFields
 {
     public interface IObjectData
     {
-        int EntryID { get; }
-        uint DynamicFlags { get; }
-        float Scale { get; }
+        int? EntryID { get; }
+        uint? DynamicFlags { get; }
+        float? Scale { get; }
+    }
+    
+    public interface IMutableObjectData : IObjectData
+    {
+        int? EntryID { get; set; }
+        uint? DynamicFlags { get; set; }
+        float? Scale { get; set; }
+    }
+
+    public static partial class Extensions
+    {
+        public static void UpdateData(this IMutableObjectData data, IObjectData update)
+        {
+            data.EntryID = update.EntryID ?? data.EntryID;
+            data.DynamicFlags = update.DynamicFlags ?? data.DynamicFlags;
+            data.Scale = update.Scale ?? data.Scale;
+        }
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/ISceneObjectData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/ISceneObjectData.cs
@@ -1,8 +1,10 @@
-﻿namespace WowPacketParser.Store.Objects.UpdateFields
+﻿#nullable enable
+
+namespace WowPacketParser.Store.Objects.UpdateFields
 {
     public interface ISceneObjectData
     {
-        int ScriptPackageID { get; }
-        uint SceneType { get; }
+        int? ScriptPackageID { get; }
+        uint? SceneType { get; }
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/IUnitData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IUnitData.cs
@@ -4,6 +4,8 @@ using WowPacketParser.Misc;
 
 namespace WowPacketParser.Store.Objects.UpdateFields
 {
+    // when adding new properties, remember to include them in 
+    // IMutableUnitData and in Extensions.UpdateData
     public interface IUnitData
     {
         int? DisplayID { get; }

--- a/WowPacketParser/Store/Objects/UpdateFields/IUnitData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IUnitData.cs
@@ -1,45 +1,199 @@
-﻿using WowPacketParser.Misc;
+﻿#nullable enable
+using System;
+using WowPacketParser.Misc;
 
 namespace WowPacketParser.Store.Objects.UpdateFields
 {
     public interface IUnitData
     {
-        int DisplayID { get; }
-        uint[] NpcFlags { get; }
-        WowGuid SummonedBy { get; }
-        WowGuid CreatedBy { get; }
-        byte ClassId { get; }
-        byte Sex { get; }
-        long Health { get; }
-        int[] Power { get; }
-        int[] MaxPower { get; }
-        long MaxHealth { get; }
-        int Level { get; }
-        int ContentTuningID { get; }
-        int ScalingLevelMin { get; }
-        int ScalingLevelMax { get; }
-        int ScalingLevelDelta { get; }
-        int FactionTemplate { get; }
-        IVisibleItem[] VirtualItems { get; }
-        uint Flags { get; }
-        uint Flags2 { get; }
-        uint Flags3 { get; }
-        uint[] AttackRoundBaseTime { get; }
-        uint RangedAttackRoundBaseTime { get; }
-        float BoundingRadius { get; }
-        float CombatReach { get; }
-        int MountDisplayID { get; }
-        byte StandState { get; }
-        byte PetTalentPoints { get; }
-        byte VisFlags { get; }
-        byte AnimTier { get; }
-        int CreatedBySpell { get; }
-        int EmoteState { get; }
-        byte SheatheState { get; }
-        byte PvpFlags { get; }
-        byte PetFlags { get; }
-        byte ShapeshiftForm { get; }
-        float HoverHeight { get; }
-        int InteractSpellID { get; }
+        int? DisplayID { get; }
+        uint?[] NpcFlags { get; }
+        WowGuid? SummonedBy { get; }
+        WowGuid? CreatedBy { get; }
+        byte? ClassId { get; }
+        byte? Sex { get; }
+        long? Health { get; }
+        int?[] Power { get; }
+        int?[] MaxPower { get; }
+        long? MaxHealth { get; }
+        int? Level { get; }
+        int? ContentTuningID { get; }
+        int? ScalingLevelMin { get; }
+        int? ScalingLevelMax { get; }
+        int? ScalingLevelDelta { get; }
+        int? FactionTemplate { get; }
+        IVisibleItem?[] VirtualItems { get; }
+        uint? Flags { get; }
+        uint? Flags2 { get; }
+        uint? Flags3 { get; }
+        uint?[] AttackRoundBaseTime { get; }
+        uint? RangedAttackRoundBaseTime { get; }
+        float? BoundingRadius { get; }
+        float? CombatReach { get; }
+        int? MountDisplayID { get; }
+        byte? StandState { get; }
+        byte? PetTalentPoints { get; }
+        byte? VisFlags { get; }
+        byte? AnimTier { get; }
+        int? CreatedBySpell { get; }
+        int? EmoteState { get; }
+        byte? SheatheState { get; }
+        byte? PvpFlags { get; }
+        byte? PetFlags { get; }
+        byte? ShapeshiftForm { get; }
+        float? HoverHeight { get; }
+        int? InteractSpellID { get; }
+        uint? StateSpellVisualID { get; }
+        uint? StateAnimID { get; }
+        uint? StateAnimKitID { get; }
+        WowGuid? Charm { get; }
+        WowGuid? Summon { get; }
+        WowGuid? Critter { get; }
+        WowGuid? CharmedBy { get; }
+        WowGuid? DemonCreator { get; }
+        WowGuid? LookAtControllerTarget { get; }
+        WowGuid? Target { get; }
+        byte? Race { get; }
+        byte? DisplayPower { get; }
+        int? EffectiveLevel { get; }
+        uint? AuraState { get; }
+        float? DisplayScale { get; }
+        int? CreatureFamily { get; }
+        int? CreatureType { get; }
+        int? NativeDisplayID { get; }
+        float? NativeXDisplayScale { get; }
+        int?[] Resistances { get; }
+        int? BaseMana { get; }
+        int? BaseHealth { get; }
+    }
+    
+    public interface IMutableUnitData : IUnitData
+    {
+        int? DisplayID { get; set; }
+        WowGuid? SummonedBy { get; set; }
+        WowGuid? CreatedBy { get; set; }
+        byte? ClassId { get; set; }
+        byte? Sex { get; set; }
+        long? Health { get; set; }
+        long? MaxHealth { get; set; }
+        int? Level { get; set; }
+        int? ContentTuningID { get; set; }
+        int? ScalingLevelMin { get; set; }
+        int? ScalingLevelMax { get; set; }
+        int? ScalingLevelDelta { get; set; }
+        int? FactionTemplate { get; set; }
+        uint? Flags { get; set; }
+        uint? Flags2 { get; set; }
+        uint? Flags3 { get; set; }
+        uint? RangedAttackRoundBaseTime { get; set; }
+        float? BoundingRadius { get; set; }
+        float? CombatReach { get; set; }
+        int? MountDisplayID { get; set; }
+        byte? StandState { get; set; }
+        byte? PetTalentPoints { get; set; }
+        byte? VisFlags { get; set; }
+        byte? AnimTier { get; set; }
+        int? CreatedBySpell { get; set; }
+        int? EmoteState { get; set; }
+        byte? SheatheState { get; set; }
+        byte? PvpFlags { get; set; }
+        byte? PetFlags { get; set; }
+        byte? ShapeshiftForm { get; set; }
+        float? HoverHeight { get; set; }
+        int? InteractSpellID { get; set; }
+        uint? StateSpellVisualID { get; set; }
+        uint? StateAnimID { get; set; }
+        uint? StateAnimKitID { get; set; }
+        WowGuid? Charm { get; set; }
+        WowGuid? Summon { get; set; }
+        WowGuid? Critter { get; set; }
+        WowGuid? CharmedBy { get; set; }
+        WowGuid? DemonCreator { get; set; }
+        WowGuid? LookAtControllerTarget { get; set; }
+        WowGuid? Target { get; set; }
+        byte? Race { get; set; }
+        byte? DisplayPower { get; set; }
+        int? EffectiveLevel { get; set; }
+        uint? AuraState { get; set; }
+        float? DisplayScale { get; set; }
+        int? CreatureFamily { get; set; }
+        int? CreatureType { get; set; }
+        int? NativeDisplayID { get; set; }
+        float? NativeXDisplayScale { get; set; }
+        int? BaseMana { get; set; }
+        int? BaseHealth { get; set; }
+    }
+
+    public static partial class Extensions
+    {
+        public static void UpdateData(this IMutableUnitData data, IUnitData update)
+        {
+            data.DisplayID = update.DisplayID ?? data.DisplayID;
+            data.Flags = update.Flags ?? data.Flags;
+            data.Flags2 = update.Flags2 ?? data.Flags2;
+            data.Flags3 = update.Flags3 ?? data.Flags3;
+            data.RangedAttackRoundBaseTime = update.RangedAttackRoundBaseTime ?? data.RangedAttackRoundBaseTime;
+            data.BoundingRadius = update.BoundingRadius ?? data.BoundingRadius;
+            data.CombatReach = update.CombatReach ?? data.CombatReach;
+            data.MountDisplayID = update.MountDisplayID ?? data.MountDisplayID;
+            data.StandState = update.StandState ?? data.StandState;
+            data.PetTalentPoints = update.PetTalentPoints ?? data.PetTalentPoints;
+            data.VisFlags = update.VisFlags ?? data.VisFlags;
+            data.AnimTier = update.AnimTier ?? data.AnimTier;
+            data.CreatedBySpell = update.CreatedBySpell ?? data.CreatedBySpell;
+            data.EmoteState = update.EmoteState ?? data.EmoteState;
+            data.SheatheState = update.SheatheState ?? data.SheatheState;
+            data.PvpFlags = update.PvpFlags ?? data.PvpFlags;
+            data.PetFlags = update.PetFlags ?? data.PetFlags;
+            data.ShapeshiftForm = update.ShapeshiftForm ?? data.ShapeshiftForm;
+            data.HoverHeight = update.HoverHeight ?? data.HoverHeight;
+            data.InteractSpellID = update.InteractSpellID ?? data.InteractSpellID;
+            data.ScalingLevelMin = update.ScalingLevelMin ?? data.ScalingLevelMin;
+            data.ScalingLevelMax = update.ScalingLevelMax ?? data.ScalingLevelMax;
+            data.StateSpellVisualID = update.StateSpellVisualID ?? data.StateSpellVisualID;
+            data.StateAnimID = update.StateAnimID ?? data.StateAnimID;
+            data.StateAnimKitID = update.StateAnimKitID ?? data.StateAnimKitID;
+            data.Charm = update.Charm ?? data.Charm;
+            data.Summon = update.Summon ?? data.Summon;
+            data.Critter = update.Critter ?? data.Critter;
+            data.CharmedBy = update.CharmedBy ?? data.CharmedBy;
+            data.DemonCreator = update.DemonCreator ?? data.DemonCreator;
+            data.LookAtControllerTarget = update.LookAtControllerTarget ?? data.LookAtControllerTarget;
+            data.Target = update.Target ?? data.Target;
+            data.Race = update.Race ?? data.Race;
+            data.DisplayPower = update.DisplayPower ?? data.DisplayPower;
+            data.EffectiveLevel = update.EffectiveLevel ?? data.EffectiveLevel;
+            data.AuraState = update.AuraState ?? data.AuraState;
+            data.DisplayScale = update.DisplayScale ?? data.DisplayScale;
+            data.CreatureFamily = update.CreatureFamily ?? data.CreatureFamily;
+            data.CreatureType = update.CreatureType ?? data.CreatureType;
+            data.NativeDisplayID = update.NativeDisplayID ?? data.NativeDisplayID;
+            data.NativeXDisplayScale = update.NativeXDisplayScale ?? data.NativeXDisplayScale;
+            data.BaseMana = update.BaseMana ?? data.BaseMana;
+            data.BaseHealth = update.BaseHealth ?? data.BaseHealth;
+            data.SummonedBy = update.SummonedBy ?? data.SummonedBy;
+            data.CreatedBy = update.CreatedBy ?? data.CreatedBy;
+            data.ClassId = update.ClassId ?? data.ClassId;
+            data.Sex = update.Sex ?? data.Sex;
+            data.Health = update.Health ?? data.Health;
+            data.MaxHealth = update.MaxHealth ?? data.MaxHealth;
+            data.Level = update.Level ?? data.Level;
+            data.ContentTuningID = update.ContentTuningID ?? data.ContentTuningID;
+            data.ScalingLevelDelta = update.ScalingLevelDelta ?? data.ScalingLevelDelta;
+            data.FactionTemplate = update.FactionTemplate ?? data.FactionTemplate;
+            
+            for (int i = 0; i < Math.Min(data.NpcFlags.Length, update.NpcFlags.Length); i++)
+                data.NpcFlags[i] = update.NpcFlags[i] ?? data.NpcFlags[i];
+            for (int i = 0; i < Math.Min(data.Power.Length, update.Power.Length); i++)
+                data.Power[i] = update.Power[i] ?? data.Power[i];
+            for (int i = 0; i < Math.Min(data.MaxPower.Length, update.MaxPower.Length); i++)
+                data.MaxPower[i] = update.MaxPower[i] ?? data.MaxPower[i];
+            for (int i = 0; i < Math.Min(data.AttackRoundBaseTime.Length, update.AttackRoundBaseTime.Length); i++)
+                data.AttackRoundBaseTime[i] = update.AttackRoundBaseTime[i] ?? data.AttackRoundBaseTime[i];
+            for (int i = 0; i < Math.Min(data.Resistances.Length, update.Resistances.Length); i++)
+                data.Resistances[i] = update.Resistances[i] ?? data.Resistances[i];
+            for (int i = 0; i < Math.Min(data.VirtualItems.Length, update.VirtualItems.Length); i++)
+                data.VirtualItems[i] = update.VirtualItems[i] ?? data.VirtualItems[i];
+        }
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/IVisibleItem.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IVisibleItem.cs
@@ -1,9 +1,11 @@
-﻿namespace WowPacketParser.Store.Objects.UpdateFields
+﻿#nullable enable
+
+namespace WowPacketParser.Store.Objects.UpdateFields
 {
     public interface IVisibleItem
     {
-        int ItemID { get; }
-        ushort ItemAppearanceModID { get; }
-        ushort ItemVisual { get; }
+        int? ItemID { get; }
+        ushort? ItemAppearanceModID { get; }
+        ushort? ItemVisual { get; }
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/IVisualAnim.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/IVisualAnim.cs
@@ -1,9 +1,11 @@
-﻿namespace WowPacketParser.Store.Objects.UpdateFields
+﻿#nullable enable
+
+namespace WowPacketParser.Store.Objects.UpdateFields
 {
     public interface IVisualAnim
     {
-        uint AnimationDataID { get; set; }
-        uint AnimKitID { get; set; }
-        bool Field_C { get; set; }
+        uint? AnimationDataID { get; set; }
+        uint? AnimKitID { get; set; }
+        bool? Field_C { get; set; }
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/AreaTriggerData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/AreaTriggerData.cs
@@ -14,9 +14,9 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
             Object = obj;
         }
 
-        public int SpellID => UpdateFields.GetValue<AreaTriggerField, int>(AreaTriggerField.AREATRIGGER_SPELLID);
-        public uint TimeToTarget => UpdateFields.GetValue<AreaTriggerField, uint>(AreaTriggerField.AREATRIGGER_TIME_TO_TARGET);
-        public uint TimeToTargetScale => UpdateFields.GetValue<AreaTriggerField, uint>(AreaTriggerField.AREATRIGGER_TIME_TO_TARGET_SCALE);
-        public uint DecalPropertiesID => UpdateFields.GetValue<AreaTriggerField, uint>(AreaTriggerField.AREATRIGGER_DECAL_PROPERTIES_ID);
+        public int? SpellID => UpdateFields.GetValue<AreaTriggerField, int?>(AreaTriggerField.AREATRIGGER_SPELLID);
+        public uint? TimeToTarget => UpdateFields.GetValue<AreaTriggerField, uint?>(AreaTriggerField.AREATRIGGER_TIME_TO_TARGET);
+        public uint? TimeToTargetScale => UpdateFields.GetValue<AreaTriggerField, uint?>(AreaTriggerField.AREATRIGGER_TIME_TO_TARGET_SCALE);
+        public uint? DecalPropertiesID => UpdateFields.GetValue<AreaTriggerField, uint?>(AreaTriggerField.AREATRIGGER_DECAL_PROPERTIES_ID);
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/ConversationData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/ConversationData.cs
@@ -39,7 +39,7 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
             }
         }
 
-        public int LastLineEndTime => UpdateFields.GetValue<ConversationField, int>(ConversationField.CONVERSATION_LAST_LINE_END_TIME);
+        public int? LastLineEndTime => UpdateFields.GetValue<ConversationField, int?>(ConversationField.CONVERSATION_LAST_LINE_END_TIME);
 
         public DynamicUpdateField<IConversationActor> Actors
         {

--- a/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/GameObjectData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/GameObjectData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using WowPacketParser.Enums;
 using WowPacketParser.Misc;
 
@@ -14,7 +15,7 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
             Object = obj;
         }
 
-        public WowGuid CreatedBy
+        public WowGuid? CreatedBy
         {
             get
             {
@@ -31,9 +32,9 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
             }
         }
 
-        public uint Flags => UpdateFields.GetValue<GameObjectField, uint>(GameObjectField.GAMEOBJECT_FLAGS);
+        public uint? Flags => UpdateFields.GetValue<GameObjectField, uint>(GameObjectField.GAMEOBJECT_FLAGS);
 
-        public Quaternion ParentRotation
+        public Quaternion? ParentRotation
         {
             get
             {
@@ -43,12 +44,18 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
             }
         }
 
-        public int FactionTemplate => UpdateFields.GetValue<GameObjectField, int>(GameObjectField.GAMEOBJECT_FACTION);
+        public int? FactionTemplate => UpdateFields.GetValue<GameObjectField, int?>(GameObjectField.GAMEOBJECT_FACTION);
 
-        public sbyte State => (sbyte)(UpdateFields.GetValue<GameObjectField, int>(GameObjectField.GAMEOBJECT_BYTES_1) & 0x000000FF);
+        public sbyte? State => (sbyte)(UpdateFields.GetValue<GameObjectField, int>(GameObjectField.GAMEOBJECT_BYTES_1) & 0x000000FF);
 
-        public sbyte TypeID => (sbyte)((UpdateFields.GetValue<GameObjectField, int>(GameObjectField.GAMEOBJECT_BYTES_1) & 0x0000FF00) >> 8);
+        public sbyte? TypeID => (sbyte)((UpdateFields.GetValue<GameObjectField, int>(GameObjectField.GAMEOBJECT_BYTES_1) & 0x0000FF00) >> 8);
 
-        public byte PercentHealth => (byte)((UpdateFields.GetValue<GameObjectField, uint>(GameObjectField.GAMEOBJECT_BYTES_1) & 0xFF000000) >> 24);
+        public byte? PercentHealth => (byte)((UpdateFields.GetValue<GameObjectField, uint>(GameObjectField.GAMEOBJECT_BYTES_1) & 0xFF000000) >> 24);
+        
+        public int? DisplayID => UpdateFields.GetValue<GameObjectField, int?>(GameObjectField.GAMEOBJECT_DISPLAYID);
+        
+        public uint? ArtKit => UpdateFields.GetValue<GameObjectField, uint?>(GameObjectField.GAMEOBJECT_ARTKIT);
+        
+        public int? Level => UpdateFields.GetValue<GameObjectField, int?>(GameObjectField.GAMEOBJECT_LEVEL);
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/ObjectData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/ObjectData.cs
@@ -14,10 +14,10 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
             Object = obj;
         }
 
-        public int EntryID => UpdateFields.GetValue<ObjectField, int>(ObjectField.OBJECT_FIELD_ENTRY);
+        public int? EntryID => UpdateFields.GetValue<ObjectField, int>(ObjectField.OBJECT_FIELD_ENTRY);
 
-        public uint DynamicFlags => UpdateFields.GetValue<ObjectField, uint>(ObjectField.OBJECT_DYNAMIC_FLAGS);
+        public uint? DynamicFlags => UpdateFields.GetValue<ObjectField, uint>(ObjectField.OBJECT_DYNAMIC_FLAGS);
 
-        public float Scale => UpdateFields.GetValue<ObjectField, float?>(ObjectField.OBJECT_FIELD_SCALE_X).GetValueOrDefault(1.0f);
+        public float? Scale => UpdateFields.GetValue<ObjectField, float?>(ObjectField.OBJECT_FIELD_SCALE_X).GetValueOrDefault(1.0f);
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/SceneObjectData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/SceneObjectData.cs
@@ -15,8 +15,8 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
             Object = obj;
         }
 
-        public int ScriptPackageID => UpdateFields.GetValue<SceneObjectField, int>(SceneObjectField.SCENEOBJECT_FIELD_SCRIPT_PACKAGE_ID);
+        public int? ScriptPackageID => UpdateFields.GetValue<SceneObjectField, int>(SceneObjectField.SCENEOBJECT_FIELD_SCRIPT_PACKAGE_ID);
 
-        public uint SceneType => UpdateFields.GetValue<SceneObjectField, uint>(SceneObjectField.SCENEOBJECT_FIELD_SCENE_TYPE);
+        public uint? SceneType => UpdateFields.GetValue<SceneObjectField, uint>(SceneObjectField.SCENEOBJECT_FIELD_SCENE_TYPE);
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/UnitData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/UnitData.cs
@@ -29,50 +29,57 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
             }
         }
 
-        public int DisplayID => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_DISPLAYID);
+        public int? DisplayID => UpdateFields.GetValue<UnitField, int?>(UnitField.UNIT_FIELD_DISPLAYID);
 
-        public uint[] NpcFlags
+        public uint?[] NpcFlags
         {
             get
             {
                 if (ClientVersion.AddedInVersion(ClientType.Legion))
-                    return UpdateFields.GetArray<UnitField, uint>(UnitField.UNIT_NPC_FLAGS, 2);
+                    return UpdateFields.GetArray<UnitField, uint?>(UnitField.UNIT_NPC_FLAGS, 2);
                 else
-                    return new uint[] { UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_NPC_FLAGS), 0 };
+                    return new uint?[] { UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_NPC_FLAGS), 0 };
             }
         }
 
+        public int?[] Resistances => null;
+        
         public WowGuid SummonedBy => GetGuidValue(UnitField.UNIT_FIELD_SUMMONEDBY);
 
         public WowGuid CreatedBy => GetGuidValue(UnitField.UNIT_FIELD_CREATEDBY);
 
-        public byte ClassId => (byte)((UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_BYTES_0).GetValueOrDefault((uint)Class.Warrior << 8) >> 8) & 0xFF);
+        public byte? ClassId => (byte)((UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_BYTES_0).GetValueOrDefault((uint)Class.Warrior << 8) >> 8) & 0xFF);
 
-        public byte Sex => (byte)(ClientVersion.AddedInVersion(ClientVersionBuild.V5_4_0_17359)
+        public byte? Sex => (byte)(ClientVersion.AddedInVersion(ClientVersionBuild.V5_4_0_17359)
                 ? ((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_0) >> 24) & 0xFF)
                 : ((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_0) >> 16) & 0xFF));
+        
+        public byte? Race => UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_BYTES_0).HasValue ?
+            (byte)(UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_0) & 0xFF) : null;
+        
+        public byte? DisplayPower => UpdateFields.GetValue<UnitField, byte?>(UnitField.UNIT_FIELD_DISPLAY_POWER);
+        
+        public long? Health => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_HEALTH);
 
-        public long Health => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_HEALTH);
+        public long? MaxHealth => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_MAXHEALTH);
 
-        public long MaxHealth => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_MAXHEALTH);
+        public int?[] Power => new int?[] { UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_POWER) };
 
-        public int[] Power => new int[] { UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_POWER) };
+        public int?[] MaxPower => new int?[] { UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_MAXPOWER) };
 
-        public int[] MaxPower => new int[] { UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_MAXPOWER) };
+        public int? Level => UpdateFields.GetValue<UnitField, int?>(UnitField.UNIT_FIELD_LEVEL).GetValueOrDefault(1);
 
-        public int Level => UpdateFields.GetValue<UnitField, int?>(UnitField.UNIT_FIELD_LEVEL).GetValueOrDefault(1);
-
-        public int ContentTuningID => ClientVersion.AddedInVersion(ClientType.BattleForAzeroth)
+        public int? ContentTuningID => ClientVersion.AddedInVersion(ClientType.BattleForAzeroth)
                 ? UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_CONTENT_TUNING_ID)
                 : UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_SANDBOX_SCALING_ID);
 
-        public int ScalingLevelMin => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_SCALING_LEVEL_MIN);
+        public int? ScalingLevelMin => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_SCALING_LEVEL_MIN);
 
-        public int ScalingLevelMax => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_SCALING_LEVEL_MAX);
+        public int? ScalingLevelMax => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_SCALING_LEVEL_MAX);
 
-        public int ScalingLevelDelta => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_SCALING_LEVEL_DELTA);
+        public int? ScalingLevelDelta => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_SCALING_LEVEL_DELTA);
 
-        public int FactionTemplate => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_FACTIONTEMPLATE);
+        public int? FactionTemplate => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_FACTIONTEMPLATE);
 
         public IVisibleItem[] VirtualItems
         {
@@ -99,52 +106,71 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
             }
         }
 
-        public uint Flags => UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_FLAGS);
+        public uint? Flags => UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_FLAGS);
 
-        public uint Flags2 => UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_FLAGS_2);
+        public uint? Flags2 => UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_FLAGS_2);
 
-        public uint Flags3 => UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_FLAGS_3);
+        public uint? Flags3 => UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_FLAGS_3);
 
-        public uint[] AttackRoundBaseTime => UpdateFields.GetArray<UnitField, uint?>(UnitField.UNIT_FIELD_BASEATTACKTIME, 2)
-            .Select(maybeAttackTime => maybeAttackTime.GetValueOrDefault(2000)).ToArray();
+        public uint?[] AttackRoundBaseTime => UpdateFields.GetArray<UnitField, uint?>(UnitField.UNIT_FIELD_BASEATTACKTIME, 2)
+            .Select(maybeAttackTime => (uint?)maybeAttackTime.GetValueOrDefault(2000)).ToArray();
 
-        public uint RangedAttackRoundBaseTime => UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_RANGEDATTACKTIME).GetValueOrDefault(2000);
+        public uint? RangedAttackRoundBaseTime => UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_RANGEDATTACKTIME).GetValueOrDefault(2000);
 
-        public float BoundingRadius => UpdateFields.GetValue<UnitField, float?>(UnitField.UNIT_FIELD_BOUNDINGRADIUS).GetValueOrDefault(0.306f);
+        public float? BoundingRadius => UpdateFields.GetValue<UnitField, float?>(UnitField.UNIT_FIELD_BOUNDINGRADIUS).GetValueOrDefault(0.306f);
 
-        public float CombatReach => UpdateFields.GetValue<UnitField, float?>(UnitField.UNIT_FIELD_COMBATREACH).GetValueOrDefault(1.5f);
+        public float? CombatReach => UpdateFields.GetValue<UnitField, float?>(UnitField.UNIT_FIELD_COMBATREACH).GetValueOrDefault(1.5f);
 
-        public int MountDisplayID => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_MOUNTDISPLAYID);
+        public int? MountDisplayID => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_MOUNTDISPLAYID);
 
-        public byte StandState => (byte)(UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_1) & 0xFF);
+        public byte? StandState => (byte)(UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_1) & 0xFF);
 
-        public byte PetTalentPoints => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_1) >> 8) & 0xFF);
+        public byte? PetTalentPoints => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_1) >> 8) & 0xFF);
 
-        public byte VisFlags => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_1) >> 16) & 0xFF);
+        public byte? VisFlags => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_1) >> 16) & 0xFF);
 
-        public byte AnimTier => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_1) >> 24) & 0xFF);
+        public byte? AnimTier => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_1) >> 24) & 0xFF);
 
-        public int CreatedBySpell => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_CREATED_BY_SPELL);
+        public int? CreatedBySpell => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_CREATED_BY_SPELL);
 
-        public int EmoteState => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_NPC_EMOTESTATE);
+        public int? EmoteState => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_NPC_EMOTESTATE);
 
-        public byte SheatheState => (byte)(UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_2) & 0xFF);
+        public byte? SheatheState => (byte)(UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_2) & 0xFF);
 
-        public byte PvpFlags => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_2) >> 8) & 0xFF);
+        public byte? PvpFlags => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_2) >> 8) & 0xFF);
 
-        public byte PetFlags => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_2) >> 16) & 0xFF);
+        public byte? PetFlags => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_2) >> 16) & 0xFF);
 
-        public byte ShapeshiftForm => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_2) >> 24) & 0xFF);
+        public byte? ShapeshiftForm => (byte)((UpdateFields.GetValue<UnitField, uint>(UnitField.UNIT_FIELD_BYTES_2) >> 24) & 0xFF);
 
-        public float HoverHeight => UpdateFields.GetValue<UnitField, float?>(UnitField.UNIT_FIELD_HOVERHEIGHT).GetValueOrDefault(1.0f);
+        public float? HoverHeight => UpdateFields.GetValue<UnitField, float?>(UnitField.UNIT_FIELD_HOVERHEIGHT).GetValueOrDefault(1.0f);
 
-        public int InteractSpellID => UpdateFields.GetValue<UnitField, int>(UnitField.UNIT_FIELD_INTERACT_SPELLID);
+        public int? InteractSpellID => UpdateFields.GetValue<UnitField, int?>(UnitField.UNIT_FIELD_INTERACT_SPELLID);
+        public uint? StateSpellVisualID => UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_STATE_SPELL_VISUAL_ID);
+        public uint? StateAnimID => UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_STATE_ANIM_ID);
+        public uint? StateAnimKitID => UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_STATE_ANIM_KIT_ID);
+        public WowGuid? Charm => GetGuidValue(UnitField.UNIT_FIELD_CHARM);
+        public WowGuid? Summon => GetGuidValue(UnitField.UNIT_FIELD_SUMMON);
+        public WowGuid? Critter => GetGuidValue(UnitField.UNIT_FIELD_CRITTER);
+        public WowGuid? CharmedBy => GetGuidValue(UnitField.UNIT_FIELD_CHARMEDBY);
+        public WowGuid? DemonCreator => GetGuidValue(UnitField.UNIT_FIELD_DEMON_CREATOR);
+        public WowGuid? LookAtControllerTarget => GetGuidValue(UnitField.UNIT_FIELD_LOOK_AT_CONTROLLER_TARGET);
+        public WowGuid? Target => GetGuidValue(UnitField.UNIT_FIELD_TARGET);
+        public int? EffectiveLevel => UpdateFields.GetValue<UnitField, int?>(UnitField.UNIT_FIELD_EFFECTIVE_LEVEL);
+        public uint? AuraState => UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_AURASTATE);
+        public float? DisplayScale => UpdateFields.GetValue<UnitField, float?>(UnitField.UNIT_FIELD_DISPLAY_SCALE);
+        public int? CreatureFamily => null;
+        public int? CreatureType => null;
+        public int? NativeDisplayID => UpdateFields.GetValue<UnitField, int?>(UnitField.UNIT_FIELD_NATIVEDISPLAYID);
+        public float? NativeXDisplayScale => UpdateFields.GetValue<UnitField, float?>(UnitField.UNIT_FIELD_NATIVE_X_DISPLAY_SCALE);
+        public int? BaseMana => UpdateFields.GetValue<UnitField, int?>(UnitField.UNIT_FIELD_BASE_MANA);
+        public int? BaseHealth => UpdateFields.GetValue<UnitField, int?>(UnitField.UNIT_FIELD_BASE_HEALTH);
 
         public class VisibleItem : IVisibleItem
         {
-            public int ItemID { get; set; }
-            public ushort ItemAppearanceModID { get; set; }
-            public ushort ItemVisual { get; set; }
+            public int? ItemID { get; set; }
+            public ushort? ItemAppearanceModID { get; set; }
+            public ushort? ItemVisual { get; set; }
         }
     }
 }

--- a/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/UnitData.cs
+++ b/WowPacketParser/Store/Objects/UpdateFields/LegacyImplementation/UnitData.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#nullable enable
+using System.Collections.Generic;
 using System.Linq;
 using WowPacketParser.Enums;
 using WowPacketParser.Misc;
@@ -44,9 +45,9 @@ namespace WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation
 
         public int?[] Resistances => null;
         
-        public WowGuid SummonedBy => GetGuidValue(UnitField.UNIT_FIELD_SUMMONEDBY);
+        public WowGuid? SummonedBy => GetGuidValue(UnitField.UNIT_FIELD_SUMMONEDBY);
 
-        public WowGuid CreatedBy => GetGuidValue(UnitField.UNIT_FIELD_CREATEDBY);
+        public WowGuid? CreatedBy => GetGuidValue(UnitField.UNIT_FIELD_CREATEDBY);
 
         public byte? ClassId => (byte)((UpdateFields.GetValue<UnitField, uint?>(UnitField.UNIT_FIELD_BYTES_0).GetValueOrDefault((uint)Class.Warrior << 8) >> 8) & 0xFF);
 

--- a/WowPacketParserModule.V1_13_2_31446/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V1_13_2_31446/Parsers/UpdateHandler.cs
@@ -57,8 +57,8 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues() {Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
                         break;
                     }
@@ -66,7 +66,7 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
                     case UpdateTypeCataclysm.CreateObject2:
                     {
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType() };
+                        var createObject = new CreateObject() { Guid = guid, Values = new() {Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -84,7 +84,7 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, createObject, guid, obj, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,

--- a/WowPacketParserModule.V2_5_1_38707/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V2_5_1_38707/Parsers/UpdateHandler.cs
@@ -51,8 +51,8 @@ namespace WowPacketParserModule.V2_5_1_38707.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues() {Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject { Guid = guid, Values = updateValues, Text = partWriter.Text });
                         break;
                     }
@@ -60,7 +60,7 @@ namespace WowPacketParserModule.V2_5_1_38707.Parsers
                     case UpdateTypeCataclysm.CreateObject2:
                     {
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType()};
+                        var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType()};
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -78,7 +78,7 @@ namespace WowPacketParserModule.V2_5_1_38707.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, guid, obj, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,

--- a/WowPacketParserModule.V4_3_4_15595/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V4_3_4_15595/Parsers/UpdateHandler.cs
@@ -32,8 +32,8 @@ namespace WowPacketParserModule.V4_3_4_15595.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues(){Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
                         break;
                     }
@@ -41,7 +41,7 @@ namespace WowPacketParserModule.V4_3_4_15595.Parsers
                     case UpdateTypeCataclysm.CreateObject2:
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType() };
+                        var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -62,7 +62,7 @@ namespace WowPacketParserModule.V4_3_4_15595.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock434(packet, guid, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
 
             // If this is the second time we see the same object (same guid,
             // same position) update its phasemask

--- a/WowPacketParserModule.V5_3_0_16981/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_3_0_16981/Parsers/UpdateHandler.cs
@@ -32,8 +32,8 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues() {Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
                         break;
                     }
@@ -41,7 +41,7 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
                     case UpdateTypeCataclysm.CreateObject2: // Might != CreateObject1 on Cata
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType() };
+                        var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -62,7 +62,7 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, guid, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,

--- a/WowPacketParserModule.V5_4_0_17359/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_0_17359/Parsers/UpdateHandler.cs
@@ -32,8 +32,8 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues(){Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
                         break;
                     }
@@ -41,7 +41,7 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
                     case UpdateTypeCataclysm.CreateObject2: // Might != CreateObject1 on Cata
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType()};
+                        var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType()};
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -62,7 +62,7 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, guid, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,

--- a/WowPacketParserModule.V5_4_1_17538/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_1_17538/Parsers/UpdateHandler.cs
@@ -32,8 +32,8 @@ namespace WowPacketParserModule.V5_4_1_17538.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues(){Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
                         break;
                     }
@@ -41,7 +41,7 @@ namespace WowPacketParserModule.V5_4_1_17538.Parsers
                     case UpdateTypeCataclysm.CreateObject2: // Might != CreateObject1 on Cata
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType() };
+                        var createObject = new CreateObject() { Guid = guid, Values = new() { Legacy = new() }, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -62,7 +62,7 @@ namespace WowPacketParserModule.V5_4_1_17538.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, guid, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,

--- a/WowPacketParserModule.V5_4_2_17658/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_2_17658/Parsers/UpdateHandler.cs
@@ -32,8 +32,8 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues(){Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
                         break;
                     }
@@ -41,7 +41,7 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
                     case UpdateTypeCataclysm.CreateObject2: // Might != CreateObject1 on Cata
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType() };
+                        var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -62,7 +62,7 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, guid, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,

--- a/WowPacketParserModule.V5_4_7_17898/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_7_17898/Parsers/UpdateHandler.cs
@@ -61,8 +61,8 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues(){Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
                         break;
                     }
@@ -70,7 +70,7 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
                     case UpdateTypeCataclysm.CreateObject2: // Might != CreateObject1 on Cata
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType() };
+                        var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -91,7 +91,7 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, guid, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,

--- a/WowPacketParserModule.V5_4_8_18291/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_8_18291/Parsers/UpdateHandler.cs
@@ -52,8 +52,8 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues(){Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{ Guid = guid, Values = updateValues, Text = partWriter.Text });
                         break;
                     }
@@ -61,7 +61,7 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
                     case UpdateTypeCataclysm.CreateObject2: // Might != CreateObject1 on Cata
                     {
                         var guid = packet.ReadPackedGuid("GUID", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType() };
+                        var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -82,7 +82,7 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, guid, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
@@ -421,7 +421,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                     WoWObject obj = Storage.Objects[guid].Item1;
                     if (obj.Type == ObjectType.Unit)
                     {
-                        int factionTemplateId = (obj as Unit).UnitData.FactionTemplate;
+                        int factionTemplateId = (obj as Unit).UnitData.FactionTemplate ?? 0;
                         int faction = 0;
 
                         if (factionTemplateId != 0 && DBC.FactionTemplate.ContainsKey(factionTemplateId))

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/UpdateHandler.cs
@@ -53,8 +53,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues(){Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text});
                         break;
                     }
@@ -62,7 +62,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                     case UpdateTypeCataclysm.CreateObject2: // Might != CreateObject1 on Cata
                     {
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType() };
+                        var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -78,7 +78,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, createObject, guid, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/UpdateHandler.cs
@@ -56,8 +56,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                     case UpdateTypeCataclysm.Values:
                     {
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
-                        var updateValues = new UpdateValues();
-                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues, guid, i);
+                        var updateValues = new UpdateValues(){Legacy = new()};
+                        CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text});
                         break;
                     }
@@ -65,7 +65,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                     case UpdateTypeCataclysm.CreateObject2:
                     {
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
-                        var createObject = new CreateObject() { Guid = guid, Values = new(), CreateType = type.ToCreateObjectType() };
+                        var createObject = new CreateObject() { Guid = guid, Values = new() {Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
                         updateObject.Created.Add(createObject);
@@ -82,7 +82,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             WoWObject obj = CoreParsers.UpdateHandler.CreateObject(objType, guid, map);
 
             obj.Movement = ReadMovementUpdateBlock(packet, createObject, guid, obj, index);
-            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values, objType, index);
+            obj.UpdateFields = CoreParsers.UpdateHandler.ReadValuesUpdateBlockOnCreate(packet, createObject.Values.Legacy, objType, index);
             obj.DynamicUpdateFields = CoreParsers.UpdateHandler.ReadDynamicValuesUpdateBlockOnCreate(packet, objType, index);
 
             // If this is the second time we see the same object (same guid,

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler810.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler810.cs
@@ -18,11 +18,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public override IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ObjectData;
-            if (data == null)
-                data = new ObjectData();
+            var data = new ObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);
@@ -224,11 +222,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public override IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemData;
-            if (data == null)
-                data = new ItemData();
+            var data = new ItemData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -401,11 +397,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public override IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ContainerData;
-            if (data == null)
-                data = new ContainerData();
+            var data = new ContainerData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -446,11 +440,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteEmpoweredItemData;
-            if (data == null)
-                data = new AzeriteEmpoweredItemData();
+            var data = new AzeriteEmpoweredItemData();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -487,11 +479,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteItemData;
-            if (data == null)
-                data = new AzeriteItemData();
+            var data = new AzeriteItemData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(6);
             var changesMask = new BitArray(rawChangesMask);
@@ -791,11 +781,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitData;
-            if (data == null)
-                data = new UnitData();
+            var data = new UnitData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -1562,11 +1550,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public override IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as PlayerData;
-            if (data == null)
-                data = new PlayerData();
+            var data = new PlayerData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -2235,11 +2221,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerData;
-            if (data == null)
-                data = new ActivePlayerData();
+            var data = new ActivePlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[46];
             var rawMaskMask = new int[2];
@@ -3002,11 +2986,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as GameObjectData;
-            if (data == null)
-                data = new GameObjectData();
+            var data = new GameObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(20);
             var changesMask = new BitArray(rawChangesMask);
@@ -3127,11 +3109,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as DynamicObjectData;
-            if (data == null)
-                data = new DynamicObjectData();
+            var data = new DynamicObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
             var changesMask = new BitArray(rawChangesMask);
@@ -3196,11 +3176,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            var data = existingData as CorpseData;
-            if (data == null)
-                data = new CorpseData();
+            var data = new CorpseData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -3372,11 +3350,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AreaTriggerData;
-            if (data == null)
-                data = new AreaTriggerData();
+            var data = new AreaTriggerData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(14);
             var changesMask = new BitArray(rawChangesMask);
@@ -3450,11 +3426,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as SceneObjectData;
-            if (data == null)
-                data = new SceneObjectData();
+            var data = new SceneObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -3557,11 +3531,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             return data;
         }
 
-        public override IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public override IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationData;
-            if (data == null)
-                data = new ConversationData();
+            var data = new ConversationData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler815.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler815.cs
@@ -18,11 +18,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public override IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ObjectData;
-            if (data == null)
-                data = new ObjectData();
+            var data = new ObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);
@@ -223,11 +221,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public override IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemData;
-            if (data == null)
-                data = new ItemData();
+            var data = new ItemData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -392,11 +388,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public override IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ContainerData;
-            if (data == null)
-                data = new ContainerData();
+            var data = new ContainerData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -437,11 +431,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteEmpoweredItemData;
-            if (data == null)
-                data = new AzeriteEmpoweredItemData();
+            var data = new AzeriteEmpoweredItemData();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -478,11 +470,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteItemData;
-            if (data == null)
-                data = new AzeriteItemData();
+            var data = new AzeriteItemData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(6);
             var changesMask = new BitArray(rawChangesMask);
@@ -786,11 +776,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitData;
-            if (data == null)
-                data = new UnitData();
+            var data = new UnitData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -1565,11 +1553,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public override IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as PlayerData;
-            if (data == null)
-                data = new PlayerData();
+            var data = new PlayerData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -2247,11 +2233,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerData;
-            if (data == null)
-                data = new ActivePlayerData();
+            var data = new ActivePlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[46];
             var rawMaskMask = new int[2];
@@ -3028,11 +3012,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as GameObjectData;
-            if (data == null)
-                data = new GameObjectData();
+            var data = new GameObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(20);
             var changesMask = new BitArray(rawChangesMask);
@@ -3153,11 +3135,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as DynamicObjectData;
-            if (data == null)
-                data = new DynamicObjectData();
+            var data = new DynamicObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
             var changesMask = new BitArray(rawChangesMask);
@@ -3222,11 +3202,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            var data = existingData as CorpseData;
-            if (data == null)
-                data = new CorpseData();
+            var data = new CorpseData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -3398,11 +3376,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AreaTriggerData;
-            if (data == null)
-                data = new AreaTriggerData();
+            var data = new AreaTriggerData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(14);
             var changesMask = new BitArray(rawChangesMask);
@@ -3476,11 +3452,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as SceneObjectData;
-            if (data == null)
-                data = new SceneObjectData();
+            var data = new SceneObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -3586,11 +3560,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             return data;
         }
 
-        public override IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public override IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationData;
-            if (data == null)
-                data = new ConversationData();
+            var data = new ConversationData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler820.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler820.cs
@@ -18,11 +18,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public override IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ObjectData;
-            if (data == null)
-                data = new ObjectData();
+            var data = new ObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);
@@ -222,11 +220,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public override IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemData;
-            if (data == null)
-                data = new ItemData();
+            var data = new ItemData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -391,11 +387,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public override IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ContainerData;
-            if (data == null)
-                data = new ContainerData();
+            var data = new ContainerData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -436,11 +430,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteEmpoweredItemData;
-            if (data == null)
-                data = new AzeriteEmpoweredItemData();
+            var data = new AzeriteEmpoweredItemData();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -561,11 +553,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteItemData;
-            if (data == null)
-                data = new AzeriteItemData();
+            var data = new AzeriteItemData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(9);
             var changesMask = new BitArray(rawChangesMask);
@@ -912,11 +902,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitData;
-            if (data == null)
-                data = new UnitData();
+            var data = new UnitData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -1691,11 +1679,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public override IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as PlayerData;
-            if (data == null)
-                data = new PlayerData();
+            var data = new PlayerData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -2369,11 +2355,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerData;
-            if (data == null)
-                data = new ActivePlayerData();
+            var data = new ActivePlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[47];
             var rawMaskMask = new int[2];
@@ -3150,11 +3134,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as GameObjectData;
-            if (data == null)
-                data = new GameObjectData();
+            var data = new GameObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(20);
             var changesMask = new BitArray(rawChangesMask);
@@ -3275,11 +3257,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as DynamicObjectData;
-            if (data == null)
-                data = new DynamicObjectData();
+            var data = new DynamicObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
             var changesMask = new BitArray(rawChangesMask);
@@ -3344,11 +3324,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            var data = existingData as CorpseData;
-            if (data == null)
-                data = new CorpseData();
+            var data = new CorpseData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -3520,11 +3498,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AreaTriggerData;
-            if (data == null)
-                data = new AreaTriggerData();
+            var data = new AreaTriggerData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(14);
             var changesMask = new BitArray(rawChangesMask);
@@ -3598,11 +3574,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as SceneObjectData;
-            if (data == null)
-                data = new SceneObjectData();
+            var data = new SceneObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -3706,11 +3680,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             return data;
         }
 
-        public override IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public override IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationData;
-            if (data == null)
-                data = new ConversationData();
+            var data = new ConversationData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler825.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler825.cs
@@ -18,11 +18,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public override IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ObjectData;
-            if (data == null)
-                data = new ObjectData();
+            var data = new ObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);
@@ -222,11 +220,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public override IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemData;
-            if (data == null)
-                data = new ItemData();
+            var data = new ItemData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -391,11 +387,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public override IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ContainerData;
-            if (data == null)
-                data = new ContainerData();
+            var data = new ContainerData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -436,11 +430,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteEmpoweredItemData;
-            if (data == null)
-                data = new AzeriteEmpoweredItemData();
+            var data = new AzeriteEmpoweredItemData();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -561,11 +553,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteItemData;
-            if (data == null)
-                data = new AzeriteItemData();
+            var data = new AzeriteItemData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(9);
             var changesMask = new BitArray(rawChangesMask);
@@ -912,11 +902,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitData;
-            if (data == null)
-                data = new UnitData();
+            var data = new UnitData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -1712,11 +1700,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public override IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as PlayerData;
-            if (data == null)
-                data = new PlayerData();
+            var data = new PlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
@@ -2524,11 +2510,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerData;
-            if (data == null)
-                data = new ActivePlayerData();
+            var data = new ActivePlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[47];
             var rawMaskMask = new int[2];
@@ -3349,11 +3333,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as GameObjectData;
-            if (data == null)
-                data = new GameObjectData();
+            var data = new GameObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(20);
             var changesMask = new BitArray(rawChangesMask);
@@ -3474,11 +3456,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as DynamicObjectData;
-            if (data == null)
-                data = new DynamicObjectData();
+            var data = new DynamicObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
             var changesMask = new BitArray(rawChangesMask);
@@ -3543,11 +3523,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            var data = existingData as CorpseData;
-            if (data == null)
-                data = new CorpseData();
+            var data = new CorpseData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -3719,11 +3697,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AreaTriggerData;
-            if (data == null)
-                data = new AreaTriggerData();
+            var data = new AreaTriggerData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(14);
             var changesMask = new BitArray(rawChangesMask);
@@ -3797,11 +3773,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as SceneObjectData;
-            if (data == null)
-                data = new SceneObjectData();
+            var data = new SceneObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -3905,11 +3879,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             return data;
         }
 
-        public override IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public override IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationData;
-            if (data == null)
-                data = new ConversationData();
+            var data = new ConversationData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler830.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler830.cs
@@ -18,11 +18,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public override IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ObjectData;
-            if (data == null)
-                data = new ObjectData();
+            var data = new ObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);
@@ -222,11 +220,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public override IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemData;
-            if (data == null)
-                data = new ItemData();
+            var data = new ItemData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -391,11 +387,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public override IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ContainerData;
-            if (data == null)
-                data = new ContainerData();
+            var data = new ContainerData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -436,11 +430,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteEmpoweredItemData;
-            if (data == null)
-                data = new AzeriteEmpoweredItemData();
+            var data = new AzeriteEmpoweredItemData();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -561,11 +553,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteItemData;
-            if (data == null)
-                data = new AzeriteItemData();
+            var data = new AzeriteItemData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(9);
             var changesMask = new BitArray(rawChangesMask);
@@ -913,11 +903,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitData;
-            if (data == null)
-                data = new UnitData();
+            var data = new UnitData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -1717,11 +1705,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public override IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as PlayerData;
-            if (data == null)
-                data = new PlayerData();
+            var data = new PlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
@@ -2529,11 +2515,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerData;
-            if (data == null)
-                data = new ActivePlayerData();
+            var data = new ActivePlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[47];
             var rawMaskMask = new int[2];
@@ -3354,11 +3338,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as GameObjectData;
-            if (data == null)
-                data = new GameObjectData();
+            var data = new GameObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(20);
             var changesMask = new BitArray(rawChangesMask);
@@ -3479,11 +3461,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as DynamicObjectData;
-            if (data == null)
-                data = new DynamicObjectData();
+            var data = new DynamicObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
             var changesMask = new BitArray(rawChangesMask);
@@ -3548,11 +3528,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            var data = existingData as CorpseData;
-            if (data == null)
-                data = new CorpseData();
+            var data = new CorpseData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -3724,11 +3702,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AreaTriggerData;
-            if (data == null)
-                data = new AreaTriggerData();
+            var data = new AreaTriggerData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(14);
             var changesMask = new BitArray(rawChangesMask);
@@ -3802,11 +3778,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as SceneObjectData;
-            if (data == null)
-                data = new SceneObjectData();
+            var data = new SceneObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -3910,11 +3884,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             return data;
         }
 
-        public override IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public override IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationData;
-            if (data == null)
-                data = new ConversationData();
+            var data = new ConversationData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/AreaTriggerData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/AreaTriggerData.cs
@@ -9,14 +9,14 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
         public IScaleCurve ExtraScaleCurve { get; set; }
         public WowGuid Caster { get; set; }
         public uint Duration { get; set; }
-        public uint TimeToTarget { get; set; }
-        public uint TimeToTargetScale { get; set; }
+        public uint? TimeToTarget { get; set; }
+        public uint? TimeToTargetScale { get; set; }
         public uint TimeToTargetExtraScale { get; set; }
-        public int SpellID { get; set; }
+        public int? SpellID { get; set; }
         public int SpellForVisuals { get; set; }
         public int SpellXSpellVisualID { get; set; }
         public float BoundsRadius2D { get; set; }
-        public uint DecalPropertiesID { get; set; }
+        public uint? DecalPropertiesID { get; set; }
         public WowGuid CreatingEffectGUID { get; set; }
     }
 }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/ConversationData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/ConversationData.cs
@@ -5,7 +5,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
 {
     public class ConversationData : IConversationData
     {
-        public int LastLineEndTime { get; set; }
+        public int? LastLineEndTime { get; set; }
         public IConversationLine[] Lines { get; set; }
         public DynamicUpdateField<IConversationActor> Actors { get; } = new DynamicUpdateField<IConversationActor>();
     }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/GameObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/GameObjectData.cs
@@ -1,27 +1,28 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
 {
-    public class GameObjectData : IGameObjectData
+    public class GameObjectData : IMutableGameObjectData
     {
-        public int DisplayID { get; set; }
+        public int? DisplayID { get; set; }
         public uint SpellVisualID { get; set; }
         public uint StateSpellVisualID { get; set; }
         public uint SpawnTrackingStateAnimID { get; set; }
         public uint SpawnTrackingStateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid CreatedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
-        public Quaternion ParentRotation { get; set; }
-        public int FactionTemplate { get; set; }
-        public int Level { get; set; }
-        public sbyte State { get; set; }
-        public sbyte TypeID { get; set; }
-        public byte ArtKit { get; set; }
-        public byte PercentHealth { get; set; }
+        public uint? Flags { get; set; }
+        public Quaternion? ParentRotation { get; set; }
+        public int? FactionTemplate { get; set; }
+        public int? Level { get; set; }
+        public sbyte? State { get; set; }
+        public sbyte? TypeID { get; set; }
+        public uint? ArtKit { get; set; }
+        public byte? PercentHealth { get; set; }
         public uint CustomParam { get; set; }
         public DynamicUpdateField<int> EnableDoodadSets { get; } = new DynamicUpdateField<int>();
     }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/ObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/ObjectData.cs
@@ -2,11 +2,11 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
 {
-    public class ObjectData : IObjectData
+    public class ObjectData : IMutableObjectData
     {
-        public int EntryID { get; set; }
-        public uint DynamicFlags { get; set; }
-        public float Scale { get; set; }
+        public int? EntryID { get; set; }
+        public uint? DynamicFlags { get; set; }
+        public float? Scale { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/SceneObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/SceneObjectData.cs
@@ -5,10 +5,10 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
 {
     public class SceneObjectData : ISceneObjectData
     {
-        public int ScriptPackageID { get; set; }
+        public int? ScriptPackageID { get; set; }
         public uint RndSeedVal { get; set; }
         public WowGuid CreatedBy { get; set; }
-        public uint SceneType { get; set; }
+        public uint? SceneType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/UnitData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/UnitData.cs
@@ -1,74 +1,75 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
 {
-    public class UnitData : IUnitData
+    public class UnitData : IMutableUnitData
     {
-        public int DisplayID { get; set; }
-        public uint[] NpcFlags { get; } = new uint[2];
-        public uint StateSpellVisualID { get; set; }
-        public uint StateAnimID { get; set; }
-        public uint StateAnimKitID { get; set; }
+        public int? DisplayID { get; set; }
+        public uint?[] NpcFlags { get; } = new uint?[2];
+        public uint? StateSpellVisualID { get; set; }
+        public uint? StateAnimID { get; set; }
+        public uint? StateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid Charm { get; set; }
-        public WowGuid Summon { get; set; }
-        public WowGuid Critter { get; set; }
-        public WowGuid CharmedBy { get; set; }
-        public WowGuid SummonedBy { get; set; }
-        public WowGuid CreatedBy { get; set; }
-        public WowGuid DemonCreator { get; set; }
-        public WowGuid LookAtControllerTarget { get; set; }
-        public WowGuid Target { get; set; }
+        public WowGuid? Charm { get; set; }
+        public WowGuid? Summon { get; set; }
+        public WowGuid? Critter { get; set; }
+        public WowGuid? CharmedBy { get; set; }
+        public WowGuid? SummonedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
+        public WowGuid? DemonCreator { get; set; }
+        public WowGuid? LookAtControllerTarget { get; set; }
+        public WowGuid? Target { get; set; }
         public WowGuid BattlePetCompanionGUID { get; set; }
         public ulong BattlePetDBID { get; set; }
         public IUnitChannel ChannelData { get; set; }
         public uint SummonedByHomeRealm { get; set; }
-        public byte Race { get; set; }
-        public byte ClassId { get; set; }
+        public byte? Race { get; set; }
+        public byte? ClassId { get; set; }
         public byte PlayerClassId { get; set; }
-        public byte Sex { get; set; }
-        public byte DisplayPower { get; set; }
+        public byte? Sex { get; set; }
+        public byte? DisplayPower { get; set; }
         public uint OverrideDisplayPowerID { get; set; }
-        public long Health { get; set; }
-        public int[] Power { get; } = new int[6];
-        public int[] MaxPower { get; } = new int[6];
+        public long? Health { get; set; }
+        public int?[] Power { get; } = new int?[6];
+        public int?[] MaxPower { get; } = new int?[6];
         public float[] PowerRegenFlatModifier { get; } = new float[6];
         public float[] PowerRegenInterruptedFlatModifier { get; } = new float[6];
-        public long MaxHealth { get; set; }
-        public int Level { get; set; }
-        public int EffectiveLevel { get; set; }
-        public int ContentTuningID { get; set; }
-        public int ScalingLevelMin { get; set; }
-        public int ScalingLevelMax { get; set; }
-        public int ScalingLevelDelta { get; set; }
+        public long? MaxHealth { get; set; }
+        public int? Level { get; set; }
+        public int? EffectiveLevel { get; set; }
+        public int? ContentTuningID { get; set; }
+        public int? ScalingLevelMin { get; set; }
+        public int? ScalingLevelMax { get; set; }
+        public int? ScalingLevelDelta { get; set; }
         public int ScalingFactionGroup { get; set; }
         public int ScalingHealthItemLevelCurveID { get; set; }
         public int ScalingDamageItemLevelCurveID { get; set; }
-        public int FactionTemplate { get; set; }
+        public int? FactionTemplate { get; set; }
         public IVisibleItem[] VirtualItems { get; } = new IVisibleItem[3];
-        public uint Flags { get; set; }
-        public uint Flags2 { get; set; }
-        public uint Flags3 { get; set; }
-        public uint AuraState { get; set; }
-        public uint[] AttackRoundBaseTime { get; } = new uint[2];
-        public uint RangedAttackRoundBaseTime { get; set; }
-        public float BoundingRadius { get; set; }
-        public float CombatReach { get; set; }
-        public float DisplayScale { get; set; }
-        public int NativeDisplayID { get; set; }
-        public float NativeXDisplayScale { get; set; }
-        public int MountDisplayID { get; set; }
+        public uint? Flags { get; set; }
+        public uint? Flags2 { get; set; }
+        public uint? Flags3 { get; set; }
+        public uint? AuraState { get; set; }
+        public uint?[] AttackRoundBaseTime { get; } = new uint?[2];
+        public uint? RangedAttackRoundBaseTime { get; set; }
+        public float? BoundingRadius { get; set; }
+        public float? CombatReach { get; set; }
+        public float? DisplayScale { get; set; }
+        public int? NativeDisplayID { get; set; }
+        public float? NativeXDisplayScale { get; set; }
+        public int? MountDisplayID { get; set; }
         public int CosmeticMountDisplayID { get; set; }
         public float MinDamage { get; set; }
         public float MaxDamage { get; set; }
         public float MinOffHandDamage { get; set; }
         public float MaxOffHandDamage { get; set; }
-        public byte StandState { get; set; }
-        public byte PetTalentPoints { get; set; }
-        public byte VisFlags { get; set; }
-        public byte AnimTier { get; set; }
+        public byte? StandState { get; set; }
+        public byte? PetTalentPoints { get; set; }
+        public byte? VisFlags { get; set; }
+        public byte? AnimTier { get; set; }
         public uint PetNumber { get; set; }
         public uint PetNameTimestamp { get; set; }
         public uint PetExperience { get; set; }
@@ -79,21 +80,21 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
         public float ModRangedHaste { get; set; }
         public float ModHasteRegen { get; set; }
         public float ModTimeRate { get; set; }
-        public int CreatedBySpell { get; set; }
-        public int EmoteState { get; set; }
+        public int? CreatedBySpell { get; set; }
+        public int? EmoteState { get; set; }
         public int[] Stats { get; } = new int[4];
         public int[] StatPosBuff { get; } = new int[4];
         public int[] StatNegBuff { get; } = new int[4];
-        public int[] Resistances { get; } = new int[7];
+        public int?[] Resistances { get; } = new int?[7];
         public int[] BonusResistanceMods { get; } = new int[7];
         public int[] PowerCostModifier { get; } = new int[7];
         public float[] PowerCostMultiplier { get; } = new float[7];
-        public int BaseMana { get; set; }
-        public int BaseHealth { get; set; }
-        public byte SheatheState { get; set; }
-        public byte PvpFlags { get; set; }
-        public byte PetFlags { get; set; }
-        public byte ShapeshiftForm { get; set; }
+        public int? BaseMana { get; set; }
+        public int? BaseHealth { get; set; }
+        public byte? SheatheState { get; set; }
+        public byte? PvpFlags { get; set; }
+        public byte? PetFlags { get; set; }
+        public byte? ShapeshiftForm { get; set; }
         public int AttackPower { get; set; }
         public int AttackPowerModPos { get; set; }
         public int AttackPowerModNeg { get; set; }
@@ -111,13 +112,13 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
         public float MaxRangedDamage { get; set; }
         public float ManaCostModifierModifier { get; set; }
         public float MaxHealthModifier { get; set; }
-        public float HoverHeight { get; set; }
+        public float? HoverHeight { get; set; }
         public int MinItemLevelCutoff { get; set; }
         public int MinItemLevel { get; set; }
         public int MaxItemLevel { get; set; }
         public int WildBattlePetLevel { get; set; }
         public uint BattlePetCompanionNameTimestamp { get; set; }
-        public int InteractSpellID { get; set; }
+        public int? InteractSpellID { get; set; }
         public int ScaleDuration { get; set; }
         public int SpellOverrideNameID { get; set; }
         public int LooksLikeMountID { get; set; }
@@ -127,6 +128,8 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
         public DynamicUpdateField<IPassiveSpellHistory> PassiveSpells { get; } = new DynamicUpdateField<IPassiveSpellHistory>();
         public DynamicUpdateField<int> WorldEffects { get; } = new DynamicUpdateField<int>();
         public DynamicUpdateField<WowGuid> ChannelObjects { get; } = new DynamicUpdateField<WowGuid>();
+        public int? CreatureFamily { get; set; }
+        public int? CreatureType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/VisibleItem.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_0_28724/VisibleItem.cs
@@ -4,9 +4,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
 {
     public class VisibleItem : IVisibleItem
     {
-        public int ItemID { get; set; }
-        public ushort ItemAppearanceModID { get; set; }
-        public ushort ItemVisual { get; set; }
+        public int? ItemID { get; set; }
+        public ushort? ItemAppearanceModID { get; set; }
+        public ushort? ItemVisual { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/AreaTriggerData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/AreaTriggerData.cs
@@ -9,14 +9,14 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
         public IScaleCurve ExtraScaleCurve { get; set; }
         public WowGuid Caster { get; set; }
         public uint Duration { get; set; }
-        public uint TimeToTarget { get; set; }
-        public uint TimeToTargetScale { get; set; }
+        public uint? TimeToTarget { get; set; }
+        public uint? TimeToTargetScale { get; set; }
         public uint TimeToTargetExtraScale { get; set; }
-        public int SpellID { get; set; }
+        public int? SpellID { get; set; }
         public int SpellForVisuals { get; set; }
         public int SpellXSpellVisualID { get; set; }
         public float BoundsRadius2D { get; set; }
-        public uint DecalPropertiesID { get; set; }
+        public uint? DecalPropertiesID { get; set; }
         public WowGuid CreatingEffectGUID { get; set; }
     }
 }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/ConversationData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/ConversationData.cs
@@ -5,7 +5,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
 {
     public class ConversationData : IConversationData
     {
-        public int LastLineEndTime { get; set; }
+        public int? LastLineEndTime { get; set; }
         public uint Progress { get; set; }
         public IConversationLine[] Lines { get; set; }
         public DynamicUpdateField<IConversationActor> Actors { get; } = new DynamicUpdateField<IConversationActor>();

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/GameObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/GameObjectData.cs
@@ -1,27 +1,28 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
 {
-    public class GameObjectData : IGameObjectData
+    public class GameObjectData : IMutableGameObjectData
     {
-        public int DisplayID { get; set; }
+        public int? DisplayID { get; set; }
         public uint SpellVisualID { get; set; }
         public uint StateSpellVisualID { get; set; }
         public uint SpawnTrackingStateAnimID { get; set; }
         public uint SpawnTrackingStateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid CreatedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
-        public Quaternion ParentRotation { get; set; }
-        public int FactionTemplate { get; set; }
-        public int Level { get; set; }
-        public sbyte State { get; set; }
-        public sbyte TypeID { get; set; }
-        public byte ArtKit { get; set; }
-        public byte PercentHealth { get; set; }
+        public uint? Flags { get; set; }
+        public Quaternion? ParentRotation { get; set; }
+        public int? FactionTemplate { get; set; }
+        public int? Level { get; set; }
+        public sbyte? State { get; set; }
+        public sbyte? TypeID { get; set; }
+        public uint? ArtKit { get; set; }
+        public byte? PercentHealth { get; set; }
         public uint CustomParam { get; set; }
         public DynamicUpdateField<int> EnableDoodadSets { get; } = new DynamicUpdateField<int>();
     }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/ObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/ObjectData.cs
@@ -2,11 +2,11 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
 {
-    public class ObjectData : IObjectData
+    public class ObjectData : IMutableObjectData
     {
-        public int EntryID { get; set; }
-        public uint DynamicFlags { get; set; }
-        public float Scale { get; set; }
+        public int? EntryID { get; set; }
+        public uint? DynamicFlags { get; set; }
+        public float? Scale { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/SceneObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/SceneObjectData.cs
@@ -5,10 +5,10 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
 {
     public class SceneObjectData : ISceneObjectData
     {
-        public int ScriptPackageID { get; set; }
+        public int? ScriptPackageID { get; set; }
         public uint RndSeedVal { get; set; }
         public WowGuid CreatedBy { get; set; }
-        public uint SceneType { get; set; }
+        public uint? SceneType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/UnitData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/UnitData.cs
@@ -1,74 +1,75 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
 {
-    public class UnitData : IUnitData
+    public class UnitData : IMutableUnitData
     {
-        public int DisplayID { get; set; }
-        public uint[] NpcFlags { get; } = new uint[2];
-        public uint StateSpellVisualID { get; set; }
-        public uint StateAnimID { get; set; }
-        public uint StateAnimKitID { get; set; }
+        public int? DisplayID { get; set; }
+        public uint?[] NpcFlags { get; } = new uint?[2];
+        public uint? StateSpellVisualID { get; set; }
+        public uint? StateAnimID { get; set; }
+        public uint? StateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid Charm { get; set; }
-        public WowGuid Summon { get; set; }
-        public WowGuid Critter { get; set; }
-        public WowGuid CharmedBy { get; set; }
-        public WowGuid SummonedBy { get; set; }
-        public WowGuid CreatedBy { get; set; }
-        public WowGuid DemonCreator { get; set; }
-        public WowGuid LookAtControllerTarget { get; set; }
-        public WowGuid Target { get; set; }
+        public WowGuid? Charm { get; set; }
+        public WowGuid? Summon { get; set; }
+        public WowGuid? Critter { get; set; }
+        public WowGuid? CharmedBy { get; set; }
+        public WowGuid? SummonedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
+        public WowGuid? DemonCreator { get; set; }
+        public WowGuid? LookAtControllerTarget { get; set; }
+        public WowGuid? Target { get; set; }
         public WowGuid BattlePetCompanionGUID { get; set; }
         public ulong BattlePetDBID { get; set; }
         public IUnitChannel ChannelData { get; set; }
         public uint SummonedByHomeRealm { get; set; }
-        public byte Race { get; set; }
-        public byte ClassId { get; set; }
+        public byte? Race { get; set; }
+        public byte? ClassId { get; set; }
         public byte PlayerClassId { get; set; }
-        public byte Sex { get; set; }
-        public byte DisplayPower { get; set; }
+        public byte? Sex { get; set; }
+        public byte? DisplayPower { get; set; }
         public uint OverrideDisplayPowerID { get; set; }
-        public long Health { get; set; }
-        public int[] Power { get; } = new int[6];
-        public int[] MaxPower { get; } = new int[6];
+        public long? Health { get; set; }
+        public int?[] Power { get; } = new int?[6];
+        public int?[] MaxPower { get; } = new int?[6];
         public float[] PowerRegenFlatModifier { get; } = new float[6];
         public float[] PowerRegenInterruptedFlatModifier { get; } = new float[6];
-        public long MaxHealth { get; set; }
-        public int Level { get; set; }
-        public int EffectiveLevel { get; set; }
-        public int ContentTuningID { get; set; }
-        public int ScalingLevelMin { get; set; }
-        public int ScalingLevelMax { get; set; }
-        public int ScalingLevelDelta { get; set; }
+        public long? MaxHealth { get; set; }
+        public int? Level { get; set; }
+        public int? EffectiveLevel { get; set; }
+        public int? ContentTuningID { get; set; }
+        public int? ScalingLevelMin { get; set; }
+        public int? ScalingLevelMax { get; set; }
+        public int? ScalingLevelDelta { get; set; }
         public int ScalingFactionGroup { get; set; }
         public int ScalingHealthItemLevelCurveID { get; set; }
         public int ScalingDamageItemLevelCurveID { get; set; }
-        public int FactionTemplate { get; set; }
+        public int? FactionTemplate { get; set; }
         public IVisibleItem[] VirtualItems { get; } = new IVisibleItem[3];
-        public uint Flags { get; set; }
-        public uint Flags2 { get; set; }
-        public uint Flags3 { get; set; }
-        public uint AuraState { get; set; }
-        public uint[] AttackRoundBaseTime { get; } = new uint[2];
-        public uint RangedAttackRoundBaseTime { get; set; }
-        public float BoundingRadius { get; set; }
-        public float CombatReach { get; set; }
-        public float DisplayScale { get; set; }
-        public int NativeDisplayID { get; set; }
-        public float NativeXDisplayScale { get; set; }
-        public int MountDisplayID { get; set; }
+        public uint? Flags { get; set; }
+        public uint? Flags2 { get; set; }
+        public uint? Flags3 { get; set; }
+        public uint? AuraState { get; set; }
+        public uint?[] AttackRoundBaseTime { get; } = new uint?[2];
+        public uint? RangedAttackRoundBaseTime { get; set; }
+        public float? BoundingRadius { get; set; }
+        public float? CombatReach { get; set; }
+        public float? DisplayScale { get; set; }
+        public int? NativeDisplayID { get; set; }
+        public float? NativeXDisplayScale { get; set; }
+        public int? MountDisplayID { get; set; }
         public int CosmeticMountDisplayID { get; set; }
         public float MinDamage { get; set; }
         public float MaxDamage { get; set; }
         public float MinOffHandDamage { get; set; }
         public float MaxOffHandDamage { get; set; }
-        public byte StandState { get; set; }
-        public byte PetTalentPoints { get; set; }
-        public byte VisFlags { get; set; }
-        public byte AnimTier { get; set; }
+        public byte? StandState { get; set; }
+        public byte? PetTalentPoints { get; set; }
+        public byte? VisFlags { get; set; }
+        public byte? AnimTier { get; set; }
         public uint PetNumber { get; set; }
         public uint PetNameTimestamp { get; set; }
         public uint PetExperience { get; set; }
@@ -79,21 +80,21 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
         public float ModRangedHaste { get; set; }
         public float ModHasteRegen { get; set; }
         public float ModTimeRate { get; set; }
-        public int CreatedBySpell { get; set; }
-        public int EmoteState { get; set; }
+        public int? CreatedBySpell { get; set; }
+        public int? EmoteState { get; set; }
         public int[] Stats { get; } = new int[4];
         public int[] StatPosBuff { get; } = new int[4];
         public int[] StatNegBuff { get; } = new int[4];
-        public int[] Resistances { get; } = new int[7];
+        public int?[] Resistances { get; } = new int?[7];
         public int[] BonusResistanceMods { get; } = new int[7];
         public int[] PowerCostModifier { get; } = new int[7];
         public float[] PowerCostMultiplier { get; } = new float[7];
-        public int BaseMana { get; set; }
-        public int BaseHealth { get; set; }
-        public byte SheatheState { get; set; }
-        public byte PvpFlags { get; set; }
-        public byte PetFlags { get; set; }
-        public byte ShapeshiftForm { get; set; }
+        public int? BaseMana { get; set; }
+        public int? BaseHealth { get; set; }
+        public byte? SheatheState { get; set; }
+        public byte? PvpFlags { get; set; }
+        public byte? PetFlags { get; set; }
+        public byte? ShapeshiftForm { get; set; }
         public int AttackPower { get; set; }
         public int AttackPowerModPos { get; set; }
         public int AttackPowerModNeg { get; set; }
@@ -111,14 +112,14 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
         public float MaxRangedDamage { get; set; }
         public float ManaCostModifierModifier { get; set; }
         public float MaxHealthModifier { get; set; }
-        public float HoverHeight { get; set; }
+        public float? HoverHeight { get; set; }
         public int MinItemLevelCutoff { get; set; }
         public int MinItemLevel { get; set; }
         public int MaxItemLevel { get; set; }
         public int AzeriteItemLevel { get; set; }
         public int WildBattlePetLevel { get; set; }
         public uint BattlePetCompanionNameTimestamp { get; set; }
-        public int InteractSpellID { get; set; }
+        public int? InteractSpellID { get; set; }
         public int ScaleDuration { get; set; }
         public int SpellOverrideNameID { get; set; }
         public int LooksLikeMountID { get; set; }
@@ -129,6 +130,8 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
         public DynamicUpdateField<IPassiveSpellHistory> PassiveSpells { get; } = new DynamicUpdateField<IPassiveSpellHistory>();
         public DynamicUpdateField<int> WorldEffects { get; } = new DynamicUpdateField<int>();
         public DynamicUpdateField<WowGuid> ChannelObjects { get; } = new DynamicUpdateField<WowGuid>();
+        public int? CreatureFamily { get; set; }
+        public int? CreatureType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/VisibleItem.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_1_5_29683/VisibleItem.cs
@@ -4,9 +4,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
 {
     public class VisibleItem : IVisibleItem
     {
-        public int ItemID { get; set; }
-        public ushort ItemAppearanceModID { get; set; }
-        public ushort ItemVisual { get; set; }
+        public int? ItemID { get; set; }
+        public ushort? ItemAppearanceModID { get; set; }
+        public ushort? ItemVisual { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/AreaTriggerData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/AreaTriggerData.cs
@@ -9,14 +9,14 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
         public IScaleCurve ExtraScaleCurve { get; set; }
         public WowGuid Caster { get; set; }
         public uint Duration { get; set; }
-        public uint TimeToTarget { get; set; }
-        public uint TimeToTargetScale { get; set; }
+        public uint? TimeToTarget { get; set; }
+        public uint? TimeToTargetScale { get; set; }
         public uint TimeToTargetExtraScale { get; set; }
-        public int SpellID { get; set; }
+        public int? SpellID { get; set; }
         public int SpellForVisuals { get; set; }
         public int SpellXSpellVisualID { get; set; }
         public float BoundsRadius2D { get; set; }
-        public uint DecalPropertiesID { get; set; }
+        public uint? DecalPropertiesID { get; set; }
         public WowGuid CreatingEffectGUID { get; set; }
     }
 }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/ConversationData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/ConversationData.cs
@@ -5,7 +5,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
 {
     public class ConversationData : IConversationData
     {
-        public int LastLineEndTime { get; set; }
+        public int? LastLineEndTime { get; set; }
         public uint Progress { get; set; }
         public IConversationLine[] Lines { get; set; }
         public DynamicUpdateField<IConversationActor> Actors { get; } = new DynamicUpdateField<IConversationActor>();

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/GameObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/GameObjectData.cs
@@ -1,27 +1,28 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
 {
-    public class GameObjectData : IGameObjectData
+    public class GameObjectData : IMutableGameObjectData
     {
-        public int DisplayID { get; set; }
+        public int? DisplayID { get; set; }
         public uint SpellVisualID { get; set; }
         public uint StateSpellVisualID { get; set; }
         public uint SpawnTrackingStateAnimID { get; set; }
         public uint SpawnTrackingStateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid CreatedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
-        public Quaternion ParentRotation { get; set; }
-        public int FactionTemplate { get; set; }
-        public int Level { get; set; }
-        public sbyte State { get; set; }
-        public sbyte TypeID { get; set; }
-        public byte PercentHealth { get; set; }
-        public uint ArtKit { get; set; }
+        public uint? Flags { get; set; }
+        public Quaternion? ParentRotation { get; set; }
+        public int? FactionTemplate { get; set; }
+        public int? Level { get; set; }
+        public sbyte? State { get; set; }
+        public sbyte? TypeID { get; set; }
+        public byte? PercentHealth { get; set; }
+        public uint? ArtKit { get; set; }
         public uint CustomParam { get; set; }
         public DynamicUpdateField<int> EnableDoodadSets { get; } = new DynamicUpdateField<int>();
     }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/ObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/ObjectData.cs
@@ -2,11 +2,11 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
 {
-    public class ObjectData : IObjectData
+    public class ObjectData : IMutableObjectData
     {
-        public int EntryID { get; set; }
-        public uint DynamicFlags { get; set; }
-        public float Scale { get; set; }
+        public int? EntryID { get; set; }
+        public uint? DynamicFlags { get; set; }
+        public float? Scale { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/SceneObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/SceneObjectData.cs
@@ -5,10 +5,10 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
 {
     public class SceneObjectData : ISceneObjectData
     {
-        public int ScriptPackageID { get; set; }
+        public int? ScriptPackageID { get; set; }
         public uint RndSeedVal { get; set; }
         public WowGuid CreatedBy { get; set; }
-        public uint SceneType { get; set; }
+        public uint? SceneType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/UnitData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/UnitData.cs
@@ -1,74 +1,75 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
 {
-    public class UnitData : IUnitData
+    public class UnitData : IMutableUnitData
     {
-        public int DisplayID { get; set; }
-        public uint[] NpcFlags { get; } = new uint[2];
-        public uint StateSpellVisualID { get; set; }
-        public uint StateAnimID { get; set; }
-        public uint StateAnimKitID { get; set; }
+        public int? DisplayID { get; set; }
+        public uint?[] NpcFlags { get; } = new uint?[2];
+        public uint? StateSpellVisualID { get; set; }
+        public uint? StateAnimID { get; set; }
+        public uint? StateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid Charm { get; set; }
-        public WowGuid Summon { get; set; }
-        public WowGuid Critter { get; set; }
-        public WowGuid CharmedBy { get; set; }
-        public WowGuid SummonedBy { get; set; }
-        public WowGuid CreatedBy { get; set; }
-        public WowGuid DemonCreator { get; set; }
-        public WowGuid LookAtControllerTarget { get; set; }
-        public WowGuid Target { get; set; }
+        public WowGuid? Charm { get; set; }
+        public WowGuid? Summon { get; set; }
+        public WowGuid? Critter { get; set; }
+        public WowGuid? CharmedBy { get; set; }
+        public WowGuid? SummonedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
+        public WowGuid? DemonCreator { get; set; }
+        public WowGuid? LookAtControllerTarget { get; set; }
+        public WowGuid? Target { get; set; }
         public WowGuid BattlePetCompanionGUID { get; set; }
         public ulong BattlePetDBID { get; set; }
         public IUnitChannel ChannelData { get; set; }
         public uint SummonedByHomeRealm { get; set; }
-        public byte Race { get; set; }
-        public byte ClassId { get; set; }
+        public byte? Race { get; set; }
+        public byte? ClassId { get; set; }
         public byte PlayerClassId { get; set; }
-        public byte Sex { get; set; }
-        public byte DisplayPower { get; set; }
+        public byte? Sex { get; set; }
+        public byte? DisplayPower { get; set; }
         public uint OverrideDisplayPowerID { get; set; }
-        public long Health { get; set; }
-        public int[] Power { get; } = new int[6];
-        public int[] MaxPower { get; } = new int[6];
+        public long? Health { get; set; }
+        public int?[] Power { get; } = new int?[6];
+        public int?[] MaxPower { get; } = new int?[6];
         public float[] PowerRegenFlatModifier { get; } = new float[6];
         public float[] PowerRegenInterruptedFlatModifier { get; } = new float[6];
-        public long MaxHealth { get; set; }
-        public int Level { get; set; }
-        public int EffectiveLevel { get; set; }
-        public int ContentTuningID { get; set; }
-        public int ScalingLevelMin { get; set; }
-        public int ScalingLevelMax { get; set; }
-        public int ScalingLevelDelta { get; set; }
+        public long? MaxHealth { get; set; }
+        public int? Level { get; set; }
+        public int? EffectiveLevel { get; set; }
+        public int? ContentTuningID { get; set; }
+        public int? ScalingLevelMin { get; set; }
+        public int? ScalingLevelMax { get; set; }
+        public int? ScalingLevelDelta { get; set; }
         public int ScalingFactionGroup { get; set; }
         public int ScalingHealthItemLevelCurveID { get; set; }
         public int ScalingDamageItemLevelCurveID { get; set; }
-        public int FactionTemplate { get; set; }
+        public int? FactionTemplate { get; set; }
         public IVisibleItem[] VirtualItems { get; } = new IVisibleItem[3];
-        public uint Flags { get; set; }
-        public uint Flags2 { get; set; }
-        public uint Flags3 { get; set; }
-        public uint AuraState { get; set; }
-        public uint[] AttackRoundBaseTime { get; } = new uint[2];
-        public uint RangedAttackRoundBaseTime { get; set; }
-        public float BoundingRadius { get; set; }
-        public float CombatReach { get; set; }
-        public float DisplayScale { get; set; }
-        public int NativeDisplayID { get; set; }
-        public float NativeXDisplayScale { get; set; }
-        public int MountDisplayID { get; set; }
+        public uint? Flags { get; set; }
+        public uint? Flags2 { get; set; }
+        public uint? Flags3 { get; set; }
+        public uint? AuraState { get; set; }
+        public uint?[] AttackRoundBaseTime { get; } = new uint?[2];
+        public uint? RangedAttackRoundBaseTime { get; set; }
+        public float? BoundingRadius { get; set; }
+        public float? CombatReach { get; set; }
+        public float? DisplayScale { get; set; }
+        public int? NativeDisplayID { get; set; }
+        public float? NativeXDisplayScale { get; set; }
+        public int? MountDisplayID { get; set; }
         public int CosmeticMountDisplayID { get; set; }
         public float MinDamage { get; set; }
         public float MaxDamage { get; set; }
         public float MinOffHandDamage { get; set; }
         public float MaxOffHandDamage { get; set; }
-        public byte StandState { get; set; }
-        public byte PetTalentPoints { get; set; }
-        public byte VisFlags { get; set; }
-        public byte AnimTier { get; set; }
+        public byte? StandState { get; set; }
+        public byte? PetTalentPoints { get; set; }
+        public byte? VisFlags { get; set; }
+        public byte? AnimTier { get; set; }
         public uint PetNumber { get; set; }
         public uint PetNameTimestamp { get; set; }
         public uint PetExperience { get; set; }
@@ -79,21 +80,21 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
         public float ModRangedHaste { get; set; }
         public float ModHasteRegen { get; set; }
         public float ModTimeRate { get; set; }
-        public int CreatedBySpell { get; set; }
-        public int EmoteState { get; set; }
+        public int? CreatedBySpell { get; set; }
+        public int? EmoteState { get; set; }
         public int[] Stats { get; } = new int[4];
         public int[] StatPosBuff { get; } = new int[4];
         public int[] StatNegBuff { get; } = new int[4];
-        public int[] Resistances { get; } = new int[7];
+        public int?[] Resistances { get; } = new int?[7];
         public int[] BonusResistanceMods { get; } = new int[7];
         public int[] PowerCostModifier { get; } = new int[7];
         public float[] PowerCostMultiplier { get; } = new float[7];
-        public int BaseMana { get; set; }
-        public int BaseHealth { get; set; }
-        public byte SheatheState { get; set; }
-        public byte PvpFlags { get; set; }
-        public byte PetFlags { get; set; }
-        public byte ShapeshiftForm { get; set; }
+        public int? BaseMana { get; set; }
+        public int? BaseHealth { get; set; }
+        public byte? SheatheState { get; set; }
+        public byte? PvpFlags { get; set; }
+        public byte? PetFlags { get; set; }
+        public byte? ShapeshiftForm { get; set; }
         public int AttackPower { get; set; }
         public int AttackPowerModPos { get; set; }
         public int AttackPowerModNeg { get; set; }
@@ -111,14 +112,14 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
         public float MaxRangedDamage { get; set; }
         public float ManaCostModifierModifier { get; set; }
         public float MaxHealthModifier { get; set; }
-        public float HoverHeight { get; set; }
+        public float? HoverHeight { get; set; }
         public int MinItemLevelCutoff { get; set; }
         public int MinItemLevel { get; set; }
         public int MaxItemLevel { get; set; }
         public int AzeriteItemLevel { get; set; }
         public int WildBattlePetLevel { get; set; }
         public uint BattlePetCompanionNameTimestamp { get; set; }
-        public int InteractSpellID { get; set; }
+        public int? InteractSpellID { get; set; }
         public int ScaleDuration { get; set; }
         public int SpellOverrideNameID { get; set; }
         public int LooksLikeMountID { get; set; }
@@ -129,6 +130,8 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
         public DynamicUpdateField<IPassiveSpellHistory> PassiveSpells { get; } = new DynamicUpdateField<IPassiveSpellHistory>();
         public DynamicUpdateField<int> WorldEffects { get; } = new DynamicUpdateField<int>();
         public DynamicUpdateField<WowGuid> ChannelObjects { get; } = new DynamicUpdateField<WowGuid>();
+        public int? CreatureFamily { get; set; }
+        public int? CreatureType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/VisibleItem.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_0_30898/VisibleItem.cs
@@ -4,9 +4,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
 {
     public class VisibleItem : IVisibleItem
     {
-        public int ItemID { get; set; }
-        public ushort ItemAppearanceModID { get; set; }
-        public ushort ItemVisual { get; set; }
+        public int? ItemID { get; set; }
+        public ushort? ItemAppearanceModID { get; set; }
+        public ushort? ItemVisual { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/AreaTriggerData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/AreaTriggerData.cs
@@ -9,14 +9,14 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
         public IScaleCurve ExtraScaleCurve { get; set; }
         public WowGuid Caster { get; set; }
         public uint Duration { get; set; }
-        public uint TimeToTarget { get; set; }
-        public uint TimeToTargetScale { get; set; }
+        public uint? TimeToTarget { get; set; }
+        public uint? TimeToTargetScale { get; set; }
         public uint TimeToTargetExtraScale { get; set; }
-        public int SpellID { get; set; }
+        public int? SpellID { get; set; }
         public int SpellForVisuals { get; set; }
         public int SpellXSpellVisualID { get; set; }
         public float BoundsRadius2D { get; set; }
-        public uint DecalPropertiesID { get; set; }
+        public uint? DecalPropertiesID { get; set; }
         public WowGuid CreatingEffectGUID { get; set; }
     }
 }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/ConversationData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/ConversationData.cs
@@ -5,7 +5,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
 {
     public class ConversationData : IConversationData
     {
-        public int LastLineEndTime { get; set; }
+        public int? LastLineEndTime { get; set; }
         public uint Progress { get; set; }
         public IConversationLine[] Lines { get; set; }
         public DynamicUpdateField<IConversationActor> Actors { get; } = new DynamicUpdateField<IConversationActor>();

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/GameObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/GameObjectData.cs
@@ -1,27 +1,28 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
 {
-    public class GameObjectData : IGameObjectData
+    public class GameObjectData : IMutableGameObjectData
     {
-        public int DisplayID { get; set; }
+        public int? DisplayID { get; set; }
         public uint SpellVisualID { get; set; }
         public uint StateSpellVisualID { get; set; }
         public uint SpawnTrackingStateAnimID { get; set; }
         public uint SpawnTrackingStateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid CreatedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
-        public Quaternion ParentRotation { get; set; }
-        public int FactionTemplate { get; set; }
-        public int Level { get; set; }
-        public sbyte State { get; set; }
-        public sbyte TypeID { get; set; }
-        public byte PercentHealth { get; set; }
-        public uint ArtKit { get; set; }
+        public uint? Flags { get; set; }
+        public Quaternion? ParentRotation { get; set; }
+        public int? FactionTemplate { get; set; }
+        public int? Level { get; set; }
+        public sbyte? State { get; set; }
+        public sbyte? TypeID { get; set; }
+        public byte? PercentHealth { get; set; }
+        public uint? ArtKit { get; set; }
         public uint CustomParam { get; set; }
         public DynamicUpdateField<int> EnableDoodadSets { get; } = new DynamicUpdateField<int>();
     }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/ObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/ObjectData.cs
@@ -2,11 +2,11 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
 {
-    public class ObjectData : IObjectData
+    public class ObjectData : IMutableObjectData
     {
-        public int EntryID { get; set; }
-        public uint DynamicFlags { get; set; }
-        public float Scale { get; set; }
+        public int? EntryID { get; set; }
+        public uint? DynamicFlags { get; set; }
+        public float? Scale { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/SceneObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/SceneObjectData.cs
@@ -5,10 +5,10 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
 {
     public class SceneObjectData : ISceneObjectData
     {
-        public int ScriptPackageID { get; set; }
+        public int? ScriptPackageID { get; set; }
         public uint RndSeedVal { get; set; }
         public WowGuid CreatedBy { get; set; }
-        public uint SceneType { get; set; }
+        public uint? SceneType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/UnitData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/UnitData.cs
@@ -1,74 +1,75 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
 {
-    public class UnitData : IUnitData
+    public class UnitData : IMutableUnitData
     {
-        public int DisplayID { get; set; }
-        public uint[] NpcFlags { get; } = new uint[2];
-        public uint StateSpellVisualID { get; set; }
-        public uint StateAnimID { get; set; }
-        public uint StateAnimKitID { get; set; }
+        public int? DisplayID { get; set; }
+        public uint?[] NpcFlags { get; } = new uint?[2];
+        public uint? StateSpellVisualID { get; set; }
+        public uint? StateAnimID { get; set; }
+        public uint? StateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid Charm { get; set; }
-        public WowGuid Summon { get; set; }
-        public WowGuid Critter { get; set; }
-        public WowGuid CharmedBy { get; set; }
-        public WowGuid SummonedBy { get; set; }
-        public WowGuid CreatedBy { get; set; }
-        public WowGuid DemonCreator { get; set; }
-        public WowGuid LookAtControllerTarget { get; set; }
-        public WowGuid Target { get; set; }
+        public WowGuid? Charm { get; set; }
+        public WowGuid? Summon { get; set; }
+        public WowGuid? Critter { get; set; }
+        public WowGuid? CharmedBy { get; set; }
+        public WowGuid? SummonedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
+        public WowGuid? DemonCreator { get; set; }
+        public WowGuid? LookAtControllerTarget { get; set; }
+        public WowGuid? Target { get; set; }
         public WowGuid BattlePetCompanionGUID { get; set; }
         public ulong BattlePetDBID { get; set; }
         public IUnitChannel ChannelData { get; set; }
         public uint SummonedByHomeRealm { get; set; }
-        public byte Race { get; set; }
-        public byte ClassId { get; set; }
+        public byte? Race { get; set; }
+        public byte? ClassId { get; set; }
         public byte PlayerClassId { get; set; }
-        public byte Sex { get; set; }
-        public byte DisplayPower { get; set; }
+        public byte? Sex { get; set; }
+        public byte? DisplayPower { get; set; }
         public uint OverrideDisplayPowerID { get; set; }
-        public long Health { get; set; }
-        public int[] Power { get; } = new int[6];
-        public int[] MaxPower { get; } = new int[6];
+        public long? Health { get; set; }
+        public int?[] Power { get; } = new int?[6];
+        public int?[] MaxPower { get; } = new int?[6];
         public float[] PowerRegenFlatModifier { get; } = new float[6];
         public float[] PowerRegenInterruptedFlatModifier { get; } = new float[6];
-        public long MaxHealth { get; set; }
-        public int Level { get; set; }
-        public int EffectiveLevel { get; set; }
-        public int ContentTuningID { get; set; }
-        public int ScalingLevelMin { get; set; }
-        public int ScalingLevelMax { get; set; }
-        public int ScalingLevelDelta { get; set; }
+        public long? MaxHealth { get; set; }
+        public int? Level { get; set; }
+        public int? EffectiveLevel { get; set; }
+        public int? ContentTuningID { get; set; }
+        public int? ScalingLevelMin { get; set; }
+        public int? ScalingLevelMax { get; set; }
+        public int? ScalingLevelDelta { get; set; }
         public int ScalingFactionGroup { get; set; }
         public int ScalingHealthItemLevelCurveID { get; set; }
         public int ScalingDamageItemLevelCurveID { get; set; }
-        public int FactionTemplate { get; set; }
+        public int? FactionTemplate { get; set; }
         public IVisibleItem[] VirtualItems { get; } = new IVisibleItem[3];
-        public uint Flags { get; set; }
-        public uint Flags2 { get; set; }
-        public uint Flags3 { get; set; }
-        public uint AuraState { get; set; }
-        public uint[] AttackRoundBaseTime { get; } = new uint[2];
-        public uint RangedAttackRoundBaseTime { get; set; }
-        public float BoundingRadius { get; set; }
-        public float CombatReach { get; set; }
-        public float DisplayScale { get; set; }
-        public int NativeDisplayID { get; set; }
-        public float NativeXDisplayScale { get; set; }
-        public int MountDisplayID { get; set; }
+        public uint? Flags { get; set; }
+        public uint? Flags2 { get; set; }
+        public uint? Flags3 { get; set; }
+        public uint? AuraState { get; set; }
+        public uint?[] AttackRoundBaseTime { get; } = new uint?[2];
+        public uint? RangedAttackRoundBaseTime { get; set; }
+        public float? BoundingRadius { get; set; }
+        public float? CombatReach { get; set; }
+        public float? DisplayScale { get; set; }
+        public int? NativeDisplayID { get; set; }
+        public float? NativeXDisplayScale { get; set; }
+        public int? MountDisplayID { get; set; }
         public int CosmeticMountDisplayID { get; set; }
         public float MinDamage { get; set; }
         public float MaxDamage { get; set; }
         public float MinOffHandDamage { get; set; }
         public float MaxOffHandDamage { get; set; }
-        public byte StandState { get; set; }
-        public byte PetTalentPoints { get; set; }
-        public byte VisFlags { get; set; }
-        public byte AnimTier { get; set; }
+        public byte? StandState { get; set; }
+        public byte? PetTalentPoints { get; set; }
+        public byte? VisFlags { get; set; }
+        public byte? AnimTier { get; set; }
         public uint PetNumber { get; set; }
         public uint PetNameTimestamp { get; set; }
         public uint PetExperience { get; set; }
@@ -79,21 +80,21 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
         public float ModRangedHaste { get; set; }
         public float ModHasteRegen { get; set; }
         public float ModTimeRate { get; set; }
-        public int CreatedBySpell { get; set; }
-        public int EmoteState { get; set; }
+        public int? CreatedBySpell { get; set; }
+        public int? EmoteState { get; set; }
         public int[] Stats { get; } = new int[4];
         public int[] StatPosBuff { get; } = new int[4];
         public int[] StatNegBuff { get; } = new int[4];
-        public int[] Resistances { get; } = new int[7];
+        public int?[] Resistances { get; } = new int?[7];
         public int[] BonusResistanceMods { get; } = new int[7];
         public int[] PowerCostModifier { get; } = new int[7];
         public float[] PowerCostMultiplier { get; } = new float[7];
-        public int BaseMana { get; set; }
-        public int BaseHealth { get; set; }
-        public byte SheatheState { get; set; }
-        public byte PvpFlags { get; set; }
-        public byte PetFlags { get; set; }
-        public byte ShapeshiftForm { get; set; }
+        public int? BaseMana { get; set; }
+        public int? BaseHealth { get; set; }
+        public byte? SheatheState { get; set; }
+        public byte? PvpFlags { get; set; }
+        public byte? PetFlags { get; set; }
+        public byte? ShapeshiftForm { get; set; }
         public int AttackPower { get; set; }
         public int AttackPowerModPos { get; set; }
         public int AttackPowerModNeg { get; set; }
@@ -111,14 +112,14 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
         public float MaxRangedDamage { get; set; }
         public float ManaCostModifierModifier { get; set; }
         public float MaxHealthModifier { get; set; }
-        public float HoverHeight { get; set; }
+        public float? HoverHeight { get; set; }
         public int MinItemLevelCutoff { get; set; }
         public int MinItemLevel { get; set; }
         public int MaxItemLevel { get; set; }
         public int AzeriteItemLevel { get; set; }
         public int WildBattlePetLevel { get; set; }
         public uint BattlePetCompanionNameTimestamp { get; set; }
-        public int InteractSpellID { get; set; }
+        public int? InteractSpellID { get; set; }
         public int ScaleDuration { get; set; }
         public int SpellOverrideNameID { get; set; }
         public int LooksLikeMountID { get; set; }
@@ -129,6 +130,8 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
         public DynamicUpdateField<IPassiveSpellHistory> PassiveSpells { get; } = new DynamicUpdateField<IPassiveSpellHistory>();
         public DynamicUpdateField<int> WorldEffects { get; } = new DynamicUpdateField<int>();
         public DynamicUpdateField<WowGuid> ChannelObjects { get; } = new DynamicUpdateField<WowGuid>();
+        public int? CreatureFamily { get; set; }
+        public int? CreatureType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/VisibleItem.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_2_5_31921/VisibleItem.cs
@@ -4,9 +4,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
 {
     public class VisibleItem : IVisibleItem
     {
-        public int ItemID { get; set; }
-        public ushort ItemAppearanceModID { get; set; }
-        public ushort ItemVisual { get; set; }
+        public int? ItemID { get; set; }
+        public ushort? ItemAppearanceModID { get; set; }
+        public ushort? ItemVisual { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/AreaTriggerData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/AreaTriggerData.cs
@@ -9,14 +9,14 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
         public IScaleCurve ExtraScaleCurve { get; set; }
         public WowGuid Caster { get; set; }
         public uint Duration { get; set; }
-        public uint TimeToTarget { get; set; }
-        public uint TimeToTargetScale { get; set; }
+        public uint? TimeToTarget { get; set; }
+        public uint? TimeToTargetScale { get; set; }
         public uint TimeToTargetExtraScale { get; set; }
-        public int SpellID { get; set; }
+        public int? SpellID { get; set; }
         public int SpellForVisuals { get; set; }
         public int SpellXSpellVisualID { get; set; }
         public float BoundsRadius2D { get; set; }
-        public uint DecalPropertiesID { get; set; }
+        public uint? DecalPropertiesID { get; set; }
         public WowGuid CreatingEffectGUID { get; set; }
     }
 }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/ConversationData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/ConversationData.cs
@@ -5,7 +5,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
 {
     public class ConversationData : IConversationData
     {
-        public int LastLineEndTime { get; set; }
+        public int? LastLineEndTime { get; set; }
         public uint Progress { get; set; }
         public IConversationLine[] Lines { get; set; }
         public DynamicUpdateField<IConversationActor> Actors { get; } = new DynamicUpdateField<IConversationActor>();

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/GameObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/GameObjectData.cs
@@ -1,27 +1,28 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
 {
-    public class GameObjectData : IGameObjectData
+    public class GameObjectData : IMutableGameObjectData
     {
-        public int DisplayID { get; set; }
+        public int? DisplayID { get; set; }
         public uint SpellVisualID { get; set; }
         public uint StateSpellVisualID { get; set; }
         public uint SpawnTrackingStateAnimID { get; set; }
         public uint SpawnTrackingStateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid CreatedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
-        public Quaternion ParentRotation { get; set; }
-        public int FactionTemplate { get; set; }
-        public int Level { get; set; }
-        public sbyte State { get; set; }
-        public sbyte TypeID { get; set; }
-        public byte PercentHealth { get; set; }
-        public uint ArtKit { get; set; }
+        public uint? Flags { get; set; }
+        public Quaternion? ParentRotation { get; set; }
+        public int? FactionTemplate { get; set; }
+        public int? Level { get; set; }
+        public sbyte? State { get; set; }
+        public sbyte? TypeID { get; set; }
+        public byte? PercentHealth { get; set; }
+        public uint? ArtKit { get; set; }
         public uint CustomParam { get; set; }
         public DynamicUpdateField<int> EnableDoodadSets { get; } = new DynamicUpdateField<int>();
     }

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/ObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/ObjectData.cs
@@ -2,11 +2,11 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
 {
-    public class ObjectData : IObjectData
+    public class ObjectData : IMutableObjectData
     {
-        public int EntryID { get; set; }
-        public uint DynamicFlags { get; set; }
-        public float Scale { get; set; }
+        public int? EntryID { get; set; }
+        public uint? DynamicFlags { get; set; }
+        public float? Scale { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/SceneObjectData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/SceneObjectData.cs
@@ -5,10 +5,10 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
 {
     public class SceneObjectData : ISceneObjectData
     {
-        public int ScriptPackageID { get; set; }
+        public int? ScriptPackageID { get; set; }
         public uint RndSeedVal { get; set; }
         public WowGuid CreatedBy { get; set; }
-        public uint SceneType { get; set; }
+        public uint? SceneType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/UnitData.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/UnitData.cs
@@ -1,74 +1,75 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
 {
-    public class UnitData : IUnitData
+    public class UnitData : IMutableUnitData
     {
-        public int DisplayID { get; set; }
-        public uint[] NpcFlags { get; } = new uint[2];
-        public uint StateSpellVisualID { get; set; }
-        public uint StateAnimID { get; set; }
-        public uint StateAnimKitID { get; set; }
+        public int? DisplayID { get; set; }
+        public uint?[] NpcFlags { get; } = new uint?[2];
+        public uint? StateSpellVisualID { get; set; }
+        public uint? StateAnimID { get; set; }
+        public uint? StateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid Charm { get; set; }
-        public WowGuid Summon { get; set; }
-        public WowGuid Critter { get; set; }
-        public WowGuid CharmedBy { get; set; }
-        public WowGuid SummonedBy { get; set; }
-        public WowGuid CreatedBy { get; set; }
-        public WowGuid DemonCreator { get; set; }
-        public WowGuid LookAtControllerTarget { get; set; }
-        public WowGuid Target { get; set; }
+        public WowGuid? Charm { get; set; }
+        public WowGuid? Summon { get; set; }
+        public WowGuid? Critter { get; set; }
+        public WowGuid? CharmedBy { get; set; }
+        public WowGuid? SummonedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
+        public WowGuid? DemonCreator { get; set; }
+        public WowGuid? LookAtControllerTarget { get; set; }
+        public WowGuid? Target { get; set; }
         public WowGuid BattlePetCompanionGUID { get; set; }
         public ulong BattlePetDBID { get; set; }
         public IUnitChannel ChannelData { get; set; }
         public uint SummonedByHomeRealm { get; set; }
-        public byte Race { get; set; }
-        public byte ClassId { get; set; }
+        public byte? Race { get; set; }
+        public byte? ClassId { get; set; }
         public byte PlayerClassId { get; set; }
-        public byte Sex { get; set; }
-        public byte DisplayPower { get; set; }
+        public byte? Sex { get; set; }
+        public byte? DisplayPower { get; set; }
         public uint OverrideDisplayPowerID { get; set; }
-        public long Health { get; set; }
-        public int[] Power { get; } = new int[6];
-        public int[] MaxPower { get; } = new int[6];
+        public long? Health { get; set; }
+        public int?[] Power { get; } = new int?[6];
+        public int?[] MaxPower { get; } = new int?[6];
         public float[] PowerRegenFlatModifier { get; } = new float[6];
         public float[] PowerRegenInterruptedFlatModifier { get; } = new float[6];
-        public long MaxHealth { get; set; }
-        public int Level { get; set; }
-        public int EffectiveLevel { get; set; }
-        public int ContentTuningID { get; set; }
-        public int ScalingLevelMin { get; set; }
-        public int ScalingLevelMax { get; set; }
-        public int ScalingLevelDelta { get; set; }
+        public long? MaxHealth { get; set; }
+        public int? Level { get; set; }
+        public int? EffectiveLevel { get; set; }
+        public int? ContentTuningID { get; set; }
+        public int? ScalingLevelMin { get; set; }
+        public int? ScalingLevelMax { get; set; }
+        public int? ScalingLevelDelta { get; set; }
         public int ScalingFactionGroup { get; set; }
         public int ScalingHealthItemLevelCurveID { get; set; }
         public int ScalingDamageItemLevelCurveID { get; set; }
-        public int FactionTemplate { get; set; }
+        public int? FactionTemplate { get; set; }
         public IVisibleItem[] VirtualItems { get; } = new IVisibleItem[3];
-        public uint Flags { get; set; }
-        public uint Flags2 { get; set; }
-        public uint Flags3 { get; set; }
-        public uint AuraState { get; set; }
-        public uint[] AttackRoundBaseTime { get; } = new uint[2];
-        public uint RangedAttackRoundBaseTime { get; set; }
-        public float BoundingRadius { get; set; }
-        public float CombatReach { get; set; }
-        public float DisplayScale { get; set; }
-        public int NativeDisplayID { get; set; }
-        public float NativeXDisplayScale { get; set; }
-        public int MountDisplayID { get; set; }
+        public uint? Flags { get; set; }
+        public uint? Flags2 { get; set; }
+        public uint? Flags3 { get; set; }
+        public uint? AuraState { get; set; }
+        public uint?[] AttackRoundBaseTime { get; } = new uint?[2];
+        public uint? RangedAttackRoundBaseTime { get; set; }
+        public float? BoundingRadius { get; set; }
+        public float? CombatReach { get; set; }
+        public float? DisplayScale { get; set; }
+        public int? NativeDisplayID { get; set; }
+        public float? NativeXDisplayScale { get; set; }
+        public int? MountDisplayID { get; set; }
         public int CosmeticMountDisplayID { get; set; }
         public float MinDamage { get; set; }
         public float MaxDamage { get; set; }
         public float MinOffHandDamage { get; set; }
         public float MaxOffHandDamage { get; set; }
-        public byte StandState { get; set; }
-        public byte PetTalentPoints { get; set; }
-        public byte VisFlags { get; set; }
-        public byte AnimTier { get; set; }
+        public byte? StandState { get; set; }
+        public byte? PetTalentPoints { get; set; }
+        public byte? VisFlags { get; set; }
+        public byte? AnimTier { get; set; }
         public uint PetNumber { get; set; }
         public uint PetNameTimestamp { get; set; }
         public uint PetExperience { get; set; }
@@ -79,21 +80,21 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
         public float ModRangedHaste { get; set; }
         public float ModHasteRegen { get; set; }
         public float ModTimeRate { get; set; }
-        public int CreatedBySpell { get; set; }
-        public int EmoteState { get; set; }
+        public int? CreatedBySpell { get; set; }
+        public int? EmoteState { get; set; }
         public int[] Stats { get; } = new int[4];
         public int[] StatPosBuff { get; } = new int[4];
         public int[] StatNegBuff { get; } = new int[4];
-        public int[] Resistances { get; } = new int[7];
+        public int?[] Resistances { get; } = new int?[7];
         public int[] BonusResistanceMods { get; } = new int[7];
         public int[] PowerCostModifier { get; } = new int[7];
         public float[] PowerCostMultiplier { get; } = new float[7];
-        public int BaseMana { get; set; }
-        public int BaseHealth { get; set; }
-        public byte SheatheState { get; set; }
-        public byte PvpFlags { get; set; }
-        public byte PetFlags { get; set; }
-        public byte ShapeshiftForm { get; set; }
+        public int? BaseMana { get; set; }
+        public int? BaseHealth { get; set; }
+        public byte? SheatheState { get; set; }
+        public byte? PvpFlags { get; set; }
+        public byte? PetFlags { get; set; }
+        public byte? ShapeshiftForm { get; set; }
         public int AttackPower { get; set; }
         public int AttackPowerModPos { get; set; }
         public int AttackPowerModNeg { get; set; }
@@ -111,14 +112,14 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
         public float MaxRangedDamage { get; set; }
         public float ManaCostModifierModifier { get; set; }
         public float MaxHealthModifier { get; set; }
-        public float HoverHeight { get; set; }
+        public float? HoverHeight { get; set; }
         public int MinItemLevelCutoff { get; set; }
         public int MinItemLevel { get; set; }
         public int MaxItemLevel { get; set; }
         public int AzeriteItemLevel { get; set; }
         public int WildBattlePetLevel { get; set; }
         public uint BattlePetCompanionNameTimestamp { get; set; }
-        public int InteractSpellID { get; set; }
+        public int? InteractSpellID { get; set; }
         public int ScaleDuration { get; set; }
         public int SpellOverrideNameID { get; set; }
         public int LooksLikeMountID { get; set; }
@@ -130,6 +131,8 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
         public DynamicUpdateField<IPassiveSpellHistory> PassiveSpells { get; } = new DynamicUpdateField<IPassiveSpellHistory>();
         public DynamicUpdateField<int> WorldEffects { get; } = new DynamicUpdateField<int>();
         public DynamicUpdateField<WowGuid> ChannelObjects { get; } = new DynamicUpdateField<WowGuid>();
+        public int? CreatureFamily { get; set; }
+        public int? CreatureType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/VisibleItem.cs
+++ b/WowPacketParserModule.V8_0_1_27101/UpdateFields/V8_3_0_33062/VisibleItem.cs
@@ -4,9 +4,9 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
 {
     public class VisibleItem : IVisibleItem
     {
-        public int ItemID { get; set; }
-        public ushort ItemAppearanceModID { get; set; }
-        public ushort ItemVisual { get; set; }
+        public int? ItemID { get; set; }
+        public ushort? ItemAppearanceModID { get; set; }
+        public ushort? ItemVisual { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/UpdateFieldsHandler901.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/UpdateFieldsHandler901.cs
@@ -18,11 +18,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public override IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ObjectData;
-            if (data == null)
-                data = new ObjectData();
+            var data = new ObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);
@@ -279,11 +277,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public override IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemData;
-            if (data == null)
-                data = new ItemData();
+            var data = new ItemData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -438,11 +434,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public override IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ContainerData;
-            if (data == null)
-                data = new ContainerData();
+            var data = new ContainerData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -483,11 +477,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteEmpoweredItemData;
-            if (data == null)
-                data = new AzeriteEmpoweredItemData();
+            var data = new AzeriteEmpoweredItemData();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -611,11 +603,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteItemData;
-            if (data == null)
-                data = new AzeriteItemData();
+            var data = new AzeriteItemData();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(10);
@@ -995,11 +985,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitData;
-            if (data == null)
-                data = new UnitData();
+            var data = new UnitData();
             var rawChangesMask = new int[7];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(7);
@@ -1851,11 +1839,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public override IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as PlayerData;
-            if (data == null)
-                data = new PlayerData();
+            var data = new PlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
@@ -2778,11 +2764,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerData;
-            if (data == null)
-                data = new ActivePlayerData();
+            var data = new ActivePlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[48];
             var rawMaskMask = new int[2];
@@ -3688,11 +3672,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as GameObjectData;
-            if (data == null)
-                data = new GameObjectData();
+            var data = new GameObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(21);
             var changesMask = new BitArray(rawChangesMask);
@@ -3817,11 +3799,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as DynamicObjectData;
-            if (data == null)
-                data = new DynamicObjectData();
+            var data = new DynamicObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
             var changesMask = new BitArray(rawChangesMask);
@@ -3883,11 +3863,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            var data = existingData as CorpseData;
-            if (data == null)
-                data = new CorpseData();
+            var data = new CorpseData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -4051,11 +4029,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AreaTriggerData;
-            if (data == null)
-                data = new AreaTriggerData();
+            var data = new AreaTriggerData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(14);
             var changesMask = new BitArray(rawChangesMask);
@@ -4129,11 +4105,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as SceneObjectData;
-            if (data == null)
-                data = new SceneObjectData();
+            var data = new SceneObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -4233,11 +4207,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
             return data;
         }
 
-        public override IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public override IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationData;
-            if (data == null)
-                data = new ConversationData();
+            var data = new ConversationData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/UpdateFieldsHandler902.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/UpdateFieldsHandler902.cs
@@ -20,11 +20,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public override IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ObjectData;
-            if (data == null)
-                data = new ObjectData();
+            var data = new ObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);
@@ -281,11 +279,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public override IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemData;
-            if (data == null)
-                data = new ItemData();
+            var data = new ItemData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -440,11 +436,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public override IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ContainerData;
-            if (data == null)
-                data = new ContainerData();
+            var data = new ContainerData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -485,11 +479,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteEmpoweredItemData;
-            if (data == null)
-                data = new AzeriteEmpoweredItemData();
+            var data = new AzeriteEmpoweredItemData();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -619,11 +611,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteItemData;
-            if (data == null)
-                data = new AzeriteItemData();
+            var data = new AzeriteItemData();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(10);
@@ -1002,11 +992,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitData;
-            if (data == null)
-                data = new UnitData();
+            var data = new UnitData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -1853,11 +1841,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public override IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as PlayerData;
-            if (data == null)
-                data = new PlayerData();
+            var data = new PlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
@@ -2780,11 +2766,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerData;
-            if (data == null)
-                data = new ActivePlayerData();
+            var data = new ActivePlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[48];
             var rawMaskMask = new int[2];
@@ -3690,11 +3674,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as GameObjectData;
-            if (data == null)
-                data = new GameObjectData();
+            var data = new GameObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(21);
             var changesMask = new BitArray(rawChangesMask);
@@ -3819,11 +3801,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as DynamicObjectData;
-            if (data == null)
-                data = new DynamicObjectData();
+            var data = new DynamicObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
             var changesMask = new BitArray(rawChangesMask);
@@ -3885,11 +3865,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            var data = existingData as CorpseData;
-            if (data == null)
-                data = new CorpseData();
+            var data = new CorpseData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -4052,11 +4030,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AreaTriggerData;
-            if (data == null)
-                data = new AreaTriggerData();
+            var data = new AreaTriggerData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(14);
             var changesMask = new BitArray(rawChangesMask);
@@ -4130,11 +4106,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as SceneObjectData;
-            if (data == null)
-                data = new SceneObjectData();
+            var data = new SceneObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -4234,11 +4208,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
             return data;
         }
 
-        public override IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public override IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationData;
-            if (data == null)
-                data = new ConversationData();
+            var data = new ConversationData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/UpdateFieldsHandler905.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/UpdateFieldsHandler905.cs
@@ -20,11 +20,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public override IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ObjectData;
-            if (data == null)
-                data = new ObjectData();
+            var data = new ObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);
@@ -281,11 +279,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public override IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemData;
-            if (data == null)
-                data = new ItemData();
+            var data = new ItemData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -440,11 +436,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public override IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ContainerData;
-            if (data == null)
-                data = new ContainerData();
+            var data = new ContainerData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -485,11 +479,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteEmpoweredItemData;
-            if (data == null)
-                data = new AzeriteEmpoweredItemData();
+            var data = new AzeriteEmpoweredItemData();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -619,11 +611,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteItemData;
-            if (data == null)
-                data = new AzeriteItemData();
+            var data = new AzeriteItemData();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(10);
@@ -1002,11 +992,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitData;
-            if (data == null)
-                data = new UnitData();
+            var data = new UnitData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -1853,11 +1841,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public override IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as PlayerData;
-            if (data == null)
-                data = new PlayerData();
+            var data = new PlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
@@ -2781,11 +2767,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerData;
-            if (data == null)
-                data = new ActivePlayerData();
+            var data = new ActivePlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[48];
             var rawMaskMask = new int[2];
@@ -3695,11 +3679,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as GameObjectData;
-            if (data == null)
-                data = new GameObjectData();
+            var data = new GameObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(21);
             var changesMask = new BitArray(rawChangesMask);
@@ -3824,11 +3806,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as DynamicObjectData;
-            if (data == null)
-                data = new DynamicObjectData();
+            var data = new DynamicObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
             var changesMask = new BitArray(rawChangesMask);
@@ -3890,11 +3870,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            var data = existingData as CorpseData;
-            if (data == null)
-                data = new CorpseData();
+            var data = new CorpseData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -4057,11 +4035,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AreaTriggerData;
-            if (data == null)
-                data = new AreaTriggerData();
+            var data = new AreaTriggerData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(14);
             var changesMask = new BitArray(rawChangesMask);
@@ -4135,11 +4111,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as SceneObjectData;
-            if (data == null)
-                data = new SceneObjectData();
+            var data = new SceneObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -4239,11 +4213,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
             return data;
         }
 
-        public override IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public override IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationData;
-            if (data == null)
-                data = new ConversationData();
+            var data = new ConversationData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/UpdateFieldsHandler910.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/UpdateFieldsHandler910.cs
@@ -20,11 +20,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public override IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ObjectData;
-            if (data == null)
-                data = new ObjectData();
+            var data = new ObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);
@@ -281,11 +279,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public override IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemData;
-            if (data == null)
-                data = new ItemData();
+            var data = new ItemData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -440,11 +436,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public override IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ContainerData;
-            if (data == null)
-                data = new ContainerData();
+            var data = new ContainerData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -485,11 +479,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteEmpoweredItemData;
-            if (data == null)
-                data = new AzeriteEmpoweredItemData();
+            var data = new AzeriteEmpoweredItemData();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -619,11 +611,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteItemData;
-            if (data == null)
-                data = new AzeriteItemData();
+            var data = new AzeriteItemData();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(10);
@@ -1003,11 +993,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitData;
-            if (data == null)
-                data = new UnitData();
+            var data = new UnitData();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(6);
@@ -1859,11 +1847,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public override IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as PlayerData;
-            if (data == null)
-                data = new PlayerData();
+            var data = new PlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
@@ -2793,11 +2779,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerData;
-            if (data == null)
-                data = new ActivePlayerData();
+            var data = new ActivePlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[49];
             var rawMaskMask = new int[2];
@@ -3695,11 +3679,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as GameObjectData;
-            if (data == null)
-                data = new GameObjectData();
+            var data = new GameObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(21);
             var changesMask = new BitArray(rawChangesMask);
@@ -3824,11 +3806,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as DynamicObjectData;
-            if (data == null)
-                data = new DynamicObjectData();
+            var data = new DynamicObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
             var changesMask = new BitArray(rawChangesMask);
@@ -3890,11 +3870,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            var data = existingData as CorpseData;
-            if (data == null)
-                data = new CorpseData();
+            var data = new CorpseData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -4057,11 +4035,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AreaTriggerData;
-            if (data == null)
-                data = new AreaTriggerData();
+            var data = new AreaTriggerData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(14);
             var changesMask = new BitArray(rawChangesMask);
@@ -4135,11 +4111,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as SceneObjectData;
-            if (data == null)
-                data = new SceneObjectData();
+            var data = new SceneObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -4241,11 +4215,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
             return data;
         }
 
-        public override IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public override IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationData;
-            if (data == null)
-                data = new ConversationData();
+            var data = new ConversationData();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(6);

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/UpdateFieldsHandler915.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/UpdateFieldsHandler915.cs
@@ -20,11 +20,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IObjectData ReadUpdateObjectData(Packet packet, IObjectData existingData, params object[] indexes)
+        public override IObjectData ReadUpdateObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ObjectData;
-            if (data == null)
-                data = new ObjectData();
+            var data = new ObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(4);
             var changesMask = new BitArray(rawChangesMask);
@@ -58,11 +56,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IItemEnchantment ReadUpdateItemEnchantment(Packet packet, IItemEnchantment existingData, params object[] indexes)
+        public static IItemEnchantment ReadUpdateItemEnchantment(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemEnchantment;
-            if (data == null)
-                data = new ItemEnchantment();
+            var data = new ItemEnchantment();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -98,11 +94,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IItemMod ReadUpdateItemMod(Packet packet, IItemMod existingData, params object[] indexes)
+        public static IItemMod ReadUpdateItemMod(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemMod;
-            if (data == null)
-                data = new ItemMod();
+            var data = new ItemMod();
             data.Value = packet.ReadInt32("Value", indexes);
             data.Type = packet.ReadByte("Type", indexes);
             return data;
@@ -120,11 +114,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IItemModList ReadUpdateItemModList(Packet packet, IItemModList existingData, params object[] indexes)
+        public static IItemModList ReadUpdateItemModList(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemModList;
-            if (data == null)
-                data = new ItemModList();
+            var data = new ItemModList();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(1);
@@ -163,11 +155,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IArtifactPower ReadUpdateArtifactPower(Packet packet, IArtifactPower existingData, params object[] indexes)
+        public static IArtifactPower ReadUpdateArtifactPower(Packet packet, params object[] indexes)
         {
-            var data = existingData as ArtifactPower;
-            if (data == null)
-                data = new ArtifactPower();
+            var data = new ArtifactPower();
             data.ArtifactPowerID = packet.ReadInt16("ArtifactPowerID", indexes);
             data.PurchasedRank = packet.ReadByte("PurchasedRank", indexes);
             data.CurrentRankWithBonus = packet.ReadByte("CurrentRankWithBonus", indexes);
@@ -186,11 +176,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static ISocketedGem ReadUpdateSocketedGem(Packet packet, ISocketedGem existingData, params object[] indexes)
+        public static ISocketedGem ReadUpdateSocketedGem(Packet packet, params object[] indexes)
         {
-            var data = existingData as SocketedGem;
-            if (data == null)
-                data = new SocketedGem();
+            var data = new SocketedGem();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -227,7 +215,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
         public override IItemData ReadCreateItemData(Packet packet, UpdateFieldFlag flags, params object[] indexes)
         {
             var data = new ItemData();
-            data.BonusListIDs = new int[packet.ReadUInt32()];
+            data.BonusListIDs = new System.Nullable<int>[packet.ReadUInt32()];
             for (var i = 0; i < data.BonusListIDs.Length; ++i)
             {
                 data.BonusListIDs[i] = packet.ReadInt32("BonusListIDs", indexes, i);
@@ -281,11 +269,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IItemData ReadUpdateItemData(Packet packet, IItemData existingData, params object[] indexes)
+        public override IItemData ReadUpdateItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ItemData;
-            if (data == null)
-                data = new ItemData();
+            var data = new ItemData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -299,7 +285,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             {
                 if (changesMask[1])
                 {
-                    data.BonusListIDs = Enumerable.Range(0, (int)packet.ReadBits(32)).Select(x => new int()).Cast<int>().ToArray();
+                    data.BonusListIDs = Enumerable.Range(0, (int)packet.ReadBits(32)).Select(x => new int()).Cast<System.Nullable<int>>().ToArray();
                     for (var i = 0; i < data.BonusListIDs.Length; ++i)
                     {
                         data.BonusListIDs[i] = packet.ReadInt32("BonusListIDs", indexes, i);
@@ -440,11 +426,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IContainerData ReadUpdateContainerData(Packet packet, IContainerData existingData, params object[] indexes)
+        public override IContainerData ReadUpdateContainerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ContainerData;
-            if (data == null)
-                data = new ContainerData();
+            var data = new ContainerData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -485,11 +469,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, IAzeriteEmpoweredItemData existingData, params object[] indexes)
+        public override IAzeriteEmpoweredItemData ReadUpdateAzeriteEmpoweredItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteEmpoweredItemData;
-            if (data == null)
-                data = new AzeriteEmpoweredItemData();
+            var data = new AzeriteEmpoweredItemData();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -520,11 +502,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IUnlockedAzeriteEssence ReadUpdateUnlockedAzeriteEssence(Packet packet, IUnlockedAzeriteEssence existingData, params object[] indexes)
+        public static IUnlockedAzeriteEssence ReadUpdateUnlockedAzeriteEssence(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnlockedAzeriteEssence;
-            if (data == null)
-                data = new UnlockedAzeriteEssence();
+            var data = new UnlockedAzeriteEssence();
             data.AzeriteEssenceID = packet.ReadUInt32("AzeriteEssenceID", indexes);
             data.Rank = packet.ReadUInt32("Rank", indexes);
             return data;
@@ -543,11 +523,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static ISelectedAzeriteEssences ReadUpdateSelectedAzeriteEssences(Packet packet, ISelectedAzeriteEssences existingData, params object[] indexes)
+        public static ISelectedAzeriteEssences ReadUpdateSelectedAzeriteEssences(Packet packet, params object[] indexes)
         {
-            var data = existingData as SelectedAzeriteEssences;
-            if (data == null)
-                data = new SelectedAzeriteEssences();
+            var data = new SelectedAzeriteEssences();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
@@ -619,11 +597,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, IAzeriteItemData existingData, params object[] indexes)
+        public override IAzeriteItemData ReadUpdateAzeriteItemData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AzeriteItemData;
-            if (data == null)
-                data = new AzeriteItemData();
+            var data = new AzeriteItemData();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(10);
@@ -713,11 +689,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static ISpellCastVisual ReadUpdateSpellCastVisual(Packet packet, ISpellCastVisual existingData, params object[] indexes)
+        public static ISpellCastVisual ReadUpdateSpellCastVisual(Packet packet, params object[] indexes)
         {
-            var data = existingData as SpellCastVisual;
-            if (data == null)
-                data = new SpellCastVisual();
+            var data = new SpellCastVisual();
             data.SpellXSpellVisualID = packet.ReadInt32("SpellXSpellVisualID", indexes);
             data.ScriptVisualID = packet.ReadInt32("ScriptVisualID", indexes);
             return data;
@@ -731,11 +705,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IUnitChannel ReadUpdateUnitChannel(Packet packet, IUnitChannel existingData, params object[] indexes)
+        public static IUnitChannel ReadUpdateUnitChannel(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitChannel;
-            if (data == null)
-                data = new UnitChannel();
+            var data = new UnitChannel();
             data.SpellID = packet.ReadInt32("SpellID", indexes);
             data.SpellVisual = ReadUpdateSpellCastVisual(packet, data.SpellVisual as SpellCastVisual, indexes, "SpellVisual");
             return data;
@@ -751,11 +723,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IVisibleItem ReadUpdateVisibleItem(Packet packet, IVisibleItem existingData, params object[] indexes)
+        public static IVisibleItem ReadUpdateVisibleItem(Packet packet, params object[] indexes)
         {
-            var data = existingData as VisibleItem;
-            if (data == null)
-                data = new VisibleItem();
+            var data = new VisibleItem();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -791,11 +761,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IPassiveSpellHistory ReadUpdatePassiveSpellHistory(Packet packet, IPassiveSpellHistory existingData, params object[] indexes)
+        public static IPassiveSpellHistory ReadUpdatePassiveSpellHistory(Packet packet, params object[] indexes)
         {
-            var data = existingData as PassiveSpellHistory;
-            if (data == null)
-                data = new PassiveSpellHistory();
+            var data = new PassiveSpellHistory();
             data.SpellID = packet.ReadInt32("SpellID", indexes);
             data.AuraSpellID = packet.ReadInt32("AuraSpellID", indexes);
             return data;
@@ -812,7 +780,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             data.StateSpellVisualID = packet.ReadUInt32("StateSpellVisualID", indexes);
             data.StateAnimID = packet.ReadUInt32("StateAnimID", indexes);
             data.StateAnimKitID = packet.ReadUInt32("StateAnimKitID", indexes);
-            data.StateWorldEffectIDs = new uint[packet.ReadUInt32()];
+            data.StateWorldEffectIDs = new System.Nullable<uint>[packet.ReadUInt32()];
             data.StateWorldEffectsQuestObjectiveID = packet.ReadUInt32("StateWorldEffectsQuestObjectiveID", indexes);
             data.SpellOverrideNameID = packet.ReadInt32("SpellOverrideNameID", indexes);
             for (var i = 0; i < data.StateWorldEffectIDs.Length; ++i)
@@ -1004,11 +972,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IUnitData ReadUpdateUnitData(Packet packet, IUnitData existingData, params object[] indexes)
+        public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
-            var data = existingData as UnitData;
-            if (data == null)
-                data = new UnitData();
+            var data = new UnitData();
             var rawChangesMask = new int[7];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(7);
@@ -1022,7 +988,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             {
                 if (changesMask[1])
                 {
-                    data.StateWorldEffectIDs = Enumerable.Range(0, (int)packet.ReadBits(32)).Select(x => new uint()).Cast<uint>().ToArray();
+                    data.StateWorldEffectIDs = Enumerable.Range(0, (int)packet.ReadBits(32)).Select(x => new uint()).Cast<System.Nullable<uint>>().ToArray();
                     for (var i = 0; i < data.StateWorldEffectIDs.Length; ++i)
                     {
                         data.StateWorldEffectIDs[i] = packet.ReadUInt32("StateWorldEffectIDs", indexes, i);
@@ -1639,11 +1605,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IChrCustomizationChoice ReadUpdateChrCustomizationChoice(Packet packet, IChrCustomizationChoice existingData, params object[] indexes)
+        public static IChrCustomizationChoice ReadUpdateChrCustomizationChoice(Packet packet, params object[] indexes)
         {
-            var data = existingData as ChrCustomizationChoice;
-            if (data == null)
-                data = new ChrCustomizationChoice();
+            var data = new ChrCustomizationChoice();
             data.ChrCustomizationOptionID = packet.ReadUInt32("ChrCustomizationOptionID", indexes);
             data.ChrCustomizationChoiceID = packet.ReadUInt32("ChrCustomizationChoiceID", indexes);
             return data;
@@ -1664,11 +1628,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IQuestLog ReadUpdateQuestLog(Packet packet, IQuestLog existingData, params object[] indexes)
+        public static IQuestLog ReadUpdateQuestLog(Packet packet, params object[] indexes)
         {
-            var data = existingData as QuestLog;
-            if (data == null)
-                data = new QuestLog();
+            var data = new QuestLog();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(1);
@@ -1727,11 +1689,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IArenaCooldown ReadUpdateArenaCooldown(Packet packet, IArenaCooldown existingData, params object[] indexes)
+        public static IArenaCooldown ReadUpdateArenaCooldown(Packet packet, params object[] indexes)
         {
-            var data = existingData as ArenaCooldown;
-            if (data == null)
-                data = new ArenaCooldown();
+            var data = new ArenaCooldown();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(8);
             var changesMask = new BitArray(rawChangesMask);
@@ -1780,11 +1740,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static ICTROptions ReadUpdateCTROptions(Packet packet, ICTROptions existingData, params object[] indexes)
+        public static ICTROptions ReadUpdateCTROptions(Packet packet, params object[] indexes)
         {
-            var data = existingData as CTROptions;
-            if (data == null)
-                data = new CTROptions();
+            var data = new CTROptions();
             data.ContentTuningConditionMask = packet.ReadInt32("ContentTuningConditionMask", indexes);
             data.Field_4 = packet.ReadUInt32("Field_4", indexes);
             data.ExpansionLevelMask = packet.ReadUInt32("ExpansionLevelMask", indexes);
@@ -1864,11 +1822,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IPlayerData ReadUpdatePlayerData(Packet packet, IPlayerData existingData, params object[] indexes)
+        public override IPlayerData ReadUpdatePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as PlayerData;
-            if (data == null)
-                data = new PlayerData();
+            var data = new PlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[6];
             var rawMaskMask = new int[1];
@@ -2107,11 +2063,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static ISkillInfo ReadUpdateSkillInfo(Packet packet, ISkillInfo existingData, params object[] indexes)
+        public static ISkillInfo ReadUpdateSkillInfo(Packet packet, params object[] indexes)
         {
-            var data = existingData as SkillInfo;
-            if (data == null)
-                data = new SkillInfo();
+            var data = new SkillInfo();
             var rawChangesMask = new int[57];
             var rawMaskMask = new int[2];
             for (var i = 0; i < 1; ++i)
@@ -2169,11 +2123,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IRestInfo ReadUpdateRestInfo(Packet packet, IRestInfo existingData, params object[] indexes)
+        public static IRestInfo ReadUpdateRestInfo(Packet packet, params object[] indexes)
         {
-            var data = existingData as RestInfo;
-            if (data == null)
-                data = new RestInfo();
+            var data = new RestInfo();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(3);
             var changesMask = new BitArray(rawChangesMask);
@@ -2212,11 +2164,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IPVPInfo ReadUpdatePVPInfo(Packet packet, IPVPInfo existingData, params object[] indexes)
+        public static IPVPInfo ReadUpdatePVPInfo(Packet packet, params object[] indexes)
         {
-            var data = existingData as PVPInfo;
-            if (data == null)
-                data = new PVPInfo();
+            var data = new PVPInfo();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(13);
@@ -2291,11 +2241,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static ICharacterRestriction ReadUpdateCharacterRestriction(Packet packet, ICharacterRestriction existingData, params object[] indexes)
+        public static ICharacterRestriction ReadUpdateCharacterRestriction(Packet packet, params object[] indexes)
         {
-            var data = existingData as CharacterRestriction;
-            if (data == null)
-                data = new CharacterRestriction();
+            var data = new CharacterRestriction();
             packet.ResetBitReader();
             data.Field_0 = packet.ReadInt32("Field_0", indexes);
             data.Field_4 = packet.ReadInt32("Field_4", indexes);
@@ -2313,11 +2261,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static ISpellPctModByLabel ReadUpdateSpellPctModByLabel(Packet packet, ISpellPctModByLabel existingData, params object[] indexes)
+        public static ISpellPctModByLabel ReadUpdateSpellPctModByLabel(Packet packet, params object[] indexes)
         {
-            var data = existingData as SpellPctModByLabel;
-            if (data == null)
-                data = new SpellPctModByLabel();
+            var data = new SpellPctModByLabel();
             data.ModIndex = packet.ReadInt32("ModIndex", indexes);
             data.ModifierValue = packet.ReadSingle("ModifierValue", indexes);
             data.LabelID = packet.ReadInt32("LabelID", indexes);
@@ -2333,11 +2279,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static ISpellFlatModByLabel ReadUpdateSpellFlatModByLabel(Packet packet, ISpellFlatModByLabel existingData, params object[] indexes)
+        public static ISpellFlatModByLabel ReadUpdateSpellFlatModByLabel(Packet packet, params object[] indexes)
         {
-            var data = existingData as SpellFlatModByLabel;
-            if (data == null)
-                data = new SpellFlatModByLabel();
+            var data = new SpellFlatModByLabel();
             data.ModIndex = packet.ReadInt32("ModIndex", indexes);
             data.ModifierValue = packet.ReadInt32("ModifierValue", indexes);
             data.LabelID = packet.ReadInt32("LabelID", indexes);
@@ -2351,11 +2295,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IResearch ReadUpdateResearch(Packet packet, IResearch existingData, params object[] indexes)
+        public static IResearch ReadUpdateResearch(Packet packet, params object[] indexes)
         {
-            var data = existingData as Research;
-            if (data == null)
-                data = new Research();
+            var data = new Research();
             data.ResearchProjectID = packet.ReadInt16("ResearchProjectID", indexes);
             return data;
         }
@@ -2369,11 +2311,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IMawPower ReadUpdateMawPower(Packet packet, IMawPower existingData, params object[] indexes)
+        public static IMawPower ReadUpdateMawPower(Packet packet, params object[] indexes)
         {
-            var data = existingData as MawPower;
-            if (data == null)
-                data = new MawPower();
+            var data = new MawPower();
             data.Field_0 = packet.ReadInt32("Field_0", indexes);
             data.Field_4 = packet.ReadInt32("Field_4", indexes);
             data.Field_8 = packet.ReadInt32("Field_8", indexes);
@@ -2391,11 +2331,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IMultiFloorExplore ReadUpdateMultiFloorExplore(Packet packet, IMultiFloorExplore existingData, params object[] indexes)
+        public static IMultiFloorExplore ReadUpdateMultiFloorExplore(Packet packet, params object[] indexes)
         {
-            var data = existingData as MultiFloorExplore;
-            if (data == null)
-                data = new MultiFloorExplore();
+            var data = new MultiFloorExplore();
             data.WorldMapOverlayIDs = new int[packet.ReadUInt32()];
             for (var i = 0; i < data.WorldMapOverlayIDs.Length; ++i)
             {
@@ -2413,11 +2351,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IRecipeProgressionInfo ReadUpdateRecipeProgressionInfo(Packet packet, IRecipeProgressionInfo existingData, params object[] indexes)
+        public static IRecipeProgressionInfo ReadUpdateRecipeProgressionInfo(Packet packet, params object[] indexes)
         {
-            var data = existingData as RecipeProgressionInfo;
-            if (data == null)
-                data = new RecipeProgressionInfo();
+            var data = new RecipeProgressionInfo();
             data.RecipeProgressionGroupID = packet.ReadUInt16("RecipeProgressionGroupID", indexes);
             data.Experience = packet.ReadUInt16("Experience", indexes);
             return data;
@@ -2431,11 +2367,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IActivePlayerUnk901 ReadUpdateActivePlayerUnk901(Packet packet, IActivePlayerUnk901 existingData, params object[] indexes)
+        public static IActivePlayerUnk901 ReadUpdateActivePlayerUnk901(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerUnk901;
-            if (data == null)
-                data = new ActivePlayerUnk901();
+            var data = new ActivePlayerUnk901();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(3);
             var changesMask = new BitArray(rawChangesMask);
@@ -2466,11 +2400,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IQuestSession ReadUpdateQuestSession(Packet packet, IQuestSession existingData, params object[] indexes)
+        public static IQuestSession ReadUpdateQuestSession(Packet packet, params object[] indexes)
         {
-            var data = existingData as QuestSession;
-            if (data == null)
-                data = new QuestSession();
+            var data = new QuestSession();
             var rawChangesMask = new int[28];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(28);
@@ -2509,11 +2441,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IReplayedQuest ReadUpdateReplayedQuest(Packet packet, IReplayedQuest existingData, params object[] indexes)
+        public static IReplayedQuest ReadUpdateReplayedQuest(Packet packet, params object[] indexes)
         {
-            var data = existingData as ReplayedQuest;
-            if (data == null)
-                data = new ReplayedQuest();
+            var data = new ReplayedQuest();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(3);
             var changesMask = new BitArray(rawChangesMask);
@@ -2804,11 +2734,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, IActivePlayerData existingData, params object[] indexes)
+        public override IActivePlayerData ReadUpdateActivePlayerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ActivePlayerData;
-            if (data == null)
-                data = new ActivePlayerData();
+            var data = new ActivePlayerData();
             packet.ResetBitReader();
             var rawChangesMask = new int[49];
             var rawMaskMask = new int[2];
@@ -3670,7 +3598,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             data.StateSpellVisualID = packet.ReadUInt32("StateSpellVisualID", indexes);
             data.SpawnTrackingStateAnimID = packet.ReadUInt32("SpawnTrackingStateAnimID", indexes);
             data.SpawnTrackingStateAnimKitID = packet.ReadUInt32("SpawnTrackingStateAnimKitID", indexes);
-            data.StateWorldEffectIDs = new uint[packet.ReadUInt32()];
+            data.StateWorldEffectIDs = new System.Nullable<uint>[packet.ReadUInt32()];
             data.StateWorldEffectsQuestObjectiveID = packet.ReadUInt32("StateWorldEffectsQuestObjectiveID", indexes);
             for (var i = 0; i < data.StateWorldEffectIDs.Length; ++i)
             {
@@ -3696,11 +3624,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, IGameObjectData existingData, params object[] indexes)
+        public override IGameObjectData ReadUpdateGameObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as GameObjectData;
-            if (data == null)
-                data = new GameObjectData();
+            var data = new GameObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(21);
             var changesMask = new BitArray(rawChangesMask);
@@ -3709,7 +3635,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             {
                 if (changesMask[1])
                 {
-                    data.StateWorldEffectIDs = Enumerable.Range(0, (int)packet.ReadBits(32)).Select(x => new uint()).Cast<uint>().ToArray();
+                    data.StateWorldEffectIDs = Enumerable.Range(0, (int)packet.ReadBits(32)).Select(x => new uint()).Cast<System.Nullable<uint>>().ToArray();
                     for (var i = 0; i < data.StateWorldEffectIDs.Length; ++i)
                     {
                         data.StateWorldEffectIDs[i] = packet.ReadUInt32("StateWorldEffectIDs", indexes, i);
@@ -3825,11 +3751,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, IDynamicObjectData existingData, params object[] indexes)
+        public override IDynamicObjectData ReadUpdateDynamicObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as DynamicObjectData;
-            if (data == null)
-                data = new DynamicObjectData();
+            var data = new DynamicObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
             var changesMask = new BitArray(rawChangesMask);
@@ -3891,11 +3815,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override ICorpseData ReadUpdateCorpseData(Packet packet, ICorpseData existingData, params object[] indexes)
+        public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
-            var data = existingData as CorpseData;
-            if (data == null)
-                data = new CorpseData();
+            var data = new CorpseData();
             var rawChangesMask = new int[2];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(2);
@@ -3997,11 +3919,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IScaleCurve ReadUpdateScaleCurve(Packet packet, IScaleCurve existingData, params object[] indexes)
+        public static IScaleCurve ReadUpdateScaleCurve(Packet packet, params object[] indexes)
         {
-            var data = existingData as ScaleCurve;
-            if (data == null)
-                data = new ScaleCurve();
+            var data = new ScaleCurve();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);
@@ -4050,11 +3970,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IVisualAnim ReadUpdateVisualAnim(Packet packet, IVisualAnim existingData, params object[] indexes)
+        public static IVisualAnim ReadUpdateVisualAnim(Packet packet, params object[] indexes)
         {
-            var data = existingData as VisualAnim;
-            if (data == null)
-                data = new VisualAnim();
+            var data = new VisualAnim();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
@@ -4107,11 +4025,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, IAreaTriggerData existingData, params object[] indexes)
+        public override IAreaTriggerData ReadUpdateAreaTriggerData(Packet packet, params object[] indexes)
         {
-            var data = existingData as AreaTriggerData;
-            if (data == null)
-                data = new AreaTriggerData();
+            var data = new AreaTriggerData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(16);
             var changesMask = new BitArray(rawChangesMask);
@@ -4193,11 +4109,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, ISceneObjectData existingData, params object[] indexes)
+        public override ISceneObjectData ReadUpdateSceneObjectData(Packet packet, params object[] indexes)
         {
-            var data = existingData as SceneObjectData;
-            if (data == null)
-                data = new SceneObjectData();
+            var data = new SceneObjectData();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(5);
             var changesMask = new BitArray(rawChangesMask);
@@ -4237,11 +4151,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IConversationLine ReadUpdateConversationLine(Packet packet, IConversationLine existingData, params object[] indexes)
+        public static IConversationLine ReadUpdateConversationLine(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationLine;
-            if (data == null)
-                data = new ConversationLine();
+            var data = new ConversationLine();
             data.ConversationLineID = packet.ReadInt32("ConversationLineID", indexes);
             data.StartTime = packet.ReadUInt32("StartTime", indexes);
             data.UiCameraID = packet.ReadInt32("UiCameraID", indexes);
@@ -4264,11 +4176,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public static IConversationActor ReadUpdateConversationActor(Packet packet, IConversationActor existingData, params object[] indexes)
+        public static IConversationActor ReadUpdateConversationActor(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationActor;
-            if (data == null)
-                data = new ConversationActor();
+            var data = new ConversationActor();
             packet.ResetBitReader();
             data.CreatureID = packet.ReadUInt32("CreatureID", indexes);
             data.CreatureDisplayInfoID = packet.ReadUInt32("CreatureDisplayInfoID", indexes);
@@ -4300,11 +4210,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
             return data;
         }
 
-        public override IConversationData ReadUpdateConversationData(Packet packet, IConversationData existingData, params object[] indexes)
+        public override IConversationData ReadUpdateConversationData(Packet packet, params object[] indexes)
         {
-            var data = existingData as ConversationData;
-            if (data == null)
-                data = new ConversationData();
+            var data = new ConversationData();
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             rawChangesMask[0] = (int)packet.ReadBits(7);

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/AreaTriggerData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/AreaTriggerData.cs
@@ -7,14 +7,14 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
     {
         public WowGuid Caster { get; set; }
         public uint Duration { get; set; }
-        public uint TimeToTarget { get; set; }
-        public uint TimeToTargetScale { get; set; }
+        public uint? TimeToTarget { get; set; }
+        public uint? TimeToTargetScale { get; set; }
         public uint TimeToTargetExtraScale { get; set; }
-        public int SpellID { get; set; }
+        public int? SpellID { get; set; }
         public int SpellForVisuals { get; set; }
         public ISpellCastVisual SpellVisual { get; set; }
         public float BoundsRadius2D { get; set; }
-        public uint DecalPropertiesID { get; set; }
+        public uint? DecalPropertiesID { get; set; }
         public WowGuid CreatingEffectGUID { get; set; }
         public IScaleCurve OverrideScaleCurve { get; set; }
         public IScaleCurve ExtraScaleCurve { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/ConversationData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/ConversationData.cs
@@ -5,7 +5,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
 {
     public class ConversationData : IConversationData
     {
-        public int LastLineEndTime { get; set; }
+        public int? LastLineEndTime { get; set; }
         public uint Progress { get; set; }
         public IConversationLine[] Lines { get; set; }
         public DynamicUpdateField<IConversationActor> Actors { get; } = new DynamicUpdateField<IConversationActor>();

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/GameObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/GameObjectData.cs
@@ -1,28 +1,29 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
 {
-    public class GameObjectData : IGameObjectData
+    public class GameObjectData : IMutableGameObjectData
     {
-        public int DisplayID { get; set; }
+        public int? DisplayID { get; set; }
         public uint SpellVisualID { get; set; }
         public uint StateSpellVisualID { get; set; }
         public uint SpawnTrackingStateAnimID { get; set; }
         public uint SpawnTrackingStateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid CreatedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
-        public Quaternion ParentRotation { get; set; }
-        public int FactionTemplate { get; set; }
-        public sbyte State { get; set; }
-        public sbyte TypeID { get; set; }
-        public byte PercentHealth { get; set; }
-        public uint ArtKit { get; set; }
+        public uint? Flags { get; set; }
+        public Quaternion? ParentRotation { get; set; }
+        public int? FactionTemplate { get; set; }
+        public sbyte? State { get; set; }
+        public sbyte? TypeID { get; set; }
+        public byte? PercentHealth { get; set; }
+        public uint? ArtKit { get; set; }
         public uint CustomParam { get; set; }
-        public int Level { get; set; }
+        public int? Level { get; set; }
         public uint AnimGroupInstance { get; set; }
         public DynamicUpdateField<int> EnableDoodadSets { get; } = new DynamicUpdateField<int>();
     }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/ObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/ObjectData.cs
@@ -2,11 +2,11 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
 {
-    public class ObjectData : IObjectData
+    public class ObjectData : IMutableObjectData
     {
-        public int EntryID { get; set; }
-        public uint DynamicFlags { get; set; }
-        public float Scale { get; set; }
+        public int? EntryID { get; set; }
+        public uint? DynamicFlags { get; set; }
+        public float? Scale { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/SceneObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/SceneObjectData.cs
@@ -5,10 +5,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
 {
     public class SceneObjectData : ISceneObjectData
     {
-        public int ScriptPackageID { get; set; }
+        public int? ScriptPackageID { get; set; }
         public uint RndSeedVal { get; set; }
         public WowGuid CreatedBy { get; set; }
-        public uint SceneType { get; set; }
+        public uint? SceneType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/UnitData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/UnitData.cs
@@ -1,77 +1,78 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
 {
-    public class UnitData : IUnitData
+    public class UnitData : IMutableUnitData
     {
-        public int DisplayID { get; set; }
-        public uint[] NpcFlags { get; } = new uint[2];
-        public uint StateSpellVisualID { get; set; }
-        public uint StateAnimID { get; set; }
-        public uint StateAnimKitID { get; set; }
+        public int? DisplayID { get; set; }
+        public uint?[] NpcFlags { get; } = new uint?[2];
+        public uint? StateSpellVisualID { get; set; }
+        public uint? StateAnimID { get; set; }
+        public uint? StateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public int SpellOverrideNameID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid Charm { get; set; }
-        public WowGuid Summon { get; set; }
-        public WowGuid Critter { get; set; }
-        public WowGuid CharmedBy { get; set; }
-        public WowGuid SummonedBy { get; set; }
-        public WowGuid CreatedBy { get; set; }
-        public WowGuid DemonCreator { get; set; }
-        public WowGuid LookAtControllerTarget { get; set; }
-        public WowGuid Target { get; set; }
+        public WowGuid? Charm { get; set; }
+        public WowGuid? Summon { get; set; }
+        public WowGuid? Critter { get; set; }
+        public WowGuid? CharmedBy { get; set; }
+        public WowGuid? SummonedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
+        public WowGuid? DemonCreator { get; set; }
+        public WowGuid? LookAtControllerTarget { get; set; }
+        public WowGuid? Target { get; set; }
         public WowGuid BattlePetCompanionGUID { get; set; }
         public ulong BattlePetDBID { get; set; }
         public IUnitChannel ChannelData { get; set; }
         public uint SummonedByHomeRealm { get; set; }
-        public byte Race { get; set; }
-        public byte ClassId { get; set; }
+        public byte? Race { get; set; }
+        public byte? ClassId { get; set; }
         public byte PlayerClassId { get; set; }
-        public byte Sex { get; set; }
-        public byte DisplayPower { get; set; }
+        public byte? Sex { get; set; }
+        public byte? DisplayPower { get; set; }
         public uint OverrideDisplayPowerID { get; set; }
-        public long Health { get; set; }
-        public int[] Power { get; } = new int[6];
-        public int[] MaxPower { get; } = new int[6];
+        public long? Health { get; set; }
+        public int?[] Power { get; } = new int?[6];
+        public int?[] MaxPower { get; } = new int?[6];
         public float[] PowerRegenFlatModifier { get; } = new float[6];
         public float[] PowerRegenInterruptedFlatModifier { get; } = new float[6];
-        public long MaxHealth { get; set; }
-        public int Level { get; set; }
-        public int EffectiveLevel { get; set; }
-        public int ContentTuningID { get; set; }
-        public int ScalingLevelMin { get; set; }
-        public int ScalingLevelMax { get; set; }
-        public int ScalingLevelDelta { get; set; }
+        public long? MaxHealth { get; set; }
+        public int? Level { get; set; }
+        public int? EffectiveLevel { get; set; }
+        public int? ContentTuningID { get; set; }
+        public int? ScalingLevelMin { get; set; }
+        public int? ScalingLevelMax { get; set; }
+        public int? ScalingLevelDelta { get; set; }
         public int ScalingFactionGroup { get; set; }
         public int ScalingHealthItemLevelCurveID { get; set; }
         public int ScalingDamageItemLevelCurveID { get; set; }
-        public int FactionTemplate { get; set; }
+        public int? FactionTemplate { get; set; }
         public IVisibleItem[] VirtualItems { get; } = new IVisibleItem[3];
-        public uint Flags { get; set; }
-        public uint Flags2 { get; set; }
-        public uint Flags3 { get; set; }
-        public uint AuraState { get; set; }
-        public uint[] AttackRoundBaseTime { get; } = new uint[2];
-        public uint RangedAttackRoundBaseTime { get; set; }
-        public float BoundingRadius { get; set; }
-        public float CombatReach { get; set; }
-        public float DisplayScale { get; set; }
-        public int CreatureFamily { get; set; }
-        public int CreatureType { get; set; }
-        public int NativeDisplayID { get; set; }
-        public float NativeXDisplayScale { get; set; }
-        public int MountDisplayID { get; set; }
+        public uint? Flags { get; set; }
+        public uint? Flags2 { get; set; }
+        public uint? Flags3 { get; set; }
+        public uint? AuraState { get; set; }
+        public uint?[] AttackRoundBaseTime { get; } = new uint?[2];
+        public uint? RangedAttackRoundBaseTime { get; set; }
+        public float? BoundingRadius { get; set; }
+        public float? CombatReach { get; set; }
+        public float? DisplayScale { get; set; }
+        public int? CreatureFamily { get; set; }
+        public int? CreatureType { get; set; }
+        public int? NativeDisplayID { get; set; }
+        public float? NativeXDisplayScale { get; set; }
+        public int? MountDisplayID { get; set; }
         public int CosmeticMountDisplayID { get; set; }
         public float MinDamage { get; set; }
         public float MaxDamage { get; set; }
         public float MinOffHandDamage { get; set; }
         public float MaxOffHandDamage { get; set; }
-        public byte StandState { get; set; }
-        public byte PetTalentPoints { get; set; }
-        public byte VisFlags { get; set; }
-        public byte AnimTier { get; set; }
+        public byte? StandState { get; set; }
+        public byte? PetTalentPoints { get; set; }
+        public byte? VisFlags { get; set; }
+        public byte? AnimTier { get; set; }
         public uint PetNumber { get; set; }
         public uint PetNameTimestamp { get; set; }
         public uint PetExperience { get; set; }
@@ -83,21 +84,21 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
         public float ModRangedHaste { get; set; }
         public float ModHasteRegen { get; set; }
         public float ModTimeRate { get; set; }
-        public int CreatedBySpell { get; set; }
-        public int EmoteState { get; set; }
+        public int? CreatedBySpell { get; set; }
+        public int? EmoteState { get; set; }
         public int[] Stats { get; } = new int[4];
         public int[] StatPosBuff { get; } = new int[4];
         public int[] StatNegBuff { get; } = new int[4];
-        public int[] Resistances { get; } = new int[7];
+        public int?[] Resistances { get; } = new int?[7];
         public int[] BonusResistanceMods { get; } = new int[7];
         public int[] PowerCostModifier { get; } = new int[7];
         public float[] PowerCostMultiplier { get; } = new float[7];
-        public int BaseMana { get; set; }
-        public int BaseHealth { get; set; }
-        public byte SheatheState { get; set; }
-        public byte PvpFlags { get; set; }
-        public byte PetFlags { get; set; }
-        public byte ShapeshiftForm { get; set; }
+        public int? BaseMana { get; set; }
+        public int? BaseHealth { get; set; }
+        public byte? SheatheState { get; set; }
+        public byte? PvpFlags { get; set; }
+        public byte? PetFlags { get; set; }
+        public byte? ShapeshiftForm { get; set; }
         public int AttackPower { get; set; }
         public int AttackPowerModPos { get; set; }
         public int AttackPowerModNeg { get; set; }
@@ -115,14 +116,14 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
         public float MaxRangedDamage { get; set; }
         public float ManaCostModifierModifier { get; set; }
         public float MaxHealthModifier { get; set; }
-        public float HoverHeight { get; set; }
+        public float? HoverHeight { get; set; }
         public int MinItemLevelCutoff { get; set; }
         public int MinItemLevel { get; set; }
         public int MaxItemLevel { get; set; }
         public int AzeriteItemLevel { get; set; }
         public int WildBattlePetLevel { get; set; }
         public uint BattlePetCompanionNameTimestamp { get; set; }
-        public int InteractSpellID { get; set; }
+        public int? InteractSpellID { get; set; }
         public int ScaleDuration { get; set; }
         public int LooksLikeMountID { get; set; }
         public int LooksLikeCreatureID { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/VisibleItem.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_1_36216/VisibleItem.cs
@@ -4,10 +4,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_1_36216
 {
     public class VisibleItem : IVisibleItem
     {
-        public int ItemID { get; set; }
+        public int? ItemID { get; set; }
         public int SecondaryItemModifiedAppearanceID { get; set; }
-        public ushort ItemAppearanceModID { get; set; }
-        public ushort ItemVisual { get; set; }
+        public ushort? ItemAppearanceModID { get; set; }
+        public ushort? ItemVisual { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/AreaTriggerData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/AreaTriggerData.cs
@@ -9,14 +9,14 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
     {
         public WowGuid Caster { get; set; }
         public uint Duration { get; set; }
-        public uint TimeToTarget { get; set; }
-        public uint TimeToTargetScale { get; set; }
+        public uint? TimeToTarget { get; set; }
+        public uint? TimeToTargetScale { get; set; }
         public uint TimeToTargetExtraScale { get; set; }
-        public int SpellID { get; set; }
+        public int? SpellID { get; set; }
         public int SpellForVisuals { get; set; }
         public ISpellCastVisual SpellVisual { get; set; }
         public float BoundsRadius2D { get; set; }
-        public uint DecalPropertiesID { get; set; }
+        public uint? DecalPropertiesID { get; set; }
         public WowGuid CreatingEffectGUID { get; set; }
         public IScaleCurve OverrideScaleCurve { get; set; }
         public IScaleCurve ExtraScaleCurve { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/ConversationData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/ConversationData.cs
@@ -7,7 +7,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
 {
     public class ConversationData : IConversationData
     {
-        public int LastLineEndTime { get; set; }
+        public int? LastLineEndTime { get; set; }
         public uint Progress { get; set; }
         public IConversationLine[] Lines { get; set; }
         public DynamicUpdateField<IConversationActor> Actors { get; } = new DynamicUpdateField<IConversationActor>();

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/GameObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/GameObjectData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
@@ -5,26 +6,26 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
 {
-    public class GameObjectData : IGameObjectData
+    public class GameObjectData : IMutableGameObjectData
     {
-        public int DisplayID { get; set; }
+        public int? DisplayID { get; set; }
         public uint SpellVisualID { get; set; }
         public uint StateSpellVisualID { get; set; }
         public uint SpawnTrackingStateAnimID { get; set; }
         public uint SpawnTrackingStateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid CreatedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
-        public Quaternion ParentRotation { get; set; }
-        public int FactionTemplate { get; set; }
-        public sbyte State { get; set; }
-        public sbyte TypeID { get; set; }
-        public byte PercentHealth { get; set; }
-        public uint ArtKit { get; set; }
+        public uint? Flags { get; set; }
+        public Quaternion? ParentRotation { get; set; }
+        public int? FactionTemplate { get; set; }
+        public sbyte? State { get; set; }
+        public sbyte? TypeID { get; set; }
+        public byte? PercentHealth { get; set; }
+        public uint? ArtKit { get; set; }
         public uint CustomParam { get; set; }
-        public int Level { get; set; }
+        public int? Level { get; set; }
         public uint AnimGroupInstance { get; set; }
         public DynamicUpdateField<int> EnableDoodadSets { get; } = new DynamicUpdateField<int>();
     }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/ObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/ObjectData.cs
@@ -4,11 +4,11 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
 {
-    public class ObjectData : IObjectData
+    public class ObjectData : IMutableObjectData
     {
-        public int EntryID { get; set; }
-        public uint DynamicFlags { get; set; }
-        public float Scale { get; set; }
+        public int? EntryID { get; set; }
+        public uint? DynamicFlags { get; set; }
+        public float? Scale { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/SceneObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/SceneObjectData.cs
@@ -7,10 +7,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
 {
     public class SceneObjectData : ISceneObjectData
     {
-        public int ScriptPackageID { get; set; }
+        public int? ScriptPackageID { get; set; }
         public uint RndSeedVal { get; set; }
         public WowGuid CreatedBy { get; set; }
-        public uint SceneType { get; set; }
+        public uint? SceneType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/UnitData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/UnitData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
@@ -5,75 +6,75 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
 {
-    public class UnitData : IUnitData
+    public class UnitData : IMutableUnitData
     {
-        public int DisplayID { get; set; }
-        public uint[] NpcFlags { get; } = new uint[2];
-        public uint StateSpellVisualID { get; set; }
-        public uint StateAnimID { get; set; }
-        public uint StateAnimKitID { get; set; }
+        public int? DisplayID { get; set; }
+        public uint?[] NpcFlags { get; } = new uint?[2];
+        public uint? StateSpellVisualID { get; set; }
+        public uint? StateAnimID { get; set; }
+        public uint? StateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public int SpellOverrideNameID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid Charm { get; set; }
-        public WowGuid Summon { get; set; }
-        public WowGuid Critter { get; set; }
-        public WowGuid CharmedBy { get; set; }
-        public WowGuid SummonedBy { get; set; }
-        public WowGuid CreatedBy { get; set; }
-        public WowGuid DemonCreator { get; set; }
-        public WowGuid LookAtControllerTarget { get; set; }
-        public WowGuid Target { get; set; }
+        public WowGuid? Charm { get; set; }
+        public WowGuid? Summon { get; set; }
+        public WowGuid? Critter { get; set; }
+        public WowGuid? CharmedBy { get; set; }
+        public WowGuid? SummonedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
+        public WowGuid? DemonCreator { get; set; }
+        public WowGuid? LookAtControllerTarget { get; set; }
+        public WowGuid? Target { get; set; }
         public WowGuid BattlePetCompanionGUID { get; set; }
         public ulong BattlePetDBID { get; set; }
         public IUnitChannel ChannelData { get; set; }
         public uint SummonedByHomeRealm { get; set; }
-        public byte Race { get; set; }
-        public byte ClassId { get; set; }
+        public byte? Race { get; set; }
+        public byte? ClassId { get; set; }
         public byte PlayerClassId { get; set; }
-        public byte Sex { get; set; }
-        public byte DisplayPower { get; set; }
+        public byte? Sex { get; set; }
+        public byte? DisplayPower { get; set; }
         public uint OverrideDisplayPowerID { get; set; }
-        public long Health { get; set; }
-        public int[] Power { get; } = new int[6];
-        public int[] MaxPower { get; } = new int[6];
+        public long? Health { get; set; }
+        public int?[] Power { get; } = new int?[6];
+        public int?[] MaxPower { get; } = new int?[6];
         public float[] PowerRegenFlatModifier { get; } = new float[6];
         public float[] PowerRegenInterruptedFlatModifier { get; } = new float[6];
-        public long MaxHealth { get; set; }
-        public int Level { get; set; }
-        public int EffectiveLevel { get; set; }
-        public int ContentTuningID { get; set; }
-        public int ScalingLevelMin { get; set; }
-        public int ScalingLevelMax { get; set; }
-        public int ScalingLevelDelta { get; set; }
+        public long? MaxHealth { get; set; }
+        public int? Level { get; set; }
+        public int? EffectiveLevel { get; set; }
+        public int? ContentTuningID { get; set; }
+        public int? ScalingLevelMin { get; set; }
+        public int? ScalingLevelMax { get; set; }
+        public int? ScalingLevelDelta { get; set; }
         public int ScalingFactionGroup { get; set; }
         public int ScalingHealthItemLevelCurveID { get; set; }
         public int ScalingDamageItemLevelCurveID { get; set; }
-        public int FactionTemplate { get; set; }
+        public int? FactionTemplate { get; set; }
         public IVisibleItem[] VirtualItems { get; } = new IVisibleItem[3];
-        public uint Flags { get; set; }
-        public uint Flags2 { get; set; }
-        public uint Flags3 { get; set; }
-        public uint AuraState { get; set; }
-        public uint[] AttackRoundBaseTime { get; } = new uint[2];
-        public uint RangedAttackRoundBaseTime { get; set; }
-        public float BoundingRadius { get; set; }
-        public float CombatReach { get; set; }
-        public float DisplayScale { get; set; }
-        public int CreatureFamily { get; set; }
-        public int CreatureType { get; set; }
-        public int NativeDisplayID { get; set; }
-        public float NativeXDisplayScale { get; set; }
-        public int MountDisplayID { get; set; }
+        public uint? Flags { get; set; }
+        public uint? Flags2 { get; set; }
+        public uint? Flags3 { get; set; }
+        public uint? AuraState { get; set; }
+        public uint?[] AttackRoundBaseTime { get; } = new uint?[2];
+        public uint? RangedAttackRoundBaseTime { get; set; }
+        public float? BoundingRadius { get; set; }
+        public float? CombatReach { get; set; }
+        public float? DisplayScale { get; set; }
+        public int? CreatureFamily { get; set; }
+        public int? CreatureType { get; set; }
+        public int? NativeDisplayID { get; set; }
+        public float? NativeXDisplayScale { get; set; }
+        public int? MountDisplayID { get; set; }
         public int CosmeticMountDisplayID { get; set; }
         public float MinDamage { get; set; }
         public float MaxDamage { get; set; }
         public float MinOffHandDamage { get; set; }
         public float MaxOffHandDamage { get; set; }
-        public byte StandState { get; set; }
-        public byte PetTalentPoints { get; set; }
-        public byte VisFlags { get; set; }
-        public byte AnimTier { get; set; }
+        public byte? StandState { get; set; }
+        public byte? PetTalentPoints { get; set; }
+        public byte? VisFlags { get; set; }
+        public byte? AnimTier { get; set; }
         public uint PetNumber { get; set; }
         public uint PetNameTimestamp { get; set; }
         public uint PetExperience { get; set; }
@@ -85,20 +86,20 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
         public float ModRangedHaste { get; set; }
         public float ModHasteRegen { get; set; }
         public float ModTimeRate { get; set; }
-        public int CreatedBySpell { get; set; }
-        public int EmoteState { get; set; }
+        public int? CreatedBySpell { get; set; }
+        public int? EmoteState { get; set; }
         public int[] Stats { get; } = new int[4];
         public int[] StatPosBuff { get; } = new int[4];
         public int[] StatNegBuff { get; } = new int[4];
-        public int[] Resistances { get; } = new int[7];
+        public int?[] Resistances { get; } = new int?[7];
         public int[] BonusResistanceMods { get; } = new int[7];
         public int[] ManaCostModifier { get; } = new int[7];
-        public int BaseMana { get; set; }
-        public int BaseHealth { get; set; }
-        public byte SheatheState { get; set; }
-        public byte PvpFlags { get; set; }
-        public byte PetFlags { get; set; }
-        public byte ShapeshiftForm { get; set; }
+        public int? BaseMana { get; set; }
+        public int? BaseHealth { get; set; }
+        public byte? SheatheState { get; set; }
+        public byte? PvpFlags { get; set; }
+        public byte? PetFlags { get; set; }
+        public byte? ShapeshiftForm { get; set; }
         public int AttackPower { get; set; }
         public int AttackPowerModPos { get; set; }
         public int AttackPowerModNeg { get; set; }
@@ -116,14 +117,14 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
         public float MaxRangedDamage { get; set; }
         public float ManaCostMultiplier { get; set; }
         public float MaxHealthModifier { get; set; }
-        public float HoverHeight { get; set; }
+        public float? HoverHeight { get; set; }
         public int MinItemLevelCutoff { get; set; }
         public int MinItemLevel { get; set; }
         public int MaxItemLevel { get; set; }
         public int AzeriteItemLevel { get; set; }
         public int WildBattlePetLevel { get; set; }
         public uint BattlePetCompanionNameTimestamp { get; set; }
-        public int InteractSpellID { get; set; }
+        public int? InteractSpellID { get; set; }
         public int ScaleDuration { get; set; }
         public int LooksLikeMountID { get; set; }
         public int LooksLikeCreatureID { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/VisibleItem.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_2_36639/VisibleItem.cs
@@ -6,10 +6,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_2_36639
 {
     public class VisibleItem : IVisibleItem
     {
-        public int ItemID { get; set; }
+        public int? ItemID { get; set; }
         public int SecondaryItemModifiedAppearanceID { get; set; }
-        public ushort ItemAppearanceModID { get; set; }
-        public ushort ItemVisual { get; set; }
+        public ushort? ItemAppearanceModID { get; set; }
+        public ushort? ItemVisual { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/AreaTriggerData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/AreaTriggerData.cs
@@ -9,14 +9,14 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
     {
         public WowGuid Caster { get; set; }
         public uint Duration { get; set; }
-        public uint TimeToTarget { get; set; }
-        public uint TimeToTargetScale { get; set; }
+        public uint? TimeToTarget { get; set; }
+        public uint? TimeToTargetScale { get; set; }
         public uint TimeToTargetExtraScale { get; set; }
-        public int SpellID { get; set; }
+        public int? SpellID { get; set; }
         public int SpellForVisuals { get; set; }
         public ISpellCastVisual SpellVisual { get; set; }
         public float BoundsRadius2D { get; set; }
-        public uint DecalPropertiesID { get; set; }
+        public uint? DecalPropertiesID { get; set; }
         public WowGuid CreatingEffectGUID { get; set; }
         public IScaleCurve OverrideScaleCurve { get; set; }
         public IScaleCurve ExtraScaleCurve { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/ConversationData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/ConversationData.cs
@@ -7,7 +7,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
 {
     public class ConversationData : IConversationData
     {
-        public int LastLineEndTime { get; set; }
+        public int? LastLineEndTime { get; set; }
         public uint Progress { get; set; }
         public IConversationLine[] Lines { get; set; }
         public DynamicUpdateField<IConversationActor> Actors { get; } = new DynamicUpdateField<IConversationActor>();

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/GameObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/GameObjectData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
@@ -5,26 +6,26 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
 {
-    public class GameObjectData : IGameObjectData
+    public class GameObjectData : IMutableGameObjectData
     {
-        public int DisplayID { get; set; }
+        public int? DisplayID { get; set; }
         public uint SpellVisualID { get; set; }
         public uint StateSpellVisualID { get; set; }
         public uint SpawnTrackingStateAnimID { get; set; }
         public uint SpawnTrackingStateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid CreatedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
-        public Quaternion ParentRotation { get; set; }
-        public int FactionTemplate { get; set; }
-        public sbyte State { get; set; }
-        public sbyte TypeID { get; set; }
-        public byte PercentHealth { get; set; }
-        public uint ArtKit { get; set; }
+        public uint? Flags { get; set; }
+        public Quaternion? ParentRotation { get; set; }
+        public int? FactionTemplate { get; set; }
+        public sbyte? State { get; set; }
+        public sbyte? TypeID { get; set; }
+        public byte? PercentHealth { get; set; }
+        public uint? ArtKit { get; set; }
         public uint CustomParam { get; set; }
-        public int Level { get; set; }
+        public int? Level { get; set; }
         public uint AnimGroupInstance { get; set; }
         public DynamicUpdateField<int> EnableDoodadSets { get; } = new DynamicUpdateField<int>();
     }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/ObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/ObjectData.cs
@@ -4,11 +4,11 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
 {
-    public class ObjectData : IObjectData
+    public class ObjectData : IMutableObjectData
     {
-        public int EntryID { get; set; }
-        public uint DynamicFlags { get; set; }
-        public float Scale { get; set; }
+        public int? EntryID { get; set; }
+        public uint? DynamicFlags { get; set; }
+        public float? Scale { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/SceneObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/SceneObjectData.cs
@@ -7,10 +7,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
 {
     public class SceneObjectData : ISceneObjectData
     {
-        public int ScriptPackageID { get; set; }
+        public int? ScriptPackageID { get; set; }
         public uint RndSeedVal { get; set; }
         public WowGuid CreatedBy { get; set; }
-        public uint SceneType { get; set; }
+        public uint? SceneType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/UnitData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/UnitData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
@@ -5,75 +6,75 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
 {
-    public class UnitData : IUnitData
+    public class UnitData : IMutableUnitData
     {
-        public int DisplayID { get; set; }
-        public uint[] NpcFlags { get; } = new uint[2];
-        public uint StateSpellVisualID { get; set; }
-        public uint StateAnimID { get; set; }
-        public uint StateAnimKitID { get; set; }
+        public int? DisplayID { get; set; }
+        public uint?[] NpcFlags { get; } = new uint?[2];
+        public uint? StateSpellVisualID { get; set; }
+        public uint? StateAnimID { get; set; }
+        public uint? StateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public int SpellOverrideNameID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid Charm { get; set; }
-        public WowGuid Summon { get; set; }
-        public WowGuid Critter { get; set; }
-        public WowGuid CharmedBy { get; set; }
-        public WowGuid SummonedBy { get; set; }
-        public WowGuid CreatedBy { get; set; }
-        public WowGuid DemonCreator { get; set; }
-        public WowGuid LookAtControllerTarget { get; set; }
-        public WowGuid Target { get; set; }
+        public WowGuid? Charm { get; set; }
+        public WowGuid? Summon { get; set; }
+        public WowGuid? Critter { get; set; }
+        public WowGuid? CharmedBy { get; set; }
+        public WowGuid? SummonedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
+        public WowGuid? DemonCreator { get; set; }
+        public WowGuid? LookAtControllerTarget { get; set; }
+        public WowGuid? Target { get; set; }
         public WowGuid BattlePetCompanionGUID { get; set; }
         public ulong BattlePetDBID { get; set; }
         public IUnitChannel ChannelData { get; set; }
         public uint SummonedByHomeRealm { get; set; }
-        public byte Race { get; set; }
-        public byte ClassId { get; set; }
+        public byte? Race { get; set; }
+        public byte? ClassId { get; set; }
         public byte PlayerClassId { get; set; }
-        public byte Sex { get; set; }
-        public byte DisplayPower { get; set; }
+        public byte? Sex { get; set; }
+        public byte? DisplayPower { get; set; }
         public uint OverrideDisplayPowerID { get; set; }
-        public long Health { get; set; }
-        public int[] Power { get; } = new int[6];
-        public int[] MaxPower { get; } = new int[6];
+        public long? Health { get; set; }
+        public int?[] Power { get; } = new int?[6];
+        public int?[] MaxPower { get; } = new int?[6];
         public float[] PowerRegenFlatModifier { get; } = new float[6];
         public float[] PowerRegenInterruptedFlatModifier { get; } = new float[6];
-        public long MaxHealth { get; set; }
-        public int Level { get; set; }
-        public int EffectiveLevel { get; set; }
-        public int ContentTuningID { get; set; }
-        public int ScalingLevelMin { get; set; }
-        public int ScalingLevelMax { get; set; }
-        public int ScalingLevelDelta { get; set; }
+        public long? MaxHealth { get; set; }
+        public int? Level { get; set; }
+        public int? EffectiveLevel { get; set; }
+        public int? ContentTuningID { get; set; }
+        public int? ScalingLevelMin { get; set; }
+        public int? ScalingLevelMax { get; set; }
+        public int? ScalingLevelDelta { get; set; }
         public int ScalingFactionGroup { get; set; }
         public int ScalingHealthItemLevelCurveID { get; set; }
         public int ScalingDamageItemLevelCurveID { get; set; }
-        public int FactionTemplate { get; set; }
+        public int? FactionTemplate { get; set; }
         public IVisibleItem[] VirtualItems { get; } = new IVisibleItem[3];
-        public uint Flags { get; set; }
-        public uint Flags2 { get; set; }
-        public uint Flags3 { get; set; }
-        public uint AuraState { get; set; }
-        public uint[] AttackRoundBaseTime { get; } = new uint[2];
-        public uint RangedAttackRoundBaseTime { get; set; }
-        public float BoundingRadius { get; set; }
-        public float CombatReach { get; set; }
-        public float DisplayScale { get; set; }
-        public int CreatureFamily { get; set; }
-        public int CreatureType { get; set; }
-        public int NativeDisplayID { get; set; }
-        public float NativeXDisplayScale { get; set; }
-        public int MountDisplayID { get; set; }
+        public uint? Flags { get; set; }
+        public uint? Flags2 { get; set; }
+        public uint? Flags3 { get; set; }
+        public uint? AuraState { get; set; }
+        public uint?[] AttackRoundBaseTime { get; } = new uint?[2];
+        public uint? RangedAttackRoundBaseTime { get; set; }
+        public float? BoundingRadius { get; set; }
+        public float? CombatReach { get; set; }
+        public float? DisplayScale { get; set; }
+        public int? CreatureFamily { get; set; }
+        public int? CreatureType { get; set; }
+        public int? NativeDisplayID { get; set; }
+        public float? NativeXDisplayScale { get; set; }
+        public int? MountDisplayID { get; set; }
         public int CosmeticMountDisplayID { get; set; }
         public float MinDamage { get; set; }
         public float MaxDamage { get; set; }
         public float MinOffHandDamage { get; set; }
         public float MaxOffHandDamage { get; set; }
-        public byte StandState { get; set; }
-        public byte PetTalentPoints { get; set; }
-        public byte VisFlags { get; set; }
-        public byte AnimTier { get; set; }
+        public byte? StandState { get; set; }
+        public byte? PetTalentPoints { get; set; }
+        public byte? VisFlags { get; set; }
+        public byte? AnimTier { get; set; }
         public uint PetNumber { get; set; }
         public uint PetNameTimestamp { get; set; }
         public uint PetExperience { get; set; }
@@ -85,20 +86,20 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
         public float ModRangedHaste { get; set; }
         public float ModHasteRegen { get; set; }
         public float ModTimeRate { get; set; }
-        public int CreatedBySpell { get; set; }
-        public int EmoteState { get; set; }
+        public int? CreatedBySpell { get; set; }
+        public int? EmoteState { get; set; }
         public int[] Stats { get; } = new int[4];
         public int[] StatPosBuff { get; } = new int[4];
         public int[] StatNegBuff { get; } = new int[4];
-        public int[] Resistances { get; } = new int[7];
+        public int?[] Resistances { get; } = new int?[7];
         public int[] BonusResistanceMods { get; } = new int[7];
         public int[] ManaCostModifier { get; } = new int[7];
-        public int BaseMana { get; set; }
-        public int BaseHealth { get; set; }
-        public byte SheatheState { get; set; }
-        public byte PvpFlags { get; set; }
-        public byte PetFlags { get; set; }
-        public byte ShapeshiftForm { get; set; }
+        public int? BaseMana { get; set; }
+        public int? BaseHealth { get; set; }
+        public byte? SheatheState { get; set; }
+        public byte? PvpFlags { get; set; }
+        public byte? PetFlags { get; set; }
+        public byte? ShapeshiftForm { get; set; }
         public int AttackPower { get; set; }
         public int AttackPowerModPos { get; set; }
         public int AttackPowerModNeg { get; set; }
@@ -116,14 +117,14 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
         public float MaxRangedDamage { get; set; }
         public float ManaCostMultiplier { get; set; }
         public float MaxHealthModifier { get; set; }
-        public float HoverHeight { get; set; }
+        public float? HoverHeight { get; set; }
         public int MinItemLevelCutoff { get; set; }
         public int MinItemLevel { get; set; }
         public int MaxItemLevel { get; set; }
         public int AzeriteItemLevel { get; set; }
         public int WildBattlePetLevel { get; set; }
         public uint BattlePetCompanionNameTimestamp { get; set; }
-        public int InteractSpellID { get; set; }
+        public int? InteractSpellID { get; set; }
         public int ScaleDuration { get; set; }
         public int LooksLikeMountID { get; set; }
         public int LooksLikeCreatureID { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/VisibleItem.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_0_5_37862/VisibleItem.cs
@@ -6,10 +6,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_0_5_37862
 {
     public class VisibleItem : IVisibleItem
     {
-        public int ItemID { get; set; }
+        public int? ItemID { get; set; }
         public int SecondaryItemModifiedAppearanceID { get; set; }
-        public ushort ItemAppearanceModID { get; set; }
-        public ushort ItemVisual { get; set; }
+        public ushort? ItemAppearanceModID { get; set; }
+        public ushort? ItemVisual { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/AreaTriggerData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/AreaTriggerData.cs
@@ -9,14 +9,14 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
     {
         public WowGuid Caster { get; set; }
         public uint Duration { get; set; }
-        public uint TimeToTarget { get; set; }
-        public uint TimeToTargetScale { get; set; }
+        public uint? TimeToTarget { get; set; }
+        public uint? TimeToTargetScale { get; set; }
         public uint TimeToTargetExtraScale { get; set; }
-        public int SpellID { get; set; }
+        public int? SpellID { get; set; }
         public int SpellForVisuals { get; set; }
         public ISpellCastVisual SpellVisual { get; set; }
         public float BoundsRadius2D { get; set; }
-        public uint DecalPropertiesID { get; set; }
+        public uint? DecalPropertiesID { get; set; }
         public WowGuid CreatingEffectGUID { get; set; }
         public IScaleCurve OverrideScaleCurve { get; set; }
         public IScaleCurve ExtraScaleCurve { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/ConversationData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/ConversationData.cs
@@ -7,7 +7,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
 {
     public class ConversationData : IConversationData
     {
-        public int LastLineEndTime { get; set; }
+        public int? LastLineEndTime { get; set; }
         public uint Progress { get; set; }
         public IConversationLine[] Lines { get; set; }
         public bool DontPlayBroadcastTextSounds { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/GameObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/GameObjectData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
@@ -5,26 +6,26 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
 {
-    public class GameObjectData : IGameObjectData
+    public class GameObjectData : IMutableGameObjectData
     {
-        public int DisplayID { get; set; }
+        public int? DisplayID { get; set; }
         public uint SpellVisualID { get; set; }
         public uint StateSpellVisualID { get; set; }
         public uint SpawnTrackingStateAnimID { get; set; }
         public uint SpawnTrackingStateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid CreatedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
-        public Quaternion ParentRotation { get; set; }
-        public int FactionTemplate { get; set; }
-        public sbyte State { get; set; }
-        public sbyte TypeID { get; set; }
-        public byte PercentHealth { get; set; }
-        public uint ArtKit { get; set; }
+        public uint? Flags { get; set; }
+        public Quaternion? ParentRotation { get; set; }
+        public int? FactionTemplate { get; set; }
+        public sbyte? State { get; set; }
+        public sbyte? TypeID { get; set; }
+        public byte? PercentHealth { get; set; }
+        public uint? ArtKit { get; set; }
         public uint CustomParam { get; set; }
-        public int Level { get; set; }
+        public int? Level { get; set; }
         public uint AnimGroupInstance { get; set; }
         public DynamicUpdateField<int> EnableDoodadSets { get; } = new DynamicUpdateField<int>();
     }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/ObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/ObjectData.cs
@@ -4,11 +4,11 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
 {
-    public class ObjectData : IObjectData
+    public class ObjectData : IMutableObjectData
     {
-        public int EntryID { get; set; }
-        public uint DynamicFlags { get; set; }
-        public float Scale { get; set; }
+        public int? EntryID { get; set; }
+        public uint? DynamicFlags { get; set; }
+        public float? Scale { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/SceneObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/SceneObjectData.cs
@@ -7,10 +7,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
 {
     public class SceneObjectData : ISceneObjectData
     {
-        public int ScriptPackageID { get; set; }
+        public int? ScriptPackageID { get; set; }
         public uint RndSeedVal { get; set; }
         public WowGuid CreatedBy { get; set; }
-        public uint SceneType { get; set; }
+        public uint? SceneType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/UnitData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/UnitData.cs
@@ -5,75 +5,75 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
 {
-    public class UnitData : IUnitData
+    public class UnitData : IMutableUnitData
     {
-        public int DisplayID { get; set; }
-        public uint[] NpcFlags { get; } = new uint[2];
-        public uint StateSpellVisualID { get; set; }
-        public uint StateAnimID { get; set; }
-        public uint StateAnimKitID { get; set; }
+        public int? DisplayID { get; set; }
+        public uint?[] NpcFlags { get; } = new uint?[2];
+        public uint? StateSpellVisualID { get; set; }
+        public uint? StateAnimID { get; set; }
+        public uint? StateAnimKitID { get; set; }
         public uint StateWorldEffectsQuestObjectiveID { get; set; }
         public int SpellOverrideNameID { get; set; }
         public uint[] StateWorldEffectIDs { get; set; }
-        public WowGuid Charm { get; set; }
-        public WowGuid Summon { get; set; }
-        public WowGuid Critter { get; set; }
-        public WowGuid CharmedBy { get; set; }
-        public WowGuid SummonedBy { get; set; }
-        public WowGuid CreatedBy { get; set; }
-        public WowGuid DemonCreator { get; set; }
-        public WowGuid LookAtControllerTarget { get; set; }
-        public WowGuid Target { get; set; }
+        public WowGuid? Charm { get; set; }
+        public WowGuid? Summon { get; set; }
+        public WowGuid? Critter { get; set; }
+        public WowGuid? CharmedBy { get; set; }
+        public WowGuid? SummonedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
+        public WowGuid? DemonCreator { get; set; }
+        public WowGuid? LookAtControllerTarget { get; set; }
+        public WowGuid? Target { get; set; }
         public WowGuid BattlePetCompanionGUID { get; set; }
         public ulong BattlePetDBID { get; set; }
         public IUnitChannel ChannelData { get; set; }
         public uint SummonedByHomeRealm { get; set; }
-        public byte Race { get; set; }
-        public byte ClassId { get; set; }
+        public byte? Race { get; set; }
+        public byte? ClassId { get; set; }
         public byte PlayerClassId { get; set; }
-        public byte Sex { get; set; }
-        public byte DisplayPower { get; set; }
+        public byte? Sex { get; set; }
+        public byte? DisplayPower { get; set; }
         public uint OverrideDisplayPowerID { get; set; }
-        public long Health { get; set; }
-        public int[] Power { get; } = new int[6];
-        public int[] MaxPower { get; } = new int[6];
+        public long? Health { get; set; }
+        public int?[] Power { get; } = new int?[6];
+        public int?[] MaxPower { get; } = new int?[6];
         public float[] PowerRegenFlatModifier { get; } = new float[6];
         public float[] PowerRegenInterruptedFlatModifier { get; } = new float[6];
-        public long MaxHealth { get; set; }
-        public int Level { get; set; }
-        public int EffectiveLevel { get; set; }
-        public int ContentTuningID { get; set; }
-        public int ScalingLevelMin { get; set; }
-        public int ScalingLevelMax { get; set; }
-        public int ScalingLevelDelta { get; set; }
+        public long? MaxHealth { get; set; }
+        public int? Level { get; set; }
+        public int? EffectiveLevel { get; set; }
+        public int? ContentTuningID { get; set; }
+        public int? ScalingLevelMin { get; set; }
+        public int? ScalingLevelMax { get; set; }
+        public int? ScalingLevelDelta { get; set; }
         public int ScalingFactionGroup { get; set; }
         public int ScalingHealthItemLevelCurveID { get; set; }
         public int ScalingDamageItemLevelCurveID { get; set; }
-        public int FactionTemplate { get; set; }
+        public int? FactionTemplate { get; set; }
         public IVisibleItem[] VirtualItems { get; } = new IVisibleItem[3];
-        public uint Flags { get; set; }
-        public uint Flags2 { get; set; }
-        public uint Flags3 { get; set; }
-        public uint AuraState { get; set; }
-        public uint[] AttackRoundBaseTime { get; } = new uint[2];
-        public uint RangedAttackRoundBaseTime { get; set; }
-        public float BoundingRadius { get; set; }
-        public float CombatReach { get; set; }
-        public float DisplayScale { get; set; }
-        public int CreatureFamily { get; set; }
-        public int CreatureType { get; set; }
-        public int NativeDisplayID { get; set; }
-        public float NativeXDisplayScale { get; set; }
-        public int MountDisplayID { get; set; }
+        public uint? Flags { get; set; }
+        public uint? Flags2 { get; set; }
+        public uint? Flags3 { get; set; }
+        public uint? AuraState { get; set; }
+        public uint?[] AttackRoundBaseTime { get; } = new uint?[2];
+        public uint? RangedAttackRoundBaseTime { get; set; }
+        public float? BoundingRadius { get; set; }
+        public float? CombatReach { get; set; }
+        public float? DisplayScale { get; set; }
+        public int? CreatureFamily { get; set; }
+        public int? CreatureType { get; set; }
+        public int? NativeDisplayID { get; set; }
+        public float? NativeXDisplayScale { get; set; }
+        public int? MountDisplayID { get; set; }
         public int CosmeticMountDisplayID { get; set; }
         public float MinDamage { get; set; }
         public float MaxDamage { get; set; }
         public float MinOffHandDamage { get; set; }
         public float MaxOffHandDamage { get; set; }
-        public byte StandState { get; set; }
-        public byte PetTalentPoints { get; set; }
-        public byte VisFlags { get; set; }
-        public byte AnimTier { get; set; }
+        public byte? StandState { get; set; }
+        public byte? PetTalentPoints { get; set; }
+        public byte? VisFlags { get; set; }
+        public byte? AnimTier { get; set; }
         public uint PetNumber { get; set; }
         public uint PetNameTimestamp { get; set; }
         public uint PetExperience { get; set; }
@@ -85,20 +85,20 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
         public float ModRangedHaste { get; set; }
         public float ModHasteRegen { get; set; }
         public float ModTimeRate { get; set; }
-        public int CreatedBySpell { get; set; }
-        public int EmoteState { get; set; }
+        public int? CreatedBySpell { get; set; }
+        public int? EmoteState { get; set; }
         public int[] Stats { get; } = new int[4];
         public int[] StatPosBuff { get; } = new int[4];
         public int[] StatNegBuff { get; } = new int[4];
-        public int[] Resistances { get; } = new int[7];
+        public int?[] Resistances { get; } = new int?[7];
         public int[] BonusResistanceMods { get; } = new int[7];
         public int[] ManaCostModifier { get; } = new int[7];
-        public int BaseMana { get; set; }
-        public int BaseHealth { get; set; }
-        public byte SheatheState { get; set; }
-        public byte PvpFlags { get; set; }
-        public byte PetFlags { get; set; }
-        public byte ShapeshiftForm { get; set; }
+        public int? BaseMana { get; set; }
+        public int? BaseHealth { get; set; }
+        public byte? SheatheState { get; set; }
+        public byte? PvpFlags { get; set; }
+        public byte? PetFlags { get; set; }
+        public byte? ShapeshiftForm { get; set; }
         public int AttackPower { get; set; }
         public int AttackPowerModPos { get; set; }
         public int AttackPowerModNeg { get; set; }
@@ -116,14 +116,14 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
         public float MaxRangedDamage { get; set; }
         public float ManaCostMultiplier { get; set; }
         public float MaxHealthModifier { get; set; }
-        public float HoverHeight { get; set; }
+        public float? HoverHeight { get; set; }
         public int MinItemLevelCutoff { get; set; }
         public int MinItemLevel { get; set; }
         public int MaxItemLevel { get; set; }
         public int AzeriteItemLevel { get; set; }
         public int WildBattlePetLevel { get; set; }
         public uint BattlePetCompanionNameTimestamp { get; set; }
-        public int InteractSpellID { get; set; }
+        public int? InteractSpellID { get; set; }
         public int ScaleDuration { get; set; }
         public int LooksLikeMountID { get; set; }
         public int LooksLikeCreatureID { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/VisibleItem.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_0_39185/VisibleItem.cs
@@ -6,10 +6,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_0_39185
 {
     public class VisibleItem : IVisibleItem
     {
-        public int ItemID { get; set; }
+        public int? ItemID { get; set; }
         public int SecondaryItemModifiedAppearanceID { get; set; }
-        public ushort ItemAppearanceModID { get; set; }
-        public ushort ItemVisual { get; set; }
+        public ushort? ItemAppearanceModID { get; set; }
+        public ushort? ItemVisual { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ActivePlayerData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ActivePlayerData.cs
@@ -10,126 +10,126 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
         public WowGuid[] InvSlots { get; } = new WowGuid[199];
         public WowGuid FarsightObject { get; set; }
         public WowGuid SummonedBattlePetGUID { get; set; }
-        public ulong Coinage { get; set; }
-        public int XP { get; set; }
-        public int NextLevelXP { get; set; }
-        public int TrialXP { get; set; }
+        public System.Nullable<ulong> Coinage { get; set; }
+        public System.Nullable<int> XP { get; set; }
+        public System.Nullable<int> NextLevelXP { get; set; }
+        public System.Nullable<int> TrialXP { get; set; }
         public ISkillInfo Skill { get; set; }
-        public int CharacterPoints { get; set; }
-        public int MaxTalentTiers { get; set; }
-        public uint TrackCreatureMask { get; set; }
-        public float MainhandExpertise { get; set; }
-        public float OffhandExpertise { get; set; }
-        public float RangedExpertise { get; set; }
-        public float CombatRatingExpertise { get; set; }
-        public float BlockPercentage { get; set; }
-        public float DodgePercentage { get; set; }
-        public float DodgePercentageFromAttribute { get; set; }
-        public float ParryPercentage { get; set; }
-        public float ParryPercentageFromAttribute { get; set; }
-        public float CritPercentage { get; set; }
-        public float RangedCritPercentage { get; set; }
-        public float OffhandCritPercentage { get; set; }
-        public float SpellCritPercentage { get; set; }
-        public int ShieldBlock { get; set; }
-        public float ShieldBlockCritPercentage { get; set; }
-        public float Mastery { get; set; }
-        public float Speed { get; set; }
-        public float Avoidance { get; set; }
-        public float Sturdiness { get; set; }
-        public int Versatility { get; set; }
-        public float VersatilityBonus { get; set; }
-        public float PvpPowerDamage { get; set; }
-        public float PvpPowerHealing { get; set; }
-        public ulong[] ExploredZones { get; } = new ulong[240];
+        public System.Nullable<int> CharacterPoints { get; set; }
+        public System.Nullable<int> MaxTalentTiers { get; set; }
+        public System.Nullable<uint> TrackCreatureMask { get; set; }
+        public System.Nullable<float> MainhandExpertise { get; set; }
+        public System.Nullable<float> OffhandExpertise { get; set; }
+        public System.Nullable<float> RangedExpertise { get; set; }
+        public System.Nullable<float> CombatRatingExpertise { get; set; }
+        public System.Nullable<float> BlockPercentage { get; set; }
+        public System.Nullable<float> DodgePercentage { get; set; }
+        public System.Nullable<float> DodgePercentageFromAttribute { get; set; }
+        public System.Nullable<float> ParryPercentage { get; set; }
+        public System.Nullable<float> ParryPercentageFromAttribute { get; set; }
+        public System.Nullable<float> CritPercentage { get; set; }
+        public System.Nullable<float> RangedCritPercentage { get; set; }
+        public System.Nullable<float> OffhandCritPercentage { get; set; }
+        public System.Nullable<float> SpellCritPercentage { get; set; }
+        public System.Nullable<int> ShieldBlock { get; set; }
+        public System.Nullable<float> ShieldBlockCritPercentage { get; set; }
+        public System.Nullable<float> Mastery { get; set; }
+        public System.Nullable<float> Speed { get; set; }
+        public System.Nullable<float> Avoidance { get; set; }
+        public System.Nullable<float> Sturdiness { get; set; }
+        public System.Nullable<int> Versatility { get; set; }
+        public System.Nullable<float> VersatilityBonus { get; set; }
+        public System.Nullable<float> PvpPowerDamage { get; set; }
+        public System.Nullable<float> PvpPowerHealing { get; set; }
+        public System.Nullable<ulong>[] ExploredZones { get; } = new System.Nullable<ulong>[240];
         public IRestInfo[] RestInfo { get; } = new IRestInfo[2];
-        public int[] ModDamageDonePos { get; } = new int[7];
-        public int[] ModDamageDoneNeg { get; } = new int[7];
-        public float[] ModDamageDonePercent { get; } = new float[7];
-        public float[] ModHealingDonePercent { get; } = new float[7];
-        public int ModHealingDonePos { get; set; }
-        public float ModHealingPercent { get; set; }
-        public float ModPeriodicHealingDonePercent { get; set; }
-        public float[] WeaponDmgMultipliers { get; } = new float[3];
-        public float[] WeaponAtkSpeedMultipliers { get; } = new float[3];
-        public float ModSpellPowerPercent { get; set; }
-        public float ModResiliencePercent { get; set; }
-        public float OverrideSpellPowerByAPPercent { get; set; }
-        public float OverrideAPBySpellPowerPercent { get; set; }
-        public int ModTargetResistance { get; set; }
-        public int ModTargetPhysicalResistance { get; set; }
-        public uint LocalFlags { get; set; }
-        public byte GrantableLevels { get; set; }
-        public byte MultiActionBars { get; set; }
-        public byte LifetimeMaxRank { get; set; }
-        public byte NumRespecs { get; set; }
-        public uint PvpMedals { get; set; }
-        public uint[] BuybackPrice { get; } = new uint[12];
-        public uint[] BuybackTimestamp { get; } = new uint[12];
-        public ushort TodayHonorableKills { get; set; }
-        public ushort YesterdayHonorableKills { get; set; }
-        public uint LifetimeHonorableKills { get; set; }
-        public int WatchedFactionIndex { get; set; }
-        public int[] CombatRatings { get; } = new int[32];
-        public int MaxLevel { get; set; }
-        public int ScalingPlayerLevelDelta { get; set; }
-        public int MaxCreatureScalingLevel { get; set; }
-        public uint[] NoReagentCostMask { get; } = new uint[4];
-        public int PetSpellPower { get; set; }
-        public int[] ProfessionSkillLine { get; } = new int[2];
-        public float UiHitModifier { get; set; }
-        public float UiSpellHitModifier { get; set; }
-        public int HomeRealmTimeOffset { get; set; }
-        public float ModPetHaste { get; set; }
-        public sbyte JailersTowerLevelMax { get; set; }
-        public sbyte JailersTowerLevel { get; set; }
-        public byte LocalRegenFlags { get; set; }
-        public byte AuraVision { get; set; }
-        public byte NumBackpackSlots { get; set; }
-        public int OverrideSpellsID { get; set; }
-        public ushort LootSpecID { get; set; }
-        public uint OverrideZonePVPType { get; set; }
+        public System.Nullable<int>[] ModDamageDonePos { get; } = new System.Nullable<int>[7];
+        public System.Nullable<int>[] ModDamageDoneNeg { get; } = new System.Nullable<int>[7];
+        public System.Nullable<float>[] ModDamageDonePercent { get; } = new System.Nullable<float>[7];
+        public System.Nullable<float>[] ModHealingDonePercent { get; } = new System.Nullable<float>[7];
+        public System.Nullable<int> ModHealingDonePos { get; set; }
+        public System.Nullable<float> ModHealingPercent { get; set; }
+        public System.Nullable<float> ModPeriodicHealingDonePercent { get; set; }
+        public System.Nullable<float>[] WeaponDmgMultipliers { get; } = new System.Nullable<float>[3];
+        public System.Nullable<float>[] WeaponAtkSpeedMultipliers { get; } = new System.Nullable<float>[3];
+        public System.Nullable<float> ModSpellPowerPercent { get; set; }
+        public System.Nullable<float> ModResiliencePercent { get; set; }
+        public System.Nullable<float> OverrideSpellPowerByAPPercent { get; set; }
+        public System.Nullable<float> OverrideAPBySpellPowerPercent { get; set; }
+        public System.Nullable<int> ModTargetResistance { get; set; }
+        public System.Nullable<int> ModTargetPhysicalResistance { get; set; }
+        public System.Nullable<uint> LocalFlags { get; set; }
+        public System.Nullable<byte> GrantableLevels { get; set; }
+        public System.Nullable<byte> MultiActionBars { get; set; }
+        public System.Nullable<byte> LifetimeMaxRank { get; set; }
+        public System.Nullable<byte> NumRespecs { get; set; }
+        public System.Nullable<uint> PvpMedals { get; set; }
+        public System.Nullable<uint>[] BuybackPrice { get; } = new System.Nullable<uint>[12];
+        public System.Nullable<uint>[] BuybackTimestamp { get; } = new System.Nullable<uint>[12];
+        public System.Nullable<ushort> TodayHonorableKills { get; set; }
+        public System.Nullable<ushort> YesterdayHonorableKills { get; set; }
+        public System.Nullable<uint> LifetimeHonorableKills { get; set; }
+        public System.Nullable<int> WatchedFactionIndex { get; set; }
+        public System.Nullable<int>[] CombatRatings { get; } = new System.Nullable<int>[32];
+        public System.Nullable<int> MaxLevel { get; set; }
+        public System.Nullable<int> ScalingPlayerLevelDelta { get; set; }
+        public System.Nullable<int> MaxCreatureScalingLevel { get; set; }
+        public System.Nullable<uint>[] NoReagentCostMask { get; } = new System.Nullable<uint>[4];
+        public System.Nullable<int> PetSpellPower { get; set; }
+        public System.Nullable<int>[] ProfessionSkillLine { get; } = new System.Nullable<int>[2];
+        public System.Nullable<float> UiHitModifier { get; set; }
+        public System.Nullable<float> UiSpellHitModifier { get; set; }
+        public System.Nullable<int> HomeRealmTimeOffset { get; set; }
+        public System.Nullable<float> ModPetHaste { get; set; }
+        public System.Nullable<sbyte> JailersTowerLevelMax { get; set; }
+        public System.Nullable<sbyte> JailersTowerLevel { get; set; }
+        public System.Nullable<byte> LocalRegenFlags { get; set; }
+        public System.Nullable<byte> AuraVision { get; set; }
+        public System.Nullable<byte> NumBackpackSlots { get; set; }
+        public System.Nullable<int> OverrideSpellsID { get; set; }
+        public System.Nullable<ushort> LootSpecID { get; set; }
+        public System.Nullable<uint> OverrideZonePVPType { get; set; }
         public WowGuid BnetAccount { get; set; }
-        public ulong GuildClubMemberID { get; set; }
-        public uint[] BagSlotFlags { get; } = new uint[4];
-        public uint[] BankBagSlotFlags { get; } = new uint[7];
-        public ulong[] QuestCompleted { get; } = new ulong[875];
-        public int Honor { get; set; }
-        public int HonorNextLevel { get; set; }
-        public byte NumBankSlots { get; set; }
+        public System.Nullable<ulong> GuildClubMemberID { get; set; }
+        public System.Nullable<uint>[] BagSlotFlags { get; } = new System.Nullable<uint>[4];
+        public System.Nullable<uint>[] BankBagSlotFlags { get; } = new System.Nullable<uint>[7];
+        public System.Nullable<ulong>[] QuestCompleted { get; } = new System.Nullable<ulong>[875];
+        public System.Nullable<int> Honor { get; set; }
+        public System.Nullable<int> HonorNextLevel { get; set; }
+        public System.Nullable<byte> NumBankSlots { get; set; }
         public IActivePlayerUnk901 Field_1410 { get; set; }
         public IQuestSession QuestSession { get; set; }
-        public int UiChromieTimeExpansionID { get; set; }
-        public int TransportServerTime { get; set; }
-        public uint WeeklyRewardsPeriodSinceOrigin { get; set; }
-        public short DEBUGSoulbindConduitRank { get; set; }
+        public System.Nullable<int> UiChromieTimeExpansionID { get; set; }
+        public System.Nullable<int> TransportServerTime { get; set; }
+        public System.Nullable<uint> WeeklyRewardsPeriodSinceOrigin { get; set; }
+        public System.Nullable<short> DEBUGSoulbindConduitRank { get; set; }
         public DynamicUpdateField<IResearch>[] Research { get; } = new DynamicUpdateField<IResearch>[1] { new DynamicUpdateField<IResearch>() };
-        public DynamicUpdateField<ulong> KnownTitles { get; } = new DynamicUpdateField<ulong>();
-        public DynamicUpdateField<ushort> ResearchSites { get; } = new DynamicUpdateField<ushort>();
-        public DynamicUpdateField<uint> ResearchSiteProgress { get; } = new DynamicUpdateField<uint>();
-        public DynamicUpdateField<int> DailyQuestsCompleted { get; } = new DynamicUpdateField<int>();
-        public DynamicUpdateField<int> AvailableQuestLineXQuestIDs { get; } = new DynamicUpdateField<int>();
-        public DynamicUpdateField<int> Heirlooms { get; } = new DynamicUpdateField<int>();
-        public DynamicUpdateField<uint> HeirloomFlags { get; } = new DynamicUpdateField<uint>();
-        public DynamicUpdateField<int> Toys { get; } = new DynamicUpdateField<int>();
-        public DynamicUpdateField<uint> ToyFlags { get; } = new DynamicUpdateField<uint>();
-        public DynamicUpdateField<uint> Transmog { get; } = new DynamicUpdateField<uint>();
-        public DynamicUpdateField<int> ConditionalTransmog { get; } = new DynamicUpdateField<int>();
-        public DynamicUpdateField<int> SelfResSpells { get; } = new DynamicUpdateField<int>();
-        public DynamicUpdateField<uint> RuneforgePowers { get; } = new DynamicUpdateField<uint>();
-        public DynamicUpdateField<uint> TransmogIllusions { get; } = new DynamicUpdateField<uint>();
+        public DynamicUpdateField<System.Nullable<ulong>> KnownTitles { get; } = new DynamicUpdateField<System.Nullable<ulong>>();
+        public DynamicUpdateField<System.Nullable<ushort>> ResearchSites { get; } = new DynamicUpdateField<System.Nullable<ushort>>();
+        public DynamicUpdateField<System.Nullable<uint>> ResearchSiteProgress { get; } = new DynamicUpdateField<System.Nullable<uint>>();
+        public DynamicUpdateField<System.Nullable<int>> DailyQuestsCompleted { get; } = new DynamicUpdateField<System.Nullable<int>>();
+        public DynamicUpdateField<System.Nullable<int>> AvailableQuestLineXQuestIDs { get; } = new DynamicUpdateField<System.Nullable<int>>();
+        public DynamicUpdateField<System.Nullable<int>> Heirlooms { get; } = new DynamicUpdateField<System.Nullable<int>>();
+        public DynamicUpdateField<System.Nullable<uint>> HeirloomFlags { get; } = new DynamicUpdateField<System.Nullable<uint>>();
+        public DynamicUpdateField<System.Nullable<int>> Toys { get; } = new DynamicUpdateField<System.Nullable<int>>();
+        public DynamicUpdateField<System.Nullable<uint>> ToyFlags { get; } = new DynamicUpdateField<System.Nullable<uint>>();
+        public DynamicUpdateField<System.Nullable<uint>> Transmog { get; } = new DynamicUpdateField<System.Nullable<uint>>();
+        public DynamicUpdateField<System.Nullable<int>> ConditionalTransmog { get; } = new DynamicUpdateField<System.Nullable<int>>();
+        public DynamicUpdateField<System.Nullable<int>> SelfResSpells { get; } = new DynamicUpdateField<System.Nullable<int>>();
+        public DynamicUpdateField<System.Nullable<uint>> RuneforgePowers { get; } = new DynamicUpdateField<System.Nullable<uint>>();
+        public DynamicUpdateField<System.Nullable<uint>> TransmogIllusions { get; } = new DynamicUpdateField<System.Nullable<uint>>();
         public DynamicUpdateField<ISpellPctModByLabel> SpellPctModByLabel { get; } = new DynamicUpdateField<ISpellPctModByLabel>();
         public DynamicUpdateField<ISpellFlatModByLabel> SpellFlatModByLabel { get; } = new DynamicUpdateField<ISpellFlatModByLabel>();
         public DynamicUpdateField<IMawPower> MawPowers { get; } = new DynamicUpdateField<IMawPower>();
         public DynamicUpdateField<IMultiFloorExplore> MultiFloorExploration { get; } = new DynamicUpdateField<IMultiFloorExplore>();
         public DynamicUpdateField<IRecipeProgressionInfo> RecipeProgression { get; } = new DynamicUpdateField<IRecipeProgressionInfo>();
         public DynamicUpdateField<IReplayedQuest> ReplayedQuests { get; } = new DynamicUpdateField<IReplayedQuest>();
-        public DynamicUpdateField<int> DisabledSpells { get; } = new DynamicUpdateField<int>();
+        public DynamicUpdateField<System.Nullable<int>> DisabledSpells { get; } = new DynamicUpdateField<System.Nullable<int>>();
         public IPVPInfo[] PvpInfo { get; } = new IPVPInfo[6];
-        public bool BackpackAutoSortDisabled { get; set; }
-        public bool BankAutoSortDisabled { get; set; }
-        public bool SortBagsRightToLeft { get; set; }
-        public bool InsertItemsLeftToRight { get; set; }
+        public System.Nullable<bool> BackpackAutoSortDisabled { get; set; }
+        public System.Nullable<bool> BankAutoSortDisabled { get; set; }
+        public System.Nullable<bool> SortBagsRightToLeft { get; set; }
+        public System.Nullable<bool> InsertItemsLeftToRight { get; set; }
         public DynamicUpdateField<ICharacterRestriction> CharacterRestrictions { get; } = new DynamicUpdateField<ICharacterRestriction>();
     }
 }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ActivePlayerUnk901.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ActivePlayerUnk901.cs
@@ -8,7 +8,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
     public class ActivePlayerUnk901 : IActivePlayerUnk901
     {
         public WowGuid Field_0 { get; set; }
-        public int Field_10 { get; set; }
+        public System.Nullable<int> Field_10 { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/AreaTriggerData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/AreaTriggerData.cs
@@ -8,15 +8,15 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
     public class AreaTriggerData : IAreaTriggerData
     {
         public WowGuid Caster { get; set; }
-        public uint Duration { get; set; }
-        public uint TimeToTarget { get; set; }
-        public uint TimeToTargetScale { get; set; }
-        public uint TimeToTargetExtraScale { get; set; }
-        public int SpellID { get; set; }
-        public int SpellForVisuals { get; set; }
+        public System.Nullable<uint> Duration { get; set; }
+        public System.Nullable<uint> TimeToTarget { get; set; }
+        public System.Nullable<uint> TimeToTargetScale { get; set; }
+        public System.Nullable<uint> TimeToTargetExtraScale { get; set; }
+        public System.Nullable<int> SpellID { get; set; }
+        public System.Nullable<int> SpellForVisuals { get; set; }
         public ISpellCastVisual SpellVisual { get; set; }
-        public float BoundsRadius2D { get; set; }
-        public uint DecalPropertiesID { get; set; }
+        public System.Nullable<float> BoundsRadius2D { get; set; }
+        public System.Nullable<uint> DecalPropertiesID { get; set; }
         public WowGuid CreatingEffectGUID { get; set; }
         public WowGuid Field_80 { get; set; }
         public IScaleCurve OverrideScaleCurve { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ArenaCooldown.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ArenaCooldown.cs
@@ -7,13 +7,13 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class ArenaCooldown : IArenaCooldown
     {
-        public int SpellID { get; set; }
-        public int Charges { get; set; }
-        public uint Flags { get; set; }
-        public uint StartTime { get; set; }
-        public uint EndTime { get; set; }
-        public uint NextChargeTime { get; set; }
-        public byte MaxCharges { get; set; }
+        public System.Nullable<int> SpellID { get; set; }
+        public System.Nullable<int> Charges { get; set; }
+        public System.Nullable<uint> Flags { get; set; }
+        public System.Nullable<uint> StartTime { get; set; }
+        public System.Nullable<uint> EndTime { get; set; }
+        public System.Nullable<uint> NextChargeTime { get; set; }
+        public System.Nullable<byte> MaxCharges { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/AzeriteEmpoweredItemData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/AzeriteEmpoweredItemData.cs
@@ -7,7 +7,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class AzeriteEmpoweredItemData : IAzeriteEmpoweredItemData
     {
-        public int[] Selections { get; } = new int[5];
+        public System.Nullable<int>[] Selections { get; } = new System.Nullable<int>[5];
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/AzeriteItemData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/AzeriteItemData.cs
@@ -7,14 +7,14 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class AzeriteItemData : IAzeriteItemData
     {
-        public ulong Xp { get; set; }
-        public uint Level { get; set; }
-        public uint AuraLevel { get; set; }
-        public uint KnowledgeLevel { get; set; }
-        public int DEBUGknowledgeWeek { get; set; }
+        public System.Nullable<ulong> Xp { get; set; }
+        public System.Nullable<uint> Level { get; set; }
+        public System.Nullable<uint> AuraLevel { get; set; }
+        public System.Nullable<uint> KnowledgeLevel { get; set; }
+        public System.Nullable<int> DEBUGknowledgeWeek { get; set; }
         public DynamicUpdateField<IUnlockedAzeriteEssence> UnlockedEssences { get; } = new DynamicUpdateField<IUnlockedAzeriteEssence>();
-        public DynamicUpdateField<uint> UnlockedEssenceMilestones { get; } = new DynamicUpdateField<uint>();
-        public bool Enabled { get; set; }
+        public DynamicUpdateField<System.Nullable<uint>> UnlockedEssenceMilestones { get; } = new DynamicUpdateField<System.Nullable<uint>>();
+        public System.Nullable<bool> Enabled { get; set; }
         public DynamicUpdateField<ISelectedAzeriteEssences> SelectedEssences { get; } = new DynamicUpdateField<ISelectedAzeriteEssences>();
     }
 }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ContainerData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ContainerData.cs
@@ -8,7 +8,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
     public class ContainerData : IContainerData
     {
         public WowGuid[] Slots { get; } = new WowGuid[36];
-        public uint NumSlots { get; set; }
+        public System.Nullable<uint> NumSlots { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ConversationData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ConversationData.cs
@@ -5,13 +5,13 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
-    public class ConversationData : IConversationData
+    public class ConversationData : IMutableConversationData
     {
-        public int LastLineEndTime { get; set; }
-        public uint Progress { get; set; }
+        public System.Nullable<int> LastLineEndTime { get; set; }
+        public System.Nullable<uint> Progress { get; set; }
         public IConversationLine[] Lines { get; set; }
-        public uint Flags { get; set; }
-        public bool DontPlayBroadcastTextSounds { get; set; }
+        public System.Nullable<uint> Flags { get; set; }
+        public System.Nullable<bool> DontPlayBroadcastTextSounds { get; set; }
         public DynamicUpdateField<IConversationActor> Actors { get; } = new DynamicUpdateField<IConversationActor>();
     }
 }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/CorpseData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/CorpseData.cs
@@ -7,18 +7,18 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class CorpseData : ICorpseData
     {
-        public uint DynamicFlags { get; set; }
+        public System.Nullable<uint> DynamicFlags { get; set; }
         public WowGuid Owner { get; set; }
         public WowGuid PartyGUID { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint DisplayID { get; set; }
-        public uint[] Items { get; } = new uint[19];
-        public byte RaceID { get; set; }
-        public byte Sex { get; set; }
-        public byte Class { get; set; }
-        public uint Flags { get; set; }
-        public int FactionTemplate { get; set; }
-        public uint StateSpellVisualKitID { get; set; }
+        public System.Nullable<uint> DisplayID { get; set; }
+        public System.Nullable<uint>[] Items { get; } = new System.Nullable<uint>[19];
+        public System.Nullable<byte> RaceID { get; set; }
+        public System.Nullable<byte> Sex { get; set; }
+        public System.Nullable<byte> Class { get; set; }
+        public System.Nullable<uint> Flags { get; set; }
+        public System.Nullable<int> FactionTemplate { get; set; }
+        public System.Nullable<uint> StateSpellVisualKitID { get; set; }
         public DynamicUpdateField<IChrCustomizationChoice> Customizations { get; } = new DynamicUpdateField<IChrCustomizationChoice>();
     }
 }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/DynamicObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/DynamicObjectData.cs
@@ -9,10 +9,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
     {
         public WowGuid Caster { get; set; }
         public ISpellCastVisual SpellVisual { get; set; }
-        public int SpellID { get; set; }
-        public float Radius { get; set; }
-        public uint CastTime { get; set; }
-        public byte Type { get; set; }
+        public System.Nullable<int> SpellID { get; set; }
+        public System.Nullable<float> Radius { get; set; }
+        public System.Nullable<uint> CastTime { get; set; }
+        public System.Nullable<byte> Type { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/GameObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/GameObjectData.cs
@@ -5,28 +5,28 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
-    public class GameObjectData : IGameObjectData
+    public class GameObjectData : IMutableGameObjectData
     {
-        public int DisplayID { get; set; }
-        public uint SpellVisualID { get; set; }
-        public uint StateSpellVisualID { get; set; }
-        public uint SpawnTrackingStateAnimID { get; set; }
-        public uint SpawnTrackingStateAnimKitID { get; set; }
-        public uint StateWorldEffectsQuestObjectiveID { get; set; }
-        public uint[] StateWorldEffectIDs { get; set; }
+        public System.Nullable<int> DisplayID { get; set; }
+        public System.Nullable<uint> SpellVisualID { get; set; }
+        public System.Nullable<uint> StateSpellVisualID { get; set; }
+        public System.Nullable<uint> SpawnTrackingStateAnimID { get; set; }
+        public System.Nullable<uint> SpawnTrackingStateAnimKitID { get; set; }
+        public System.Nullable<uint> StateWorldEffectsQuestObjectiveID { get; set; }
+        public System.Nullable<uint>[] StateWorldEffectIDs { get; set; }
         public WowGuid CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
-        public uint Flags { get; set; }
-        public Quaternion ParentRotation { get; set; }
-        public int FactionTemplate { get; set; }
-        public sbyte State { get; set; }
-        public sbyte TypeID { get; set; }
-        public byte PercentHealth { get; set; }
-        public uint ArtKit { get; set; }
-        public uint CustomParam { get; set; }
-        public int Level { get; set; }
-        public uint AnimGroupInstance { get; set; }
-        public DynamicUpdateField<int> EnableDoodadSets { get; } = new DynamicUpdateField<int>();
+        public System.Nullable<uint> Flags { get; set; }
+        public Quaternion? ParentRotation { get; set; }
+        public System.Nullable<int> FactionTemplate { get; set; }
+        public System.Nullable<sbyte> State { get; set; }
+        public System.Nullable<sbyte> TypeID { get; set; }
+        public System.Nullable<byte> PercentHealth { get; set; }
+        public System.Nullable<uint> ArtKit { get; set; }
+        public System.Nullable<uint> CustomParam { get; set; }
+        public System.Nullable<int> Level { get; set; }
+        public System.Nullable<uint> AnimGroupInstance { get; set; }
+        public DynamicUpdateField<System.Nullable<int>> EnableDoodadSets { get; } = new DynamicUpdateField<System.Nullable<int>>();
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/GameObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/GameObjectData.cs
@@ -1,3 +1,4 @@
+#nullable enable
 using WowPacketParser.Misc;
 using WowPacketParser.Store.Objects.UpdateFields;
 
@@ -14,7 +15,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
         public System.Nullable<uint> SpawnTrackingStateAnimKitID { get; set; }
         public System.Nullable<uint> StateWorldEffectsQuestObjectiveID { get; set; }
         public System.Nullable<uint>[] StateWorldEffectIDs { get; set; }
-        public WowGuid CreatedBy { get; set; }
+        public WowGuid? CreatedBy { get; set; }
         public WowGuid GuildGUID { get; set; }
         public System.Nullable<uint> Flags { get; set; }
         public Quaternion? ParentRotation { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ItemData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ItemData.cs
@@ -7,24 +7,24 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class ItemData : IItemData
     {
-        public int[] BonusListIDs { get; set; }
+        public System.Nullable<int>[] BonusListIDs { get; set; }
         public WowGuid Owner { get; set; }
         public WowGuid ContainedIn { get; set; }
         public WowGuid Creator { get; set; }
         public WowGuid GiftCreator { get; set; }
-        public uint StackCount { get; set; }
-        public uint Expiration { get; set; }
-        public int[] SpellCharges { get; } = new int[5];
-        public uint DynamicFlags { get; set; }
+        public System.Nullable<uint> StackCount { get; set; }
+        public System.Nullable<uint> Expiration { get; set; }
+        public System.Nullable<int>[] SpellCharges { get; } = new System.Nullable<int>[5];
+        public System.Nullable<uint> DynamicFlags { get; set; }
         public IItemEnchantment[] Enchantment { get; } = new IItemEnchantment[13];
-        public uint Durability { get; set; }
-        public uint MaxDurability { get; set; }
-        public uint CreatePlayedTime { get; set; }
-        public int Context { get; set; }
-        public long CreateTime { get; set; }
-        public ulong ArtifactXP { get; set; }
-        public byte ItemAppearanceModID { get; set; }
-        public uint DynamicFlags2 { get; set; }
+        public System.Nullable<uint> Durability { get; set; }
+        public System.Nullable<uint> MaxDurability { get; set; }
+        public System.Nullable<uint> CreatePlayedTime { get; set; }
+        public System.Nullable<int> Context { get; set; }
+        public System.Nullable<long> CreateTime { get; set; }
+        public System.Nullable<ulong> ArtifactXP { get; set; }
+        public System.Nullable<byte> ItemAppearanceModID { get; set; }
+        public System.Nullable<uint> DynamicFlags2 { get; set; }
         public DynamicUpdateField<IArtifactPower> ArtifactPowers { get; } = new DynamicUpdateField<IArtifactPower>();
         public DynamicUpdateField<ISocketedGem> Gems { get; } = new DynamicUpdateField<ISocketedGem>();
         public IItemModList Modifiers { get; set; }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ItemEnchantment.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ItemEnchantment.cs
@@ -7,10 +7,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class ItemEnchantment : IItemEnchantment
     {
-        public int ID { get; set; }
-        public uint Duration { get; set; }
-        public short Charges { get; set; }
-        public ushort Inactive { get; set; }
+        public System.Nullable<int> ID { get; set; }
+        public System.Nullable<uint> Duration { get; set; }
+        public System.Nullable<short> Charges { get; set; }
+        public System.Nullable<ushort> Inactive { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ObjectData.cs
@@ -5,11 +5,11 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
-    public class ObjectData : IObjectData
+    public class ObjectData : IMutableObjectData
     {
-        public int EntryID { get; set; }
-        public uint DynamicFlags { get; set; }
-        public float Scale { get; set; }
+        public System.Nullable<int> EntryID { get; set; }
+        public System.Nullable<uint> DynamicFlags { get; set; }
+        public System.Nullable<float> Scale { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/PVPInfo.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/PVPInfo.cs
@@ -7,18 +7,18 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class PVPInfo : IPVPInfo
     {
-        public uint WeeklyPlayed { get; set; }
-        public uint WeeklyWon { get; set; }
-        public uint SeasonPlayed { get; set; }
-        public uint SeasonWon { get; set; }
-        public uint Rating { get; set; }
-        public uint WeeklyBestRating { get; set; }
-        public uint SeasonBestRating { get; set; }
-        public uint PvpTierID { get; set; }
-        public uint WeeklyBestWinPvpTierID { get; set; }
-        public uint Field_28 { get; set; }
-        public uint Field_2C { get; set; }
-        public bool Disqualified { get; set; }
+        public System.Nullable<uint> WeeklyPlayed { get; set; }
+        public System.Nullable<uint> WeeklyWon { get; set; }
+        public System.Nullable<uint> SeasonPlayed { get; set; }
+        public System.Nullable<uint> SeasonWon { get; set; }
+        public System.Nullable<uint> Rating { get; set; }
+        public System.Nullable<uint> WeeklyBestRating { get; set; }
+        public System.Nullable<uint> SeasonBestRating { get; set; }
+        public System.Nullable<uint> PvpTierID { get; set; }
+        public System.Nullable<uint> WeeklyBestWinPvpTierID { get; set; }
+        public System.Nullable<uint> Field_28 { get; set; }
+        public System.Nullable<uint> Field_2C { get; set; }
+        public System.Nullable<bool> Disqualified { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/PlayerData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/PlayerData.cs
@@ -10,38 +10,38 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
         public WowGuid DuelArbiter { get; set; }
         public WowGuid WowAccount { get; set; }
         public WowGuid LootTargetGUID { get; set; }
-        public uint PlayerFlags { get; set; }
-        public uint PlayerFlagsEx { get; set; }
-        public uint GuildRankID { get; set; }
-        public uint GuildDeleteDate { get; set; }
-        public int GuildLevel { get; set; }
-        public byte PartyType { get; set; }
-        public byte NativeSex { get; set; }
-        public byte Inebriation { get; set; }
-        public byte PvpTitle { get; set; }
-        public byte ArenaFaction { get; set; }
-        public uint DuelTeam { get; set; }
-        public int GuildTimeStamp { get; set; }
+        public System.Nullable<uint> PlayerFlags { get; set; }
+        public System.Nullable<uint> PlayerFlagsEx { get; set; }
+        public System.Nullable<uint> GuildRankID { get; set; }
+        public System.Nullable<uint> GuildDeleteDate { get; set; }
+        public System.Nullable<int> GuildLevel { get; set; }
+        public System.Nullable<byte> PartyType { get; set; }
+        public System.Nullable<byte> NativeSex { get; set; }
+        public System.Nullable<byte> Inebriation { get; set; }
+        public System.Nullable<byte> PvpTitle { get; set; }
+        public System.Nullable<byte> ArenaFaction { get; set; }
+        public System.Nullable<uint> DuelTeam { get; set; }
+        public System.Nullable<int> GuildTimeStamp { get; set; }
         public IQuestLog[] QuestLog { get; } = new IQuestLog[125];
         public IVisibleItem[] VisibleItems { get; } = new IVisibleItem[19];
-        public int PlayerTitle { get; set; }
-        public int FakeInebriation { get; set; }
-        public uint VirtualPlayerRealm { get; set; }
-        public uint CurrentSpecID { get; set; }
-        public int TaxiMountAnimKitID { get; set; }
-        public float[] AvgItemLevel { get; } = new float[6];
-        public byte CurrentBattlePetBreedQuality { get; set; }
-        public int HonorLevel { get; set; }
-        public int Field_B0 { get; set; }
-        public int Field_B4 { get; set; }
+        public System.Nullable<int> PlayerTitle { get; set; }
+        public System.Nullable<int> FakeInebriation { get; set; }
+        public System.Nullable<uint> VirtualPlayerRealm { get; set; }
+        public System.Nullable<uint> CurrentSpecID { get; set; }
+        public System.Nullable<int> TaxiMountAnimKitID { get; set; }
+        public System.Nullable<float>[] AvgItemLevel { get; } = new System.Nullable<float>[6];
+        public System.Nullable<byte> CurrentBattlePetBreedQuality { get; set; }
+        public System.Nullable<int> HonorLevel { get; set; }
+        public System.Nullable<int> Field_B0 { get; set; }
+        public System.Nullable<int> Field_B4 { get; set; }
         public ICTROptions CtrOptions { get; set; }
-        public int CovenantID { get; set; }
-        public int SoulbindID { get; set; }
+        public System.Nullable<int> CovenantID { get; set; }
+        public System.Nullable<int> SoulbindID { get; set; }
         public DynamicUpdateField<IChrCustomizationChoice> Customizations { get; } = new DynamicUpdateField<IChrCustomizationChoice>();
         public DynamicUpdateField<IQuestLog> QuestSessionQuestLog { get; } = new DynamicUpdateField<IQuestLog>();
         public DynamicUpdateField<IArenaCooldown> ArenaCooldowns { get; } = new DynamicUpdateField<IArenaCooldown>();
-        public bool HasQuestSession { get; set; }
-        public bool HasLevelLink { get; set; }
+        public System.Nullable<bool> HasQuestSession { get; set; }
+        public System.Nullable<bool> HasLevelLink { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/QuestLog.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/QuestLog.cs
@@ -7,12 +7,12 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class QuestLog : IQuestLog
     {
-        public int QuestID { get; set; }
-        public uint StateFlags { get; set; }
-        public uint EndTime { get; set; }
-        public uint AcceptTime { get; set; }
-        public uint ObjectiveFlags { get; set; }
-        public short[] ObjectiveProgress { get; } = new short[24];
+        public System.Nullable<int> QuestID { get; set; }
+        public System.Nullable<uint> StateFlags { get; set; }
+        public System.Nullable<uint> EndTime { get; set; }
+        public System.Nullable<uint> AcceptTime { get; set; }
+        public System.Nullable<uint> ObjectiveFlags { get; set; }
+        public System.Nullable<short>[] ObjectiveProgress { get; } = new System.Nullable<short>[24];
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/QuestSession.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/QuestSession.cs
@@ -8,7 +8,7 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
     public class QuestSession : IQuestSession
     {
         public WowGuid Owner { get; set; }
-        public ulong[] QuestCompleted { get; } = new ulong[875];
+        public System.Nullable<ulong>[] QuestCompleted { get; } = new System.Nullable<ulong>[875];
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ReplayedQuest.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ReplayedQuest.cs
@@ -7,8 +7,8 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class ReplayedQuest : IReplayedQuest
     {
-        public int QuestID { get; set; }
-        public uint ReplayTime { get; set; }
+        public System.Nullable<int> QuestID { get; set; }
+        public System.Nullable<uint> ReplayTime { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/RestInfo.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/RestInfo.cs
@@ -7,8 +7,8 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class RestInfo : IRestInfo
     {
-        public uint Threshold { get; set; }
-        public byte StateID { get; set; }
+        public System.Nullable<uint> Threshold { get; set; }
+        public System.Nullable<byte> StateID { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ScaleCurve.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/ScaleCurve.cs
@@ -7,10 +7,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class ScaleCurve : IScaleCurve
     {
-        public uint StartTimeOffset { get; set; }
+        public System.Nullable<uint> StartTimeOffset { get; set; }
         public Vector2[] Points { get; } = new Vector2[2];
-        public uint ParameterCurve { get; set; }
-        public bool OverrideActive { get; set; }
+        public System.Nullable<uint> ParameterCurve { get; set; }
+        public System.Nullable<bool> OverrideActive { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/SceneObjectData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/SceneObjectData.cs
@@ -7,10 +7,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class SceneObjectData : ISceneObjectData
     {
-        public int ScriptPackageID { get; set; }
-        public uint RndSeedVal { get; set; }
+        public System.Nullable<int> ScriptPackageID { get; set; }
+        public System.Nullable<uint> RndSeedVal { get; set; }
         public WowGuid CreatedBy { get; set; }
-        public uint SceneType { get; set; }
+        public System.Nullable<uint> SceneType { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/SelectedAzeriteEssences.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/SelectedAzeriteEssences.cs
@@ -7,9 +7,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class SelectedAzeriteEssences : ISelectedAzeriteEssences
     {
-        public uint[] AzeriteEssenceID { get; } = new uint[4];
-        public uint SpecializationID { get; set; }
-        public bool Enabled { get; set; }
+        public System.Nullable<uint>[] AzeriteEssenceID { get; } = new System.Nullable<uint>[4];
+        public System.Nullable<uint> SpecializationID { get; set; }
+        public System.Nullable<bool> Enabled { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/SkillInfo.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/SkillInfo.cs
@@ -7,13 +7,13 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class SkillInfo : ISkillInfo
     {
-        public ushort[] SkillLineID { get; } = new ushort[256];
-        public ushort[] SkillStep { get; } = new ushort[256];
-        public ushort[] SkillRank { get; } = new ushort[256];
-        public ushort[] SkillStartingRank { get; } = new ushort[256];
-        public ushort[] SkillMaxRank { get; } = new ushort[256];
-        public short[] SkillTempBonus { get; } = new short[256];
-        public ushort[] SkillPermBonus { get; } = new ushort[256];
+        public System.Nullable<ushort>[] SkillLineID { get; } = new System.Nullable<ushort>[256];
+        public System.Nullable<ushort>[] SkillStep { get; } = new System.Nullable<ushort>[256];
+        public System.Nullable<ushort>[] SkillRank { get; } = new System.Nullable<ushort>[256];
+        public System.Nullable<ushort>[] SkillStartingRank { get; } = new System.Nullable<ushort>[256];
+        public System.Nullable<ushort>[] SkillMaxRank { get; } = new System.Nullable<ushort>[256];
+        public System.Nullable<short>[] SkillTempBonus { get; } = new System.Nullable<short>[256];
+        public System.Nullable<ushort>[] SkillPermBonus { get; } = new System.Nullable<ushort>[256];
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/SocketedGem.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/SocketedGem.cs
@@ -7,9 +7,9 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class SocketedGem : ISocketedGem
     {
-        public int ItemID { get; set; }
-        public ushort[] BonusListIDs { get; } = new ushort[16];
-        public byte Context { get; set; }
+        public System.Nullable<int> ItemID { get; set; }
+        public System.Nullable<ushort>[] BonusListIDs { get; } = new System.Nullable<ushort>[16];
+        public System.Nullable<byte> Context { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/UnitData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/UnitData.cs
@@ -139,4 +139,3 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
         public DynamicUpdateField<WowGuid> ChannelObjects { get; } = new DynamicUpdateField<WowGuid>();
     }
 }
-

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/UnitData.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/UnitData.cs
@@ -5,16 +5,16 @@ using WowPacketParser.Store.Objects.UpdateFields;
 
 namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
-    public class UnitData : IUnitData
+    public class UnitData : IMutableUnitData
     {
-        public int DisplayID { get; set; }
-        public uint[] NpcFlags { get; } = new uint[2];
-        public uint StateSpellVisualID { get; set; }
-        public uint StateAnimID { get; set; }
-        public uint StateAnimKitID { get; set; }
-        public uint StateWorldEffectsQuestObjectiveID { get; set; }
-        public int SpellOverrideNameID { get; set; }
-        public uint[] StateWorldEffectIDs { get; set; }
+        public System.Nullable<int> DisplayID { get; set; }
+        public System.Nullable<uint>[] NpcFlags { get; } = new System.Nullable<uint>[2];
+        public System.Nullable<uint> StateSpellVisualID { get; set; }
+        public System.Nullable<uint> StateAnimID { get; set; }
+        public System.Nullable<uint> StateAnimKitID { get; set; }
+        public System.Nullable<uint> StateWorldEffectsQuestObjectiveID { get; set; }
+        public System.Nullable<int> SpellOverrideNameID { get; set; }
+        public System.Nullable<uint>[] StateWorldEffectIDs { get; set; }
         public WowGuid Charm { get; set; }
         public WowGuid Summon { get; set; }
         public WowGuid Critter { get; set; }
@@ -25,117 +25,117 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
         public WowGuid LookAtControllerTarget { get; set; }
         public WowGuid Target { get; set; }
         public WowGuid BattlePetCompanionGUID { get; set; }
-        public ulong BattlePetDBID { get; set; }
+        public System.Nullable<ulong> BattlePetDBID { get; set; }
         public IUnitChannel ChannelData { get; set; }
-        public uint SummonedByHomeRealm { get; set; }
-        public byte Race { get; set; }
-        public byte ClassId { get; set; }
-        public byte PlayerClassId { get; set; }
-        public byte Sex { get; set; }
-        public byte DisplayPower { get; set; }
-        public uint OverrideDisplayPowerID { get; set; }
-        public long Health { get; set; }
-        public int[] Power { get; } = new int[7];
-        public int[] MaxPower { get; } = new int[7];
-        public float[] PowerRegenFlatModifier { get; } = new float[7];
-        public float[] PowerRegenInterruptedFlatModifier { get; } = new float[7];
-        public long MaxHealth { get; set; }
-        public int Level { get; set; }
-        public int EffectiveLevel { get; set; }
-        public int ContentTuningID { get; set; }
-        public int ScalingLevelMin { get; set; }
-        public int ScalingLevelMax { get; set; }
-        public int ScalingLevelDelta { get; set; }
-        public int ScalingFactionGroup { get; set; }
-        public int ScalingHealthItemLevelCurveID { get; set; }
-        public int ScalingDamageItemLevelCurveID { get; set; }
-        public int FactionTemplate { get; set; }
+        public System.Nullable<uint> SummonedByHomeRealm { get; set; }
+        public System.Nullable<byte> Race { get; set; }
+        public System.Nullable<byte> ClassId { get; set; }
+        public System.Nullable<byte> PlayerClassId { get; set; }
+        public System.Nullable<byte> Sex { get; set; }
+        public System.Nullable<byte> DisplayPower { get; set; }
+        public System.Nullable<uint> OverrideDisplayPowerID { get; set; }
+        public System.Nullable<long> Health { get; set; }
+        public System.Nullable<int>[] Power { get; } = new System.Nullable<int>[7];
+        public System.Nullable<int>[] MaxPower { get; } = new System.Nullable<int>[7];
+        public System.Nullable<float>[] PowerRegenFlatModifier { get; } = new System.Nullable<float>[7];
+        public System.Nullable<float>[] PowerRegenInterruptedFlatModifier { get; } = new System.Nullable<float>[7];
+        public System.Nullable<long> MaxHealth { get; set; }
+        public System.Nullable<int> Level { get; set; }
+        public System.Nullable<int> EffectiveLevel { get; set; }
+        public System.Nullable<int> ContentTuningID { get; set; }
+        public System.Nullable<int> ScalingLevelMin { get; set; }
+        public System.Nullable<int> ScalingLevelMax { get; set; }
+        public System.Nullable<int> ScalingLevelDelta { get; set; }
+        public System.Nullable<int> ScalingFactionGroup { get; set; }
+        public System.Nullable<int> ScalingHealthItemLevelCurveID { get; set; }
+        public System.Nullable<int> ScalingDamageItemLevelCurveID { get; set; }
+        public System.Nullable<int> FactionTemplate { get; set; }
         public IVisibleItem[] VirtualItems { get; } = new IVisibleItem[3];
-        public uint Flags { get; set; }
-        public uint Flags2 { get; set; }
-        public uint Flags3 { get; set; }
-        public uint AuraState { get; set; }
-        public uint[] AttackRoundBaseTime { get; } = new uint[2];
-        public uint RangedAttackRoundBaseTime { get; set; }
-        public float BoundingRadius { get; set; }
-        public float CombatReach { get; set; }
-        public float DisplayScale { get; set; }
-        public int CreatureFamily { get; set; }
-        public int CreatureType { get; set; }
-        public int NativeDisplayID { get; set; }
-        public float NativeXDisplayScale { get; set; }
-        public int MountDisplayID { get; set; }
-        public int CosmeticMountDisplayID { get; set; }
-        public float MinDamage { get; set; }
-        public float MaxDamage { get; set; }
-        public float MinOffHandDamage { get; set; }
-        public float MaxOffHandDamage { get; set; }
-        public byte StandState { get; set; }
-        public byte PetTalentPoints { get; set; }
-        public byte VisFlags { get; set; }
-        public byte AnimTier { get; set; }
-        public uint PetNumber { get; set; }
-        public uint PetNameTimestamp { get; set; }
-        public uint PetExperience { get; set; }
-        public uint PetNextLevelExperience { get; set; }
-        public float ModCastingSpeed { get; set; }
-        public float ModCastingSpeedNeg { get; set; }
-        public float ModSpellHaste { get; set; }
-        public float ModHaste { get; set; }
-        public float ModRangedHaste { get; set; }
-        public float ModHasteRegen { get; set; }
-        public float ModTimeRate { get; set; }
-        public int CreatedBySpell { get; set; }
-        public int EmoteState { get; set; }
-        public int[] Stats { get; } = new int[4];
-        public int[] StatPosBuff { get; } = new int[4];
-        public int[] StatNegBuff { get; } = new int[4];
-        public int[] Resistances { get; } = new int[7];
-        public int[] BonusResistanceMods { get; } = new int[7];
-        public int[] ManaCostModifier { get; } = new int[7];
-        public int BaseMana { get; set; }
-        public int BaseHealth { get; set; }
-        public byte SheatheState { get; set; }
-        public byte PvpFlags { get; set; }
-        public byte PetFlags { get; set; }
-        public byte ShapeshiftForm { get; set; }
-        public int AttackPower { get; set; }
-        public int AttackPowerModPos { get; set; }
-        public int AttackPowerModNeg { get; set; }
-        public float AttackPowerMultiplier { get; set; }
-        public int RangedAttackPower { get; set; }
-        public int RangedAttackPowerModPos { get; set; }
-        public int RangedAttackPowerModNeg { get; set; }
-        public float RangedAttackPowerMultiplier { get; set; }
-        public int MainHandWeaponAttackPower { get; set; }
-        public int OffHandWeaponAttackPower { get; set; }
-        public int RangedWeaponAttackPower { get; set; }
-        public int SetAttackSpeedAura { get; set; }
-        public float Lifesteal { get; set; }
-        public float MinRangedDamage { get; set; }
-        public float MaxRangedDamage { get; set; }
-        public float ManaCostMultiplier { get; set; }
-        public float MaxHealthModifier { get; set; }
-        public float HoverHeight { get; set; }
-        public int MinItemLevelCutoff { get; set; }
-        public int MinItemLevel { get; set; }
-        public int MaxItemLevel { get; set; }
-        public int AzeriteItemLevel { get; set; }
-        public int WildBattlePetLevel { get; set; }
-        public int BattlePetCompanionExperience { get; set; }
-        public uint BattlePetCompanionNameTimestamp { get; set; }
-        public int InteractSpellID { get; set; }
-        public int ScaleDuration { get; set; }
-        public int LooksLikeMountID { get; set; }
-        public int LooksLikeCreatureID { get; set; }
-        public int LookAtControllerID { get; set; }
-        public int TaxiNodesID { get; set; }
+        public System.Nullable<uint> Flags { get; set; }
+        public System.Nullable<uint> Flags2 { get; set; }
+        public System.Nullable<uint> Flags3 { get; set; }
+        public System.Nullable<uint> AuraState { get; set; }
+        public System.Nullable<uint>[] AttackRoundBaseTime { get; } = new System.Nullable<uint>[2];
+        public System.Nullable<uint> RangedAttackRoundBaseTime { get; set; }
+        public System.Nullable<float> BoundingRadius { get; set; }
+        public System.Nullable<float> CombatReach { get; set; }
+        public System.Nullable<float> DisplayScale { get; set; }
+        public System.Nullable<int> CreatureFamily { get; set; }
+        public System.Nullable<int> CreatureType { get; set; }
+        public System.Nullable<int> NativeDisplayID { get; set; }
+        public System.Nullable<float> NativeXDisplayScale { get; set; }
+        public System.Nullable<int> MountDisplayID { get; set; }
+        public System.Nullable<int> CosmeticMountDisplayID { get; set; }
+        public System.Nullable<float> MinDamage { get; set; }
+        public System.Nullable<float> MaxDamage { get; set; }
+        public System.Nullable<float> MinOffHandDamage { get; set; }
+        public System.Nullable<float> MaxOffHandDamage { get; set; }
+        public System.Nullable<byte> StandState { get; set; }
+        public System.Nullable<byte> PetTalentPoints { get; set; }
+        public System.Nullable<byte> VisFlags { get; set; }
+        public System.Nullable<byte> AnimTier { get; set; }
+        public System.Nullable<uint> PetNumber { get; set; }
+        public System.Nullable<uint> PetNameTimestamp { get; set; }
+        public System.Nullable<uint> PetExperience { get; set; }
+        public System.Nullable<uint> PetNextLevelExperience { get; set; }
+        public System.Nullable<float> ModCastingSpeed { get; set; }
+        public System.Nullable<float> ModCastingSpeedNeg { get; set; }
+        public System.Nullable<float> ModSpellHaste { get; set; }
+        public System.Nullable<float> ModHaste { get; set; }
+        public System.Nullable<float> ModRangedHaste { get; set; }
+        public System.Nullable<float> ModHasteRegen { get; set; }
+        public System.Nullable<float> ModTimeRate { get; set; }
+        public System.Nullable<int> CreatedBySpell { get; set; }
+        public System.Nullable<int> EmoteState { get; set; }
+        public System.Nullable<int>[] Stats { get; } = new System.Nullable<int>[4];
+        public System.Nullable<int>[] StatPosBuff { get; } = new System.Nullable<int>[4];
+        public System.Nullable<int>[] StatNegBuff { get; } = new System.Nullable<int>[4];
+        public System.Nullable<int>[] Resistances { get; } = new System.Nullable<int>[7];
+        public System.Nullable<int>[] BonusResistanceMods { get; } = new System.Nullable<int>[7];
+        public System.Nullable<int>[] ManaCostModifier { get; } = new System.Nullable<int>[7];
+        public System.Nullable<int> BaseMana { get; set; }
+        public System.Nullable<int> BaseHealth { get; set; }
+        public System.Nullable<byte> SheatheState { get; set; }
+        public System.Nullable<byte> PvpFlags { get; set; }
+        public System.Nullable<byte> PetFlags { get; set; }
+        public System.Nullable<byte> ShapeshiftForm { get; set; }
+        public System.Nullable<int> AttackPower { get; set; }
+        public System.Nullable<int> AttackPowerModPos { get; set; }
+        public System.Nullable<int> AttackPowerModNeg { get; set; }
+        public System.Nullable<float> AttackPowerMultiplier { get; set; }
+        public System.Nullable<int> RangedAttackPower { get; set; }
+        public System.Nullable<int> RangedAttackPowerModPos { get; set; }
+        public System.Nullable<int> RangedAttackPowerModNeg { get; set; }
+        public System.Nullable<float> RangedAttackPowerMultiplier { get; set; }
+        public System.Nullable<int> MainHandWeaponAttackPower { get; set; }
+        public System.Nullable<int> OffHandWeaponAttackPower { get; set; }
+        public System.Nullable<int> RangedWeaponAttackPower { get; set; }
+        public System.Nullable<int> SetAttackSpeedAura { get; set; }
+        public System.Nullable<float> Lifesteal { get; set; }
+        public System.Nullable<float> MinRangedDamage { get; set; }
+        public System.Nullable<float> MaxRangedDamage { get; set; }
+        public System.Nullable<float> ManaCostMultiplier { get; set; }
+        public System.Nullable<float> MaxHealthModifier { get; set; }
+        public System.Nullable<float> HoverHeight { get; set; }
+        public System.Nullable<int> MinItemLevelCutoff { get; set; }
+        public System.Nullable<int> MinItemLevel { get; set; }
+        public System.Nullable<int> MaxItemLevel { get; set; }
+        public System.Nullable<int> AzeriteItemLevel { get; set; }
+        public System.Nullable<int> WildBattlePetLevel { get; set; }
+        public System.Nullable<int> BattlePetCompanionExperience { get; set; }
+        public System.Nullable<uint> BattlePetCompanionNameTimestamp { get; set; }
+        public System.Nullable<int> InteractSpellID { get; set; }
+        public System.Nullable<int> ScaleDuration { get; set; }
+        public System.Nullable<int> LooksLikeMountID { get; set; }
+        public System.Nullable<int> LooksLikeCreatureID { get; set; }
+        public System.Nullable<int> LookAtControllerID { get; set; }
+        public System.Nullable<int> TaxiNodesID { get; set; }
         public WowGuid GuildGUID { get; set; }
         public WowGuid SkinningOwnerGUID { get; set; }
-        public uint SilencedSchoolMask { get; set; }
+        public System.Nullable<uint> SilencedSchoolMask { get; set; }
         public WowGuid NameplateAttachToGUID { get; set; }
         public DynamicUpdateField<IPassiveSpellHistory> PassiveSpells { get; } = new DynamicUpdateField<IPassiveSpellHistory>();
-        public DynamicUpdateField<int> WorldEffects { get; } = new DynamicUpdateField<int>();
+        public DynamicUpdateField<System.Nullable<int>> WorldEffects { get; } = new DynamicUpdateField<System.Nullable<int>>();
         public DynamicUpdateField<WowGuid> ChannelObjects { get; } = new DynamicUpdateField<WowGuid>();
     }
 }

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/VisibleItem.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/VisibleItem.cs
@@ -7,10 +7,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class VisibleItem : IVisibleItem
     {
-        public int ItemID { get; set; }
-        public int SecondaryItemModifiedAppearanceID { get; set; }
-        public ushort ItemAppearanceModID { get; set; }
-        public ushort ItemVisual { get; set; }
+        public System.Nullable<int> ItemID { get; set; }
+        public System.Nullable<int> SecondaryItemModifiedAppearanceID { get; set; }
+        public System.Nullable<ushort> ItemAppearanceModID { get; set; }
+        public System.Nullable<ushort> ItemVisual { get; set; }
     }
 }
 

--- a/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/VisualAnim.cs
+++ b/WowPacketParserModule.V9_0_1_36216/UpdateFields/V9_1_5_40772/VisualAnim.cs
@@ -7,10 +7,10 @@ namespace WowPacketParserModule.V9_0_1_36216.UpdateFields.V9_1_5_40772
 {
     public class VisualAnim : IVisualAnim
     {
-        public uint AnimationDataID { get; set; }
-        public uint AnimKitID { get; set; }
-        public uint AnimProgress { get; set; }
-        public bool Field_C { get; set; }
+        public System.Nullable<uint> AnimationDataID { get; set; }
+        public System.Nullable<uint> AnimKitID { get; set; }
+        public System.Nullable<uint> AnimProgress { get; set; }
+        public System.Nullable<bool> Field_C { get; set; }
     }
 }
 


### PR DESCRIPTION
Changed UpdateField types so that their properties with simple types are now nullable, to better reflect what they actually store: when the value is not send by the server, the field will be null.

Also, update handlers **no longer modify existing global data**, instead they return an object with updated fields and those are later merged with the global object storage.

Use with: https://github.com/Shauren/wow-tools/pull/8

Tested with:
4.3.4, 6.2.3, 7.2.5, 7.3.5, 8.1.5, 8.2.0, 8.2.5, 9.0.1 both txt and sql output, all are equal