### PR TITLE
New dump type: UniversalProtoWithSeparateText

### DIFF
--- a/WowPacketParser.Proto/PacketStructures/StructureVersion.cs
+++ b/WowPacketParser.Proto/PacketStructures/StructureVersion.cs
@@ -6,6 +6,6 @@ namespace WowPacketParser.PacketStructures
          * Everytime you change structures.proto, please increment this version
          * so that user could know if one needs to reparse the sniff
          */
-        public static readonly ulong ProtobufStructureVersion = 15;
+        public static readonly ulong ProtobufStructureVersion = 16;
     }
 }

--- a/WowPacketParser.Proto/PacketStructures/StructureVersion.cs
+++ b/WowPacketParser.Proto/PacketStructures/StructureVersion.cs
@@ -6,6 +6,6 @@ namespace WowPacketParser.PacketStructures
          * Everytime you change structures.proto, please increment this version
          * so that user could know if one needs to reparse the sniff
          */
-        public static readonly ulong ProtobufStructureVersion = 14;
+        public static readonly ulong ProtobufStructureVersion = 15;
     }
 }

--- a/WowPacketParser.Proto/PacketStructures/structures.proto
+++ b/WowPacketParser.Proto/PacketStructures/structures.proto
@@ -12,12 +12,15 @@ option csharp_namespace = "WowPacketParser.Proto";
 
 message PacketsVersion {
   uint64 version = 1;
+  uint64 gameVersion = 2;
+  uint32 dumpType = 3;
 }
 
 message Packets {
   uint64 version = 1;
   uint64 gameVersion = 2;
-  repeated PacketHolder packets = 3;
+  uint32 dumpType = 3;
+  repeated PacketHolder packets = 4;
 }
 
 message PacketBase {
@@ -25,6 +28,8 @@ message PacketBase {
   string opcode = 2;
   google.protobuf.Timestamp time = 3;
   string stringData = 4;
+  google.protobuf.Int64Value textStartOffset = 5;
+  google.protobuf.Int32Value textLength = 6;
 }
 
 message PacketHolder {
@@ -689,18 +694,24 @@ message CreateObject {
   optional StationaryPositionData stationary = 6;
   optional VehicleCreate vehicle = 7;
   optional Quat rotation = 8;
-  optional string text = 9;
+  google.protobuf.Int32Value textStartOffset = 9;
+  google.protobuf.Int32Value textLength = 10;
+  optional string text = 11;
 }
 
 message UpdateObject {
   UniversalGuid guid = 1;
   UpdateValues values = 2;
-  optional string text = 3;
+  google.protobuf.Int32Value textStartOffset = 3;
+  google.protobuf.Int32Value textLength = 4;
+  optional string text = 5;
 }
 
 message DestroyedObject {
   UniversalGuid guid = 1;
-  optional string text = 2;
+  google.protobuf.Int32Value textStartOffset = 2;
+  google.protobuf.Int32Value textLength = 3;
+  optional string text = 4;
 }
 
 message PacketUpdateObject {

--- a/WowPacketParser.Proto/PacketStructures/structures.proto
+++ b/WowPacketParser.Proto/PacketStructures/structures.proto
@@ -16,7 +16,8 @@ message PacketsVersion {
 
 message Packets {
   uint64 version = 1;
-  repeated PacketHolder packets = 2;
+  uint64 gameVersion = 2;
+  repeated PacketHolder packets = 3;
 }
 
 message PacketBase {

--- a/WowPacketParser/Enums/DumpFormatType.cs
+++ b/WowPacketParser/Enums/DumpFormatType.cs
@@ -17,6 +17,7 @@
         ConnectionIndexes,
         Fusion,
         UniversalProto,
-        UniversalProtoWithText
+        UniversalProtoWithText,
+        UniversalProtoWithSeparateText
     }
 }

--- a/WowPacketParser/Loading/SniffFile.cs
+++ b/WowPacketParser/Loading/SniffFile.cs
@@ -204,7 +204,7 @@ namespace WowPacketParser.Loading
                             {
                                 Trace.WriteLine(
                                     $"{_logPrefix}: Parsing {Utilities.BytesToString(reader.PacketReader.GetTotalSize())} of packets. Detected version {ClientVersion.VersionString}");
-
+                                packets.GameVersion = (ulong)ClientVersion.Build;
                                 firstRead = false;
                             }
 

--- a/WowPacketParser/Misc/Extensions.cs
+++ b/WowPacketParser/Misc/Extensions.cs
@@ -350,5 +350,11 @@ namespace WowPacketParser.Misc
                 ItemAppearanceModID = item.ItemAppearanceModID ?? 0
             };
         }
+
+        public static bool IsUniversalProtobufType(this DumpFormatType type)
+        {
+            return type is DumpFormatType.UniversalProto or DumpFormatType.UniversalProtoWithText
+                or DumpFormatType.UniversalProtoWithSeparateText;
+        }
     }
 }

--- a/WowPacketParser/Misc/StringBuilderProtoPart.cs
+++ b/WowPacketParser/Misc/StringBuilderProtoPart.cs
@@ -14,12 +14,16 @@ namespace WowPacketParser.Misc
             startLength = stringBuilder?.Length ?? 0;
         }
 
+        public int StartOffset => startLength;
+
+        public int Length => stringBuilder.Length - startLength;
+
         public string Text
         {
             get
             {
                 if (Settings.DumpFormat == DumpFormatType.UniversalProtoWithText)
-                    return stringBuilder?.ToString(startLength, stringBuilder.Length - startLength) ?? "";
+                    return stringBuilder?.ToString(StartOffset, Length) ?? "";
                 return "";
             }
         }

--- a/WowPacketParser/Parsing/Parsers/UpdateHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/UpdateHandler.cs
@@ -41,7 +41,7 @@ namespace WowPacketParser.Parsing.Parsers
                         var guid = packet.ReadPackedGuid("GUID", i);
                         var updateValues = new UpdateValues(){Legacy = new()};
                         ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text});
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                         break;
                     }
                     case "Movement":
@@ -59,6 +59,8 @@ namespace WowPacketParser.Parsing.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new() {Legacy = new()}, CreateType = createType };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }
@@ -162,7 +164,7 @@ namespace WowPacketParser.Parsing.Parsers
             {
                 var partWriter = new StringBuilderProtoPart(packet.Writer);
                 var guid = packet.ReadPackedGuid("Object GUID", index, j);
-                packet.Holder.UpdateObject.Destroyed.Add(new DestroyedObject(){Guid = guid, Text = partWriter.Text});
+                packet.Holder.UpdateObject.Destroyed.Add(new DestroyedObject(){Guid = guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
             }
         }
 

--- a/WowPacketParserModule.V1_13_2_31446/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V1_13_2_31446/Parsers/UpdateHandler.cs
@@ -36,14 +36,14 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
                 {
                     var partWriter = new StringBuilderProtoPart(packet.Writer);
                     var guid = packet.ReadPackedGuid128("ObjectGUID", "Destroyed", i);
-                    updateObject.Destroyed.Add(new DestroyedObject(){Guid=guid, Text = partWriter.Text});
+                    updateObject.Destroyed.Add(new DestroyedObject(){Guid=guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                 }
 
                 for (var i = 0; i < outOfRangeObjCount; i++)
                 {
                     var partWriter = new StringBuilderProtoPart(packet.Writer);
                     var guid = packet.ReadPackedGuid128("ObjectGUID", "OutOfRange", i);
-                    updateObject.OutOfRange.Add(new DestroyedObject(){Guid=guid, Text = partWriter.Text});
+                    updateObject.OutOfRange.Add(new DestroyedObject(){Guid=guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                 }
             }
             packet.ReadUInt32("Data size");
@@ -61,7 +61,7 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
                         var updateValues = new UpdateValues() {Legacy = new()};
                         CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -71,6 +71,8 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new() {Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V2_5_1_38707/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V2_5_1_38707/Parsers/UpdateHandler.cs
@@ -35,14 +35,14 @@ namespace WowPacketParserModule.V2_5_1_38707.Parsers
                 {
                     var partWriter = new StringBuilderProtoPart(packet.Writer);
                     var guid = packet.ReadPackedGuid128("ObjectGUID", "Destroyed", i);
-                    updateObject.Destroyed.Add(new DestroyedObject(){Guid=guid, Text = partWriter.Text});
+                    updateObject.Destroyed.Add(new DestroyedObject(){Guid=guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                 }
 
                 for (var i = 0; i < outOfRangeObjCount; i++)
                 {
                     var partWriter = new StringBuilderProtoPart(packet.Writer);
                     var guid = packet.ReadPackedGuid128("ObjectGUID", "OutOfRange", i);
-                    updateObject.OutOfRange.Add(new DestroyedObject(){Guid=guid, Text = partWriter.Text});
+                    updateObject.OutOfRange.Add(new DestroyedObject(){Guid=guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                 }
             }
             packet.ReadUInt32("Data size");
@@ -138,7 +138,7 @@ namespace WowPacketParserModule.V2_5_1_38707.Parsers
                             updateValues.Legacy = new();
                             CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         }
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text});
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -148,6 +148,8 @@ namespace WowPacketParserModule.V2_5_1_38707.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new(){}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V4_3_4_15595/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V4_3_4_15595/Parsers/UpdateHandler.cs
@@ -35,7 +35,7 @@ namespace WowPacketParserModule.V4_3_4_15595.Parsers
                         var guid = packet.ReadPackedGuid("GUID", i);
                         var updateValues = new UpdateValues(){Legacy = new()};
                         CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -45,6 +45,8 @@ namespace WowPacketParserModule.V4_3_4_15595.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V5_3_0_16981/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_3_0_16981/Parsers/UpdateHandler.cs
@@ -35,7 +35,7 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
                         var guid = packet.ReadPackedGuid("GUID", i);
                         var updateValues = new UpdateValues() {Legacy = new()};
                         CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -45,6 +45,8 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V5_4_0_17359/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_0_17359/Parsers/UpdateHandler.cs
@@ -35,7 +35,7 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
                         var guid = packet.ReadPackedGuid("GUID", i);
                         var updateValues = new UpdateValues(){Legacy = new()};
                         CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -45,6 +45,8 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType()};
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V5_4_1_17538/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_1_17538/Parsers/UpdateHandler.cs
@@ -35,7 +35,7 @@ namespace WowPacketParserModule.V5_4_1_17538.Parsers
                         var guid = packet.ReadPackedGuid("GUID", i);
                         var updateValues = new UpdateValues(){Legacy = new()};
                         CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -45,6 +45,8 @@ namespace WowPacketParserModule.V5_4_1_17538.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new() { Legacy = new() }, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V5_4_2_17658/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_2_17658/Parsers/UpdateHandler.cs
@@ -35,7 +35,7 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
                         var guid = packet.ReadPackedGuid("GUID", i);
                         var updateValues = new UpdateValues(){Legacy = new()};
                         CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -45,6 +45,8 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V5_4_7_17898/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_7_17898/Parsers/UpdateHandler.cs
@@ -71,7 +71,7 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
                         var guid = packet.ReadPackedGuid("GUID", i);
                         var updateValues = new UpdateValues(){Legacy = new()};
                         CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text });
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -81,6 +81,8 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V5_4_8_18291/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_8_18291/Parsers/UpdateHandler.cs
@@ -62,7 +62,7 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
                         var guid = packet.ReadPackedGuid("GUID", i);
                         var updateValues = new UpdateValues(){Legacy = new()};
                         CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{ Guid = guid, Values = updateValues, Text = partWriter.Text });
+                        updateObject.Updated.Add(new UpdateObject{ Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -72,6 +72,8 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/UpdateHandler.cs
@@ -32,13 +32,13 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 {
                     var partWriter = new StringBuilderProtoPart(packet.Writer);
                     var guid = packet.ReadPackedGuid128("ObjectGUID", "Destroyed", i);
-                    updateObject.Destroyed.Add(new DestroyedObject(){Guid = guid, Text = partWriter.Text });
+                    updateObject.Destroyed.Add(new DestroyedObject(){Guid = guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                 }
                 for (var i = 0; i < outOfRangeObjCount; i++)
                 {
                     var partWriter = new StringBuilderProtoPart(packet.Writer);
                     var guid = packet.ReadPackedGuid128("ObjectGUID", "OutOfRange", i);
-                    updateObject.OutOfRange.Add(new DestroyedObject(){Guid = guid, Text = partWriter.Text });
+                    updateObject.OutOfRange.Add(new DestroyedObject(){Guid = guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                 }
             }
             packet.ReadUInt32("Data size");
@@ -56,7 +56,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
                         var updateValues = new UpdateValues(){Legacy = new()};
                         CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text});
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -66,6 +66,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new(){Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/UpdateHandler.cs
@@ -36,13 +36,13 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 {
                     var partWriter = new StringBuilderProtoPart(packet.Writer);
                     var guid = packet.ReadPackedGuid128("ObjectGUID", "Destroyed", i);
-                    updateObject.Destroyed.Add(new DestroyedObject(){Guid = guid, Text = partWriter.Text });
+                    updateObject.Destroyed.Add(new DestroyedObject(){Guid = guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                 }
                 for (var i = 0; i < outOfRangeObjCount; i++)
                 {
                     var partWriter = new StringBuilderProtoPart(packet.Writer);
                     var guid = packet.ReadPackedGuid128("ObjectGUID", "OutOfRange", i);
-                    updateObject.OutOfRange.Add(new DestroyedObject(){Guid = guid, Text = partWriter.Text });
+                    updateObject.OutOfRange.Add(new DestroyedObject(){Guid = guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text });
                 }
             }
             packet.ReadUInt32("Data size");
@@ -60,7 +60,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                         var guid = packet.ReadPackedGuid128("Object Guid", i);
                         var updateValues = new UpdateValues(){Legacy = new()};
                         CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text});
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -70,6 +70,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new() {Legacy = new()}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateHandler.cs
@@ -39,14 +39,14 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 {
                     var partWriter = new StringBuilderProtoPart(packet.Writer);
                     var guid = packet.ReadPackedGuid128("ObjectGUID", "Destroyed", i);
-                    updateObject.Destroyed.Add(new DestroyedObject(){Guid=guid, Text = partWriter.Text});
+                    updateObject.Destroyed.Add(new DestroyedObject(){Guid=guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                 }
 
                 for (var i = 0; i < outOfRangeObjCount; i++)
                 {
                     var partWriter = new StringBuilderProtoPart(packet.Writer);
                     var guid = packet.ReadPackedGuid128("ObjectGUID", "OutOfRange", i);
-                    updateObject.OutOfRange.Add(new DestroyedObject(){Guid=guid, Text = partWriter.Text});
+                    updateObject.OutOfRange.Add(new DestroyedObject(){Guid=guid, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                 }
             }
             packet.ReadUInt32("Data size");
@@ -142,7 +142,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                             updateValues.Legacy = new();
                             CoreParsers.UpdateHandler.ReadValuesUpdateBlock(packet, updateValues.Legacy, guid, i);
                         }
-                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, Text = partWriter.Text});
+                        updateObject.Updated.Add(new UpdateObject{Guid = guid, Values = updateValues, TextStartOffset = partWriter.StartOffset, TextLength = partWriter.Length, Text = partWriter.Text});
                         break;
                     }
                     case UpdateTypeCataclysm.CreateObject1:
@@ -152,6 +152,8 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                         var createObject = new CreateObject() { Guid = guid, Values = new(){}, CreateType = type.ToCreateObjectType() };
                         ReadCreateObjectBlock(packet, createObject, guid, map, i);
                         createObject.Text = partWriter.Text;
+                        createObject.TextStartOffset = partWriter.StartOffset;
+                        createObject.TextLength = partWriter.Length;
                         updateObject.Created.Add(createObject);
                         break;
                     }


### PR DESCRIPTION
TL;DR: UniversalProtoWithSeparateText is a new dump type which dumps both _parsed.txt and _parsed.dat (proto output) and the _parsed.dat contains offsets in _parsed.txt when referencing packet output text.

---

While protobuf is nice in general, has good support for many programming languages (you can easily parse a sniff in c++ 🕺), it doesn't really work well with large messages. Protobuf always load everything to RAM, so storing raw packet text output in protobuf wasn't a good choice. Hence the idea to dump both .txt and .dat (proto) files, and store file offset reference in proto file.

External tools can now load on demand the packet output text. It works really good now and allow working with much larger sniffs. However, if anyone has another solution, I am open to change the idea ;)   