### PR TITLE
Unify gossip quest options reading.

### DIFF
--- a/WowPacketParser/Parsing/Parsers/NpcHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/NpcHandler.cs
@@ -538,6 +538,25 @@ namespace WowPacketParser.Parsing.Parsers
             TempGossipOptionPOI.Guid = LastGossipOption.Guid;
         }
 
+        public static GossipQuestOption ReadGossipQuestTextData(Packet packet, params object[] idx)
+        {
+            var gossipQuest = new GossipQuestOption();
+            gossipQuest.QuestId = (uint)packet.ReadInt32("QuestID", idx);
+            packet.ReadInt32("QuestType", idx);
+            packet.ReadInt32("QuestLevel", idx);
+
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V3_3_3_11685))
+                packet.ReadUInt32E<QuestFlags>("Flags", idx);
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V5_1_0_16309))
+                packet.ReadUInt32E<QuestFlagsEx>("FlagsEx", idx);
+
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V3_3_3_11685))
+                packet.ReadBool("Repeatable", idx);
+
+            gossipQuest.Title = packet.ReadCString("Title", idx);
+            return gossipQuest;
+        }
+
         [HasSniffData]
         [Parser(Opcode.SMSG_GOSSIP_MESSAGE)]
         public static void HandleNpcGossip(Packet packet)
@@ -591,20 +610,9 @@ namespace WowPacketParser.Parsing.Parsers
                 });
             }
 
-            uint questgossips = packet.ReadUInt32("Amount of Quest gossips");
-            for (int i = 0; i < questgossips; i++)
-            {
-                packet.ReadUInt32<QuestId>("Quest ID", i);
-
-                packet.ReadUInt32("Icon", i);
-                packet.ReadInt32("Level", i);
-                packet.ReadUInt32E<QuestFlags>("Flags", i);
-                if (ClientVersion.AddedInVersion(ClientVersionBuild.V5_1_0_16309))
-                    packet.ReadUInt32E<QuestFlagsEx>("Flags 2", i);
-
-                packet.ReadBool("Change Icon", i);
-                packet.ReadCString("Title", i);
-            }
+            uint questsCount = packet.ReadUInt32("GossipQuestsCount");
+            for (int i = 0; i < questsCount; i++)
+                ReadGossipQuestTextData(packet, i, "GossipQuests");
 
             if (guid.GetObjectType() == ObjectType.Unit)
             {

--- a/WowPacketParser/Parsing/Parsers/QuestHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/QuestHandler.cs
@@ -840,20 +840,9 @@ namespace WowPacketParser.Parsing.Parsers
             packet.ReadUInt32("Delay");
             packet.ReadUInt32("Emote");
 
-            var count = packet.ReadByte("Count");
+            var count = packet.ReadByte("GossipQuestsCount");
             for (var i = 0; i < count; i++)
-            {
-                packet.ReadUInt32<QuestId>("Quest ID", i);
-                packet.ReadUInt32("Quest Icon", i);
-                packet.ReadInt32("Quest Level", i);
-                packet.ReadUInt32E<QuestFlags>("Quest Flags", i);
-                if (ClientVersion.AddedInVersion(ClientVersionBuild.V5_1_0_16309))
-                    packet.ReadUInt32E<QuestFlagsEx>("Quest Flags 2", i);
-
-                packet.ReadBool("Change icon", i);
-                packet.ReadCString("Title", i);
-            }
-
+                NpcHandler.ReadGossipQuestTextData(packet, i, "GossipQuests");
         }
 
         [Parser(Opcode.CMSG_QUEST_GIVER_QUERY_QUEST)]

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
@@ -84,7 +84,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             packet.ResetBitReader();
 
-            packet.ReadBit("Repeatable");
+            packet.ReadBit("Repeatable", idx);
 
             uint questTitleLen = packet.ReadBits(9);
 
@@ -261,14 +261,14 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             gossip.TextID = packetGossip.TextId = (uint)packet.ReadInt32("TextID");
 
-            int int44 = packet.ReadInt32("GossipOptions");
-            int int60 = packet.ReadInt32("GossipText");
+            int optionsCount = packet.ReadInt32("GossipOptionsCount");
+            int questsCount = packet.ReadInt32("GossipQuestsCount");
 
-            for (int i = 0; i < int44; ++i)
+            for (int i = 0; i < optionsCount; ++i)
                 packetGossip.Options.Add(ReadGossipOptionsData((uint)menuId, guid, packet, i, "GossipOptions"));
 
-            for (int i = 0; i < int60; ++i)
-                packetGossip.Quests.Add(ReadGossipQuestTextData(packet, i, "GossipQuestText"));
+            for (int i = 0; i < questsCount; ++i)
+                packetGossip.Quests.Add(ReadGossipQuestTextData(packet, i, "GossipQuests"));
 
             if (guid.GetObjectType() == ObjectType.Unit)
             {

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/QuestHandler.cs
@@ -60,23 +60,6 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadBit("bit44");
         }
 
-        public static void ReadGossipText(Packet packet, params object[] indexes)
-        {
-            packet.ReadInt32("QuestID", indexes);
-            packet.ReadInt32("QuestType", indexes);
-            packet.ReadInt32("QuestLevel", indexes);
-
-            for (int i = 0; i < 2; i++)
-                packet.ReadUInt32("QuestFlags", indexes, i);
-
-            packet.ResetBitReader();
-
-            packet.ReadBit("Repeatable", indexes);
-
-            var bits13 = packet.ReadBits(9);
-            packet.ReadWoWString("QuestTitle", bits13, indexes);
-        }
-
         [Parser(Opcode.CMSG_QUERY_QUEST_INFO)]
         public static void HandleQuestQuery(Packet packet)
         {
@@ -642,9 +625,9 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 GreetEmoteType = packet.ReadUInt32("GreetEmoteType")
             };
 
-            uint int520 = packet.ReadUInt32("GossipTextCount");
-            for (int i = 0; i < int520; i++)
-                ReadGossipText(packet, i);
+            uint questsCount = packet.ReadUInt32("GossipQuestsCount");
+            for (int i = 0; i < questsCount; i++)
+                NpcHandler.ReadGossipQuestTextData(packet, i, "GossipQuests");
 
             packet.ResetBitReader();
 

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/NpcHandler.cs
@@ -20,7 +20,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 packet.ReadInt32("ContentTuningID", idx);
 
             packet.ReadInt32("QuestType", idx);
-            if (ClientVersion.RemovedInVersion(ClientType.Shadowlands))
+            if (ClientVersion.RemovedInVersion(ClientType.Shadowlands) || ClientVersion.IsClassicClientVersionBuild(ClientVersion.Build))
             {
                 packet.ReadInt32("QuestLevel", idx);
                 if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
@@ -36,8 +36,13 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             if (ClientVersion.RemovedInVersion(ClientVersionBuild.V7_2_0_23826))
                 packet.ReadBit("Ignored");
 
-            uint questTitleLen = packet.ReadBits(9);
+            int titleBits;
+            if (ClientVersion.InVersion(ClientVersionBuild.V8_1_0_28724, ClientVersionBuild.V8_1_5_29683))
+                titleBits = 10;
+            else
+                titleBits = 9;
 
+            uint questTitleLen = packet.ReadBits(titleBits);
             gossipQuest.Title = packet.ReadWoWString("QuestTitle", questTitleLen, idx);
 
             return gossipQuest;
@@ -63,14 +68,14 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
             gossip.TextID = packetGossip.TextId = (uint)packet.ReadInt32("TextID");
 
-            int int44 = packet.ReadInt32("GossipOptions");
-            int int60 = packet.ReadInt32("GossipText");
+            int optionsCount = packet.ReadInt32("GossipOptionsCount");
+            int questsCount = packet.ReadInt32("GossipQuestsCount");
 
-            for (int i = 0; i < int44; ++i)
+            for (int i = 0; i < optionsCount; ++i)
                 packetGossip.Options.Add(V6_0_2_19033.Parsers.NpcHandler.ReadGossipOptionsData((uint)menuId, guid, packet, i, "GossipOptions"));
 
-            for (int i = 0; i < int60; ++i)
-                packetGossip.Quests.Add(ReadGossipQuestTextData(packet, i, "GossipQuestText"));
+            for (int i = 0; i < questsCount; ++i)
+                packetGossip.Quests.Add(ReadGossipQuestTextData(packet, i, "GossipQuests"));
 
             if (guid.GetObjectType() == ObjectType.Unit)
             {

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/QuestHandler.cs
@@ -67,29 +67,6 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ReadBit("IsBoostSpell", idx);
         }
 
-        public static void ReadGossipText(Packet packet, params object[] indexes)
-        {
-            packet.ReadInt32("QuestID", indexes);
-            packet.ReadInt32("QuestType", indexes);
-            packet.ReadInt32("QuestLevel", indexes);
-
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_5_25848))
-                packet.ReadInt32("QuestMaxScalingLevel", indexes);
-
-            for (int i = 0; i < 2; i++)
-                packet.ReadUInt32("QuestFlags", indexes, i);
-
-            packet.ResetBitReader();
-
-            packet.ReadBit("Repeatable", indexes);
-
-            if (ClientVersion.RemovedInVersion(ClientVersionBuild.V7_2_0_23826))
-                packet.ReadBit("IsQuestIgnored", indexes);
-
-            var guestTitleLen = packet.ReadBits(9);
-            packet.ReadWoWString("QuestTitle", guestTitleLen, indexes);
-        }
-
         [HasSniffData]
         [Parser(Opcode.SMSG_QUERY_QUEST_INFO_RESPONSE)]
         public static void HandleQuestQueryResponse(Packet packet)
@@ -587,12 +564,12 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 GreetEmoteType = packet.ReadUInt32("GreetEmoteType")
             };
 
-            uint gossipTextCount = packet.ReadUInt32("GossipTextCount");
+            uint questsCount = packet.ReadUInt32("GossipQuestsCount");
             packet.ResetBitReader();
             uint greetingLen = packet.ReadBits(11);
 
-            for (int i = 0; i < gossipTextCount; i++)
-                ReadGossipText(packet, i);
+            for (int i = 0; i < questsCount; i++)
+                NpcHandler.ReadGossipQuestTextData(packet, i, "GossipQuests");
 
             questGreeting.Greeting = packet.ReadWoWString("Greeting", greetingLen);
 

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/NpcHandler.cs
@@ -82,21 +82,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         public static void HandleGossipQuestUpdate(Packet packet)
         {
             packet.ReadPackedGuid128("GossipGUID");
-
-            packet.ReadInt32<QuestId>("QuestID");
-            packet.ReadInt32("QuestType");
-            packet.ReadInt32("QuestLevel");
-            packet.ReadInt32("QuestMaxScalingLevel");
-
-            for (int i = 0; i < 2; ++i)
-                packet.ReadInt32("QuestFlags", i);
-
-            packet.ResetBitReader();
-
-            packet.ReadBit("Repeatable");
-            uint questTitleLen = packet.ReadBits(9);
-
-            packet.ReadWoWString("QuestTitle", questTitleLen);
+            V7_0_3_22248.Parsers.NpcHandler.ReadGossipQuestTextData(packet);
         }
     }
 }

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/QuestHandler.cs
@@ -66,24 +66,6 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             packet.ReadBit("IsBoostSpell", idx);
         }
 
-        public static void ReadGossipText(Packet packet, params object[] indexes)
-        {
-            packet.ReadInt32("QuestID", indexes);
-            packet.ReadInt32("QuestType", indexes);
-            packet.ReadInt32("QuestLevel", indexes);
-            packet.ReadInt32("QuestMaxScalingLevel", indexes);
-
-            for (int i = 0; i < 2; i++)
-                packet.ReadUInt32("QuestFlags", indexes, i);
-
-            packet.ResetBitReader();
-
-            packet.ReadBit("Repeatable", indexes);
-
-            var guestTitleLen = packet.ReadBits(10);
-            packet.ReadWoWString("QuestTitle", guestTitleLen, indexes);
-        }
-
         [Parser(Opcode.SMSG_QUEST_GIVER_QUEST_DETAILS)]
         public static void HandleQuestGiverQuestDetails(Packet packet)
         {

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/QuestHandler.cs
@@ -844,12 +844,12 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 GreetEmoteType = packet.ReadUInt32("GreetEmoteType")
             };
 
-            uint gossipTextCount = packet.ReadUInt32("GossipTextCount");
+            uint questsCount = packet.ReadUInt32("GossipQuestsCount");
             packet.ResetBitReader();
             uint greetingLen = packet.ReadBits(12);
 
-            for (int i = 0; i < gossipTextCount; i++)
-                ReadGossipText(packet, i);
+            for (int i = 0; i < questsCount; i++)
+                V7_0_3_22248.Parsers.NpcHandler.ReadGossipQuestTextData(packet, i, "GossipQuests");
 
             questGreeting.Greeting = packet.ReadWoWString("Greeting", greetingLen);
 

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/QuestHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/QuestHandler.cs
@@ -9,22 +9,6 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
 {
     public static class QuestHandler
     {
-        public static void ReadGossipText(Packet packet, params object[] indexes)
-        {
-            packet.ReadInt32("QuestID", indexes);
-            packet.ReadInt32("ContentTuningID", indexes);
-            packet.ReadInt32("QuestType", indexes);
-
-            for (int i = 0; i < 2; i++)
-                packet.ReadUInt32("QuestFlags", indexes, i);
-
-            packet.ResetBitReader();
-
-            packet.ReadBit("Repeatable", indexes);
-
-            var bits13 = packet.ReadBits(9);
-            packet.ReadWoWString("QuestTitle", bits13, indexes);
-        }
         public static ItemInstance ReadRewardItem(Packet packet, params object[] idx)
         {
             packet.ResetBitReader();
@@ -528,51 +512,6 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
             packet.ReadWoWString("PortraitTurnInName", portraitTurnInNameLen);
 
             Storage.QuestDetails.Add(questDetails, packet.TimeSpan);
-        }
-
-        [Parser(Opcode.SMSG_QUEST_GIVER_QUEST_LIST_MESSAGE)]
-        public static void HandleQuestgiverQuestList(Packet packet)
-        {
-            WowGuid guid = packet.ReadPackedGuid128("QuestGiverGUID");
-
-            QuestGreeting questGreeting = new QuestGreeting
-            {
-                ID = guid.GetEntry(),
-                GreetEmoteDelay = packet.ReadUInt32("GreetEmoteDelay"),
-                GreetEmoteType = packet.ReadUInt32("GreetEmoteType")
-            };
-
-            uint gossipTextCount = packet.ReadUInt32("GossipTextCount");
-            packet.ResetBitReader();
-            uint greetingLen = packet.ReadBits(11);
-
-            for (int i = 0; i < gossipTextCount; i++)
-                ReadGossipText(packet, i);
-
-            questGreeting.Greeting = packet.ReadWoWString("Greeting", greetingLen);
-
-            switch (guid.GetObjectType())
-            {
-                case ObjectType.Unit:
-                    questGreeting.Type = 0;
-                    break;
-                case ObjectType.GameObject:
-                    questGreeting.Type = 1;
-                    break;
-            }
-
-            Storage.QuestGreetings.Add(questGreeting, packet.TimeSpan);
-
-            if (ClientLocale.PacketLocale != LocaleConstant.enUS && questGreeting.Greeting != string.Empty)
-            {
-                QuestGreetingLocale localesQuestGreeting = new QuestGreetingLocale
-                {
-                    ID = questGreeting.ID,
-                    Type = questGreeting.Type,
-                    Greeting = questGreeting.Greeting
-                };
-                Storage.LocalesQuestGreeting.Add(localesQuestGreeting, packet.TimeSpan);
-            }
         }
 
         [Parser(Opcode.CMSG_QUEST_GIVER_CLOSE_QUEST)]


### PR DESCRIPTION
The following opcodes use the same substructure for the list of quests: SMSG_GOSSIP_QUEST_UPDATE, SMSG_QUEST_GIVER_QUEST_LIST_MESSAGE, SMSG_GOSSIP_MESSAGE

This pull request reduces duplicated code, by removing ReadGossipText used in SMSG_QUEST_GIVER_QUEST_LIST_MESSAGE and replacing it with ReadGossipQuestTextData which reads the exact same data, but also returns a protobuf structure.

Also fixed the following:
- Reading of the structure in those 3 packets for 2.5 sniffs. The quest level was dropped from the structure in 9.0, but it remained in Classic because it's needed there.
- Reading of the quest title in SMSG_GOSSIP_MESSAGE for 8.1.0.