### PR TITLE
Optimize ByteArrayToHexString

### DIFF
--- a/WowPacketParser.Tests/Misc/UtilitiesTest.cs
+++ b/WowPacketParser.Tests/Misc/UtilitiesTest.cs
@@ -37,15 +37,7 @@ namespace WowPacketParser.Tests.Misc
 
             Assert.Throws<ArgumentOutOfRangeException>(() => Utilities.HexStringToBinary("B"));
         }
-
-        [Test]
-        public void TestByteArrayToHexString()
-        {
-            Assert.AreEqual(string.Empty, Utilities.ByteArrayToHexString(new byte[0]));
-            Assert.AreEqual("01020304", Utilities.ByteArrayToHexString(new byte[] { 1, 2, 3, 4 }));
-            Assert.AreEqual("FF00", Utilities.ByteArrayToHexString(new byte[] { 255, 0 }));
-        }
-
+        
         [Test]
         public void TestGetDateTimeFromGameTime()
         {

--- a/WowPacketParser/Misc/BattlenetPacket.cs
+++ b/WowPacketParser/Misc/BattlenetPacket.cs
@@ -1,4 +1,5 @@
-﻿using WowPacketParser.Enums.Battlenet;
+﻿using System;
+using WowPacketParser.Enums.Battlenet;
 
 namespace WowPacketParser.Misc
 {
@@ -87,7 +88,7 @@ namespace WowPacketParser.Misc
         public byte[] ReadBytes(string name, int length, params object[] indexes)
         {
             var value = BitStream.ReadBytes(length);
-            Stream.AddValue(name, Utilities.ByteArrayToHexString(value), indexes);
+            Stream.AddValue(name, Convert.ToHexString(value), indexes);
             return value;
         }
 

--- a/WowPacketParser/Misc/PacketReads.cs
+++ b/WowPacketParser/Misc/PacketReads.cs
@@ -464,7 +464,7 @@ namespace WowPacketParser.Misc
         public byte[] ReadBytes(string name, int length, params object[] indexes)
         {
             var val = ReadBytes(length);
-            AddValue(name, Utilities.ByteArrayToHexString(val), indexes);
+            AddValue(name, Convert.ToHexString(val), indexes);
             return val;
         }
 

--- a/WowPacketParser/Misc/Utilities.cs
+++ b/WowPacketParser/Misc/Utilities.cs
@@ -44,7 +44,7 @@ namespace WowPacketParser.Misc
 
         public static string ByteArrayToHexString(byte[] data)
         {
-            return data.Aggregate(String.Empty, (current, t) => current + t.ToString("X2", CultureInfo.InvariantCulture));
+            return Convert.ToHexString(data);
         }
 
         public static string ByteArrayToHexTable(byte[] data, bool sh0rt = false, int offset = 0, bool noOffsetFirstLine = true)

--- a/WowPacketParser/Misc/Utilities.cs
+++ b/WowPacketParser/Misc/Utilities.cs
@@ -42,11 +42,6 @@ namespace WowPacketParser.Misc
             return bytes.ToArray();
         }
 
-        public static string ByteArrayToHexString(byte[] data)
-        {
-            return Convert.ToHexString(data);
-        }
-
         public static string ByteArrayToHexTable(byte[] data, bool sh0rt = false, int offset = 0, bool noOffsetFirstLine = true)
         {
             var n = Environment.NewLine;

--- a/WowPacketParser/Parsing/Parsers/BattlenetModuleHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/BattlenetModuleHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using WowPacketParser.Misc;
@@ -84,19 +85,19 @@ namespace WowPacketParser.Parsing.Parsers
             switch (state)
             {
                 case 0:
-                    AddValue("I", Utilities.ByteArrayToHexString(reader.ReadBytes(32)), values);
-                    AddValue("s", Utilities.ByteArrayToHexString(reader.ReadBytes(32)), values);
-                    AddValue("B", Utilities.ByteArrayToHexString(reader.ReadBytes(128)), values);
-                    AddValue("unk", Utilities.ByteArrayToHexString(reader.ReadBytes(128)), values);
+                    AddValue("I", Convert.ToHexString(reader.ReadBytes(32)), values);
+                    AddValue("s", Convert.ToHexString(reader.ReadBytes(32)), values);
+                    AddValue("B", Convert.ToHexString(reader.ReadBytes(128)), values);
+                    AddValue("unk", Convert.ToHexString(reader.ReadBytes(128)), values);
                     return false;
                 case 2:
-                    AddValue("a", Utilities.ByteArrayToHexString(reader.ReadBytes(128)), values);
-                    AddValue("M1", Utilities.ByteArrayToHexString(reader.ReadBytes(32)), values);
-                    AddValue("A", Utilities.ByteArrayToHexString(reader.ReadBytes(128)), values);
+                    AddValue("a", Convert.ToHexString(reader.ReadBytes(128)), values);
+                    AddValue("M1", Convert.ToHexString(reader.ReadBytes(32)), values);
+                    AddValue("A", Convert.ToHexString(reader.ReadBytes(128)), values);
                     return true;
                 case 3:
-                    AddValue("M2", Utilities.ByteArrayToHexString(reader.ReadBytes(32)), values);
-                    AddValue("unk", Utilities.ByteArrayToHexString(reader.ReadBytes(128)), values);
+                    AddValue("M2", Convert.ToHexString(reader.ReadBytes(32)), values);
+                    AddValue("unk", Convert.ToHexString(reader.ReadBytes(128)), values);
                     return true;
             }
             return false;
@@ -110,22 +111,22 @@ namespace WowPacketParser.Parsing.Parsers
             {
                 case 0:
                     AddValue("Unk", reader.ReadByte(), values);
-                    AddValue("Token id", Utilities.ByteArrayToHexString(reader.ReadBytes(8).Reverse().ToArray()), values);
+                    AddValue("Token id", Convert.ToHexString(reader.ReadBytes(8).Reverse().ToArray()), values);
                     AddValue("Unk counter", reader.ReadByte(), values);
-                    AddValue("Crypt entropy", Utilities.ByteArrayToHexString(reader.ReadBytes(16)), values);
+                    AddValue("Crypt entropy", Convert.ToHexString(reader.ReadBytes(16)), values);
                     return false;
                 case 1:
-                    AddValue("Token key", Utilities.ByteArrayToHexString(reader.ReadBytes(8)), values);
+                    AddValue("Token key", Convert.ToHexString(reader.ReadBytes(8)), values);
                     AddValue("Token", reader.ReadUInt32(), values);
                     return true;
                 case 2:
-                    AddValue("data", Utilities.ByteArrayToHexString(reader.ReadBytes(36)), values);
+                    AddValue("data", Convert.ToHexString(reader.ReadBytes(36)), values);
                     return true;
                 case 3:
-                    AddValue("Token id", Utilities.ByteArrayToHexString(reader.ReadBytes(8).Reverse().ToArray()), values);
-                    AddValue("Crypt entropy", Utilities.ByteArrayToHexString(reader.ReadBytes(16)), values);
-                    AddValue("Token key", Utilities.ByteArrayToHexString(reader.ReadBytes(8)), values);
-                    AddValue("Token data", Utilities.ByteArrayToHexString(reader.ReadBytes(16)), values);
+                    AddValue("Token id", Convert.ToHexString(reader.ReadBytes(8).Reverse().ToArray()), values);
+                    AddValue("Crypt entropy", Convert.ToHexString(reader.ReadBytes(16)), values);
+                    AddValue("Token key", Convert.ToHexString(reader.ReadBytes(8)), values);
+                    AddValue("Token data", Convert.ToHexString(reader.ReadBytes(16)), values);
                     return true;
             }
 
@@ -134,7 +135,7 @@ namespace WowPacketParser.Parsing.Parsers
 
         private bool HandleThumbprint(BinaryReader reader, params object[] values)
         {
-            AddValue("Data", Utilities.ByteArrayToHexString(reader.ReadBytes(512)), values);
+            AddValue("Data", Convert.ToHexString(reader.ReadBytes(512)), values);
             return true;
         }
 
@@ -187,14 +188,14 @@ namespace WowPacketParser.Parsing.Parsers
             switch (state)
             {
                 case 0:
-                    AddValue("Server challenge", Utilities.ByteArrayToHexString(reader.ReadBytes(16).Reverse().ToArray()), values);
+                    AddValue("Server challenge", Convert.ToHexString(reader.ReadBytes(16).Reverse().ToArray()), values);
                     return false;
                 case 1:
-                    AddValue("Client challenge", Utilities.ByteArrayToHexString(reader.ReadBytes(16).Reverse().ToArray()), values);
-                    AddValue("Client proof", Utilities.ByteArrayToHexString(reader.ReadBytes(32).Reverse().ToArray()), values);
+                    AddValue("Client challenge", Convert.ToHexString(reader.ReadBytes(16).Reverse().ToArray()), values);
+                    AddValue("Client proof", Convert.ToHexString(reader.ReadBytes(32).Reverse().ToArray()), values);
                     break;
                 case 2:
-                    AddValue("Server proof", Utilities.ByteArrayToHexString(reader.ReadBytes(32).Reverse().ToArray()), values);
+                    AddValue("Server proof", Convert.ToHexString(reader.ReadBytes(32).Reverse().ToArray()), values);
                     break;
             }
 

--- a/WowPacketParser/Parsing/Parsers/SessionHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/SessionHandler.cs
@@ -252,7 +252,7 @@ namespace WowPacketParser.Parsing.Parsers
             var size = lowBits | highBits;
             packet.AddValue("Size", size);
             packet.AddValue("Account name", Encoding.UTF8.GetString(packet.ReadBytes(size)));
-            packet.AddValue("Proof SHA-1 Hash", Utilities.ByteArrayToHexString(sha));
+            packet.AddValue("Proof SHA-1 Hash", Convert.ToHexString(sha));
         }
 
         [Parser(Opcode.CMSG_AUTH_SESSION, ClientVersionBuild.V5_0_5_16048)]
@@ -297,7 +297,7 @@ namespace WowPacketParser.Parsing.Parsers
             packet.ReadBit("Unk bit");
             var size = (int)packet.ReadBits(12);
             packet.AddValue("Account name", Encoding.UTF8.GetString(packet.ReadBytes(size)));
-            packet.AddValue("Proof SHA-1 Hash", Utilities.ByteArrayToHexString(sha));
+            packet.AddValue("Proof SHA-1 Hash", Convert.ToHexString(sha));
         }
 
         [Parser(Opcode.SMSG_AUTH_RESPONSE, ClientVersionBuild.Zero, ClientVersionBuild.V4_3_4_15595)]
@@ -532,7 +532,7 @@ namespace WowPacketParser.Parsing.Parsers
             bytes[16] = packet.ReadByte();
             bytes[14] = packet.ReadByte();
             bytes[10] = packet.ReadByte();
-            packet.AddValue("Proof RSA Hash", Utilities.ByteArrayToHexString(bytes));
+            packet.AddValue("Proof RSA Hash", Convert.ToHexString(bytes));
         }
 
         [Parser(Opcode.SMSG_KICK_REASON)]

--- a/WowPacketParser/SQL/SQLUtil.cs
+++ b/WowPacketParser/SQL/SQLUtil.cs
@@ -138,7 +138,7 @@ namespace WowPacketParser.SQL
                 value = string.Format("{0:F20}", value).Substring(0, 20).TrimEnd('0').TrimEnd('.');
 
             if (value is Blob blob)
-                value = "0x" + Utilities.ByteArrayToHexString(blob.Data);
+                value = "0x" + Convert.ToHexString(blob.Data);
 
             return value;
         }

--- a/WowPacketParserModule.BattleNet.V37165/Parsers/Authentication.cs
+++ b/WowPacketParserModule.BattleNet.V37165/Parsers/Authentication.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using WowPacketParser.Enums.Battlenet;
 using WowPacketParser.Misc;
 using WowPacketParser.Parsing;
@@ -94,7 +95,7 @@ namespace WowPacketParserModule.BattleNet.V37165.Parsers
                 {
                     packet.ReadFixedLengthString("Type", 4, "Strings");
                     packet.ReadFourCC("Region", "Strings");
-                    var id = Utilities.ByteArrayToHexString(packet.ReadBytes("ModuleId", 32, "Strings"));
+                    var id = Convert.ToHexString(packet.ReadBytes("ModuleId", 32, "Strings"));
                     var dataSize = packet.Read<int>("Data size", 0, 10);
                     var data = packet.ReadBytes(dataSize);
                     var module = new BattlenetModuleHandler(packet);
@@ -118,7 +119,7 @@ namespace WowPacketParserModule.BattleNet.V37165.Parsers
                 {
                     packet.ReadFixedLengthString("Type", 4, "FinalRequest", i);
                     packet.ReadFourCC("Region", "FinalRequest", i);
-                    var id = Utilities.ByteArrayToHexString(packet.ReadBytes("ModuleId", 32, "FinalRequest", i));
+                    var id = Convert.ToHexString(packet.ReadBytes("ModuleId", 32, "FinalRequest", i));
                     var dataSize = packet.Read<int>("Data size", 0, 10, i);
                     var data = packet.ReadBytes(dataSize);
 
@@ -157,7 +158,7 @@ namespace WowPacketParserModule.BattleNet.V37165.Parsers
                 {
                     packet.ReadFixedLengthString("Type", 4, "Strings");
                     packet.ReadFourCC("Region", "Strings");
-                    var id = Utilities.ByteArrayToHexString(packet.ReadBytes("ModuleId", 32, "Strings"));
+                    var id = Convert.ToHexString(packet.ReadBytes("ModuleId", 32, "Strings"));
                     var dataSize = packet.Read<int>("Data size", 0, 10);
                     var data = packet.ReadBytes(dataSize);
                     var module = new BattlenetModuleHandler(packet);
@@ -181,7 +182,7 @@ namespace WowPacketParserModule.BattleNet.V37165.Parsers
                 {
                     packet.ReadFixedLengthString("Type", 4, "FinalRequest", i);
                     packet.ReadFourCC("Region", "FinalRequest", i);
-                    var id = Utilities.ByteArrayToHexString(packet.ReadBytes("ModuleId", 32, "FinalRequest", i));
+                    var id = Convert.ToHexString(packet.ReadBytes("ModuleId", 32, "FinalRequest", i));
                     var dataSize = packet.Read<int>("Data size", 0, 10, i);
                     var data = packet.ReadBytes(dataSize);
 
@@ -205,7 +206,7 @@ namespace WowPacketParserModule.BattleNet.V37165.Parsers
             {
                 packet.ReadFixedLengthString("Type", 4, i);
                 packet.ReadFourCC("Region", i);
-                var id = Utilities.ByteArrayToHexString(packet.ReadBytes("ModuleId", 32, i));
+                var id = Convert.ToHexString(packet.ReadBytes("ModuleId", 32, i));
                 var dataSize = packet.Read<int>("Data size", 0, 10, i);
                 var data = packet.ReadBytes(dataSize);
 

--- a/WowPacketParserModule.BattleNet.V37165/Parsers/Presence.cs
+++ b/WowPacketParserModule.BattleNet.V37165/Parsers/Presence.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using WowPacketParser.Enums.Battlenet;
 using WowPacketParser.Misc;
@@ -117,7 +118,7 @@ namespace WowPacketParserModule.BattleNet.V37165.Parsers
                         outputStream.AddValue("Offset", bitStream.Read<ushort>(0, 16), i, "ImageTableEntry");
                         break;
                     case PresenceFieldType.OpaqueData:
-                        outputStream.AddValue("OpaqueData", Utilities.ByteArrayToHexString(bitStream.ReadBytes(bitStream.Read<int>(0, 7))), i);
+                        outputStream.AddValue("OpaqueData", Convert.ToHexString(bitStream.ReadBytes(bitStream.Read<int>(0, 7))), i);
                         break;
                     case PresenceFieldType.ToonFullName:
                         outputStream.AddValue("Region", bitStream.Read<byte>(0, 8), i, "ToonFullName");

--- a/WowPacketParserModule.BattleNet.V37165/Parsers/Profile.cs
+++ b/WowPacketParserModule.BattleNet.V37165/Parsers/Profile.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
 using WowPacketParser.Enums.Battlenet;
 using WowPacketParser.Misc;
@@ -106,7 +107,7 @@ namespace WowPacketParserModule.BattleNet.V37165.Parsers
                         while (reader.BaseStream.Position < reader.BaseStream.Length)
                         {
                             var pathLength = UnpackInt(reader);
-                            packet.Stream.AddValue("Path", Utilities.ByteArrayToHexString(reader.ReadBytes((int)pathLength)));
+                            packet.Stream.AddValue("Path", Convert.ToHexString(reader.ReadBytes((int)pathLength)));
                             var fieldType = reader.ReadByte();
                             switch (fieldType)
                             {
@@ -126,7 +127,7 @@ namespace WowPacketParserModule.BattleNet.V37165.Parsers
                                     break;
                                 case 3:
                                     var binaryLength = UnpackInt(reader);
-                                    packet.Stream.AddValue("Binary", Utilities.ByteArrayToHexString(reader.ReadBytes((int)binaryLength)));
+                                    packet.Stream.AddValue("Binary", Convert.ToHexString(reader.ReadBytes((int)binaryLength)));
                                     break;
                                 case 4:
                                     var stringLength = UnpackInt(reader);
@@ -140,7 +141,7 @@ namespace WowPacketParserModule.BattleNet.V37165.Parsers
                                 case 6: //cache handle
                                     var handleLength = UnpackInt(reader);
                                     if (handleLength == 40)
-                                        packet.Stream.AddValue("CacheHandle", Utilities.ByteArrayToHexString(reader.ReadBytes(40)));
+                                        packet.Stream.AddValue("CacheHandle", Convert.ToHexString(reader.ReadBytes(40)));
                                     break;
                             }
                         }

--- a/WowPacketParserModule.V2_5_1_38707/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V2_5_1_38707/Parsers/HotfixHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+using System;
+using System.Collections.Generic;
 using WowPacketParser.Enums;
 using WowPacketParser.Hotfix;
 using WowPacketParser.Misc;

--- a/WowPacketParserModule.V2_5_1_38707/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V2_5_1_38707/Parsers/HotfixHandler.cs
@@ -116,7 +116,7 @@ namespace WowPacketParserModule.V2_5_1_38835.Parsers
                         var optionalData = db2File.ReadBytes(24);
 
                         packet.AddValue($"(OptionalData) [{i}] Key:", hash);
-                        packet.AddValue($"(OptionalData) [{i}] OptionalData:", Utilities.ByteArrayToHexString(optionalData));
+                        packet.AddValue($"(OptionalData) [{i}] OptionalData:", Convert.ToHexString(optionalData));
 
                         HotfixOptionalData hotfixOptionalData = new HotfixOptionalData
                         {

--- a/WowPacketParserModule.V4_3_4_15595/Parsers/SessionHandler.cs
+++ b/WowPacketParserModule.V4_3_4_15595/Parsers/SessionHandler.cs
@@ -65,7 +65,7 @@ namespace WowPacketParserModule.V4_3_4_15595.Parsers
             packet.ReadBit("UseIPv6");
             var size = (int)packet.ReadBits(12);
             packet.ReadBytesString("Account", size);
-            packet.AddValue("Digest", Utilities.ByteArrayToHexString(sha));
+            packet.AddValue("Digest", Convert.ToHexString(sha));
         }
 
         [Parser(Opcode.SMSG_AUTH_RESPONSE)]
@@ -137,7 +137,7 @@ namespace WowPacketParserModule.V4_3_4_15595.Parsers
             bytes[9] = packet.ReadByte();
             bytes[19] = packet.ReadByte();
             bytes[3] = packet.ReadByte();
-            packet.AddValue("Proof SHA-1 Hash", Utilities.ByteArrayToHexString(bytes));
+            packet.AddValue("Proof SHA-1 Hash", Convert.ToHexString(bytes));
         }
     }
 }

--- a/WowPacketParserModule.V5_3_0_16981/Parsers/SessionHandler.cs
+++ b/WowPacketParserModule.V5_3_0_16981/Parsers/SessionHandler.cs
@@ -66,7 +66,7 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
             var size = (int)packet.ReadBits(11);
             packet.ResetBitReader();
             packet.ReadBytesString("Account name", size);
-            packet.AddValue("Proof SHA-1 Hash", Utilities.ByteArrayToHexString(sha));
+            packet.AddValue("Proof SHA-1 Hash", Convert.ToHexString(sha));
         }
 
         [Parser(Opcode.SMSG_AUTH_RESPONSE)]

--- a/WowPacketParserModule.V5_4_0_17359/Parsers/SessionHandler.cs
+++ b/WowPacketParserModule.V5_4_0_17359/Parsers/SessionHandler.cs
@@ -76,7 +76,7 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
             packet.ReadBit("Unk bit");
             packet.ResetBitReader();
             packet.ReadBytesString("Account name", size);
-            packet.AddValue("Proof SHA-1 Hash", Utilities.ByteArrayToHexString(sha));
+            packet.AddValue("Proof SHA-1 Hash", Convert.ToHexString(sha));
         }
 
         [Parser(Opcode.SMSG_AUTH_RESPONSE)]

--- a/WowPacketParserModule.V5_4_1_17538/Parsers/SessionHandler.cs
+++ b/WowPacketParserModule.V5_4_1_17538/Parsers/SessionHandler.cs
@@ -78,7 +78,7 @@ namespace WowPacketParserModule.V5_4_1_17538.Parsers
             packet.ReadBit("Unk bit");
             packet.ResetBitReader();
             packet.ReadBytesString("Account name", size);
-            packet.AddValue("Proof SHA-1 Hash", Utilities.ByteArrayToHexString(sha));
+            packet.AddValue("Proof SHA-1 Hash", Convert.ToHexString(sha));
         }
 
         [Parser(Opcode.SMSG_MOTD)]

--- a/WowPacketParserModule.V5_4_2_17658/Parsers/SessionHandler.cs
+++ b/WowPacketParserModule.V5_4_2_17658/Parsers/SessionHandler.cs
@@ -179,7 +179,7 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
             sha[9] = packet.ReadByte();
             sha[7] = packet.ReadByte();
 
-            packet.AddValue("SHA-1 Hash", Utilities.ByteArrayToHexString(sha));
+            packet.AddValue("SHA-1 Hash", Convert.ToHexString(sha));
         }
 
         [Parser(Opcode.SMSG_CONNECT_TO)]

--- a/WowPacketParserModule.V5_4_7_17898/Parsers/SessionHandler.cs
+++ b/WowPacketParserModule.V5_4_7_17898/Parsers/SessionHandler.cs
@@ -71,7 +71,7 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
             sha[11] = packet.ReadByte();
             sha[7] = packet.ReadByte();
 
-            packet.AddValue("SHA-1 Hash", Utilities.ByteArrayToHexString(sha));
+            packet.AddValue("SHA-1 Hash", Convert.ToHexString(sha));
         }
 
 
@@ -271,7 +271,7 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
             packet.ReadBit("Unk bit");
             packet.ResetBitReader();
             packet.ReadBytesString("Account name", size);
-            packet.AddValue("Proof SHA-1 Hash", Utilities.ByteArrayToHexString(sha));
+            packet.AddValue("Proof SHA-1 Hash", Convert.ToHexString(sha));
         }
     }
 }

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/SessionHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/SessionHandler.cs
@@ -1,4 +1,5 @@
-﻿using WowPacketParser.Enums;
+﻿using System;
+using WowPacketParser.Enums;
 using WowPacketParser.Misc;
 using WowPacketParser.Parsing;
 using CoreParsers = WowPacketParser.Parsing.Parsers;
@@ -172,7 +173,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 addons.ClosePacket(false);
             }
 
-            packet.AddValue("Proof SHA-1 Hash", Utilities.ByteArrayToHexString(sha));
+            packet.AddValue("Proof SHA-1 Hash", Convert.ToHexString(sha));
         }
 
         [Parser(Opcode.CMSG_AUTH_SESSION, ClientVersionBuild.V6_2_4_21315)]

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/HotfixHandler.cs
@@ -252,7 +252,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
                         var optionalData = db2File.ReadBytes(24);
 
                         packet.AddValue($"(OptionalData) [{i}] Key:", hash);
-                        packet.AddValue($"(OptionalData) [{i}] OptionalData:", Utilities.ByteArrayToHexString(optionalData));
+                        packet.AddValue($"(OptionalData) [{i}] OptionalData:", Convert.ToHexString(optionalData));
 
                         HotfixOptionalData hotfixOptionalData = new HotfixOptionalData
                         {


### PR DESCRIPTION
Current implementation uses Linq and... string concatenation for each bytes. This yields terrible performance and even worse memory usage (to be precise: GC pressure).

On an example 40 MB raw sniff from wow version 9.1 BytesToHexString was taking ~16.2 seconds (47% of the total time!!) compared to ~3.45 seconds using Convert.ToHexString (18% of the total time)