### PR TITLE
Fix an exception in UniversalProto dump format for UPDATE_OBJECT packets

### DIFF
--- a/WowPacketParser/Misc/StringBuilderProtoPart.cs
+++ b/WowPacketParser/Misc/StringBuilderProtoPart.cs
@@ -1,14 +1,15 @@
 using System.Text;
 using WowPacketParser.Enums;
+#nullable enable
 
 namespace WowPacketParser.Misc
 {
     public readonly struct StringBuilderProtoPart
     {
-        private readonly StringBuilder stringBuilder;
+        private readonly StringBuilder? stringBuilder;
         private readonly int startLength;
 
-        public StringBuilderProtoPart(StringBuilder stringBuilder)
+        public StringBuilderProtoPart(StringBuilder? stringBuilder)
         {
             this.stringBuilder = stringBuilder;
             startLength = stringBuilder?.Length ?? 0;
@@ -16,7 +17,7 @@ namespace WowPacketParser.Misc
 
         public int StartOffset => startLength;
 
-        public int Length => stringBuilder.Length - startLength;
+        public int Length => stringBuilder?.Length - startLength ?? 0;
 
         public string Text
         {


### PR DESCRIPTION
A null exception has been thrown when using UniversalProto dump format in UPDATE_OBJECT parsing