### PR TITLE
Parse SMSG_COMPRESSED_UPDATE_OBJECT and SMSG_DESTROY_OBJECT to protobuf

### DIFF
--- a/WowPacketParser/Parsing/Parsers/UpdateHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/UpdateHandler.cs
@@ -3085,16 +3085,24 @@ namespace WowPacketParser.Parsing.Parsers
             using (var packet2 = packet.Inflate(packet.ReadInt32()))
             {
                 HandleUpdateObject(packet2);
+                packet.Holder.UpdateObject = packet2.Holder.UpdateObject;
             }
         }
 
         [Parser(Opcode.SMSG_DESTROY_OBJECT)]
         public static void HandleDestroyObject(Packet packet)
         {
-            packet.ReadGuid("GUID");
+            var guid = packet.ReadGuid("GUID");
 
             if (packet.CanRead())
                 packet.ReadBool("Despawn Animation");
+            
+            var update = packet.Holder.UpdateObject = new();
+            update.Destroyed.Add(new DestroyedObject()
+            {
+                Guid = guid,
+                Text = packet.Writer.ToString()
+            });
         }
 
         [Parser(Opcode.CMSG_OBJECT_UPDATE_FAILED, ClientVersionBuild.Zero, ClientVersionBuild.V5_1_0_16309)] // 4.3.4

--- a/WowPacketParserModule.V5_3_0_16981/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_3_0_16981/Parsers/UpdateHandler.cs
@@ -863,7 +863,14 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
             packet.ReadBit("Despawn Animation");
             packet.StartBitStream(guid, 0, 1, 6, 2, 5, 7, 3);
             packet.ParseBitStream(guid, 7, 1, 2, 5, 0, 3, 6, 4);
-            packet.WriteGuid("GUID", guid);
+            var destroyed = packet.WriteGuid("GUID", guid);
+            
+            var update = packet.Holder.UpdateObject = new();
+            update.Destroyed.Add(new DestroyedObject()
+            {
+                Guid = destroyed,
+                Text = packet.Writer.ToString()
+            });
         }
     }
 }

--- a/WowPacketParserModule.V5_4_0_17359/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_0_17359/Parsers/UpdateHandler.cs
@@ -873,7 +873,14 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
             guid[1] = packet.ReadBit();
             packet.ParseBitStream(guid, 4, 2, 0, 3, 7, 1, 5, 6);
 
-            packet.WriteGuid("GUID", guid);
+            var destroyed = packet.WriteGuid("GUID", guid);
+            
+            var update = packet.Holder.UpdateObject = new();
+            update.Destroyed.Add(new DestroyedObject()
+            {
+                Guid = destroyed,
+                Text = packet.Writer.ToString()
+            });
         }
     }
 }

--- a/WowPacketParserModule.V5_4_2_17658/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_2_17658/Parsers/UpdateHandler.cs
@@ -908,7 +908,14 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
 
             packet.ParseBitStream(guid, 1, 5, 3, 0, 2, 6, 7, 4);
 
-            packet.WriteGuid("GUID", guid);
+            var destroyed= packet.WriteGuid("GUID", guid);
+            
+            var update = packet.Holder.UpdateObject = new();
+            update.Destroyed.Add(new DestroyedObject()
+            {
+                Guid = destroyed,
+                Text = packet.Writer.ToString()
+            });
         }
 
         [Parser(Opcode.CMSG_OBJECT_UPDATE_FAILED)]

--- a/WowPacketParserModule.V5_4_7_17898/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_7_17898/Parsers/UpdateHandler.cs
@@ -31,7 +31,14 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
 
             packet.ParseBitStream(guid, 2, 1, 5, 4, 3, 6, 7, 0);
 
-            packet.WriteGuid("GUID", guid);
+            var destroyed = packet.WriteGuid("GUID", guid);
+            
+            var update = packet.Holder.UpdateObject = new();
+            update.Destroyed.Add(new DestroyedObject()
+            {
+                Guid = destroyed,
+                Text = packet.Writer.ToString()
+            });
         }
 
         [Parser(Opcode.CMSG_OBJECT_UPDATE_FAILED)]

--- a/WowPacketParserModule.V5_4_8_18291/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_8_18291/Parsers/UpdateHandler.cs
@@ -31,7 +31,14 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
 
             packet.ParseBitStream(guid, 0, 4, 7, 2, 6, 3, 1, 5);
 
-            packet.WriteGuid("GUID", guid);
+            var destroyed = packet.WriteGuid("GUID", guid);
+            
+            var update = packet.Holder.UpdateObject = new();
+            update.Destroyed.Add(new DestroyedObject()
+            {
+                Guid = destroyed,
+                Text = packet.Writer.ToString()
+            });
         }
 
         [HasSniffData] // in ReadCreateObjectBlock


### PR DESCRIPTION
This PR adds parsing of SMSG_COMPRESSED_UPDATE_OBJECT and SMSG_DESTROY_OBJECT packets to the universal UPDATE_OBJECT protobuf structure. This way existing parsing tools can instantly supports those two other packets