### PR TITLE
Name unknowns in CMSG_GUILD_INVITE_BY_NAME.

### DIFF
--- a/WowPacketParserModule.V9_0_1_36216/Parsers/GuildHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/GuildHandler.cs
@@ -15,7 +15,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
             packet.ReadWoWString("Name", nameLength);
 
             if (isArena)
-                packet.ReadInt32("ArenaTeamSize");
+                packet.ReadInt32("ArenaTeamId");
         }
 
         [Parser(Opcode.SMSG_GUILD_ROSTER, ClientVersionBuild.V9_1_0_39185)]

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/GuildHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/GuildHandler.cs
@@ -9,13 +9,13 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         [Parser(Opcode.CMSG_GUILD_INVITE_BY_NAME, ClientVersionBuild.V9_1_0_39185)]
         public static void HandleGuildInviteByName(Packet packet)
         {
-            var bits16 = packet.ReadBits(9);
-            var unused910 = packet.ReadBit();
+            var nameLength = packet.ReadBits(9);
+            var isArena = packet.ReadBit("IsArenaTeamInvite");
 
-            packet.ReadWoWString("Name", bits16);
+            packet.ReadWoWString("Name", nameLength);
 
-            if (unused910)
-                packet.ReadInt32("Unused910");
+            if (isArena)
+                packet.ReadInt32("ArenaTeamSize");
         }
 
         [Parser(Opcode.SMSG_GUILD_ROSTER, ClientVersionBuild.V9_1_0_39185)]

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/GuildHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/GuildHandler.cs
@@ -10,11 +10,11 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         public static void HandleGuildInviteByName(Packet packet)
         {
             var nameLength = packet.ReadBits(9);
-            var isArena = packet.ReadBit("IsArenaTeamInvite");
+            var hasArenaTeamId = packet.ReadBit("HasArenaTeamId");
 
             packet.ReadWoWString("Name", nameLength);
 
-            if (isArena)
+            if (hasArenaTeamId)
                 packet.ReadInt32("ArenaTeamId");
         }
 


### PR DESCRIPTION
In TBC Classic, this packet is also used for inviting players to your arena team. If that bit is set, it means its an arena team invite, not a guild invite, and the int32 at the end is the arena team id.