### PR TITLE
Fix Monster Movement packet parsing

### DIFF
--- a/WowPacketParserModule.V8_0_1_27101/Parsers/MovementHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/MovementHandler.cs
@@ -80,6 +80,12 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             }
             var packedDeltasCount = packet.ReadBits("PackedDeltasCount", 16, indexes);
             var hasSplineFilter = packet.ReadBit("HasSplineFilter", indexes);
+
+            if (ClientVersion.AddedInVersion(ClientType.Shadowlands) && ClientVersion.AddedInVersion(ClientVersionBuild.V2_5_3_41812))
+            {
+                packet.ReadBit("HasUnknown2", indexes);
+            }
+
             var hasSpellEffectExtraData = packet.ReadBit("HasSpellEffectExtraData", indexes);
             var hasJumpExtraData = packet.ReadBit("HasJumpExtraData", indexes);
             var hasAnimTier = false;

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/MovementHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/MovementHandler.cs
@@ -80,7 +80,6 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             }
             var packedDeltasCount = packet.ReadBits("PackedDeltasCount", 16, indexes);
             var hasSplineFilter = packet.ReadBit("HasSplineFilter", indexes);
-
             var hasSpellEffectExtraData = packet.ReadBit("HasSpellEffectExtraData", indexes);
             var hasJumpExtraData = packet.ReadBit("HasJumpExtraData", indexes);
 

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/MovementHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/MovementHandler.cs
@@ -81,20 +81,16 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             var packedDeltasCount = packet.ReadBits("PackedDeltasCount", 16, indexes);
             var hasSplineFilter = packet.ReadBit("HasSplineFilter", indexes);
 
-            if (ClientVersion.AddedInVersion(ClientType.Shadowlands) && ClientVersion.AddedInVersion(ClientVersionBuild.V2_5_3_41812))
-            {
-                packet.ReadBit("HasUnknown2", indexes);
-            }
-
             var hasSpellEffectExtraData = packet.ReadBit("HasSpellEffectExtraData", indexes);
             var hasJumpExtraData = packet.ReadBit("HasJumpExtraData", indexes);
+
             var hasAnimTier = false;
+            if (ClientVersion.AddedInVersion(ClientType.Shadowlands) || ClientVersion.IsBurningCrusadeClassicClientVersionBuild(ClientVersion.Build))
+                hasAnimTier = packet.ReadBit("HasAnimTierTransition", indexes);
+
             var hasUnk901 = false;
             if (ClientVersion.AddedInVersion(ClientType.Shadowlands) && !ClientVersion.IsBurningCrusadeClassicClientVersionBuild(ClientVersion.Build))
-            {
-                hasAnimTier = packet.ReadBit("HasAnimTierTransition", indexes);
-                hasUnk901 = packet.ReadBit("HasUnknown", indexes);
-            }
+                hasUnk901 = packet.ReadBit("HasUnknown901", indexes);
 
             if (hasSplineFilter)
                 ReadMonsterSplineFilter(packet, indexes, "MonsterSplineFilter");
@@ -147,8 +143,8 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             if (hasAnimTier)
             {
                 packet.ReadInt32("TierTransitionID", indexes);
-                packet.ReadInt32("StartTime", indexes);
-                packet.ReadInt32("EndTime", indexes);
+                packet.ReadUInt32("StartTime", indexes);
+                packet.ReadUInt32("EndTime", indexes);
                 packet.ReadByte("AnimTier", indexes);
             }
 


### PR DESCRIPTION
Please verify the actual location of the bit. I used a very unscientific method for it. Fixed my parsing, I assume it will be added in 9.2.