### PR TITLE
Fix Corpse object update parsing in 2.5.4.

### DIFF
--- a/WowPacketParserModule.V2_5_1_38707/Parsers/UpdateFieldsHandler254.cs
+++ b/WowPacketParserModule.V2_5_1_38707/Parsers/UpdateFieldsHandler254.cs
@@ -3157,13 +3157,12 @@ namespace WowPacketParserModule.V2_5_1_38707.UpdateFields.V2_5_4_42800
         public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
             var data = new CorpseData();
-            var rawChangesMask = new int[2];
+            var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
-            rawMaskMask[0] = (int)packet.ReadBits(2);
+            rawMaskMask[0] = (int)packet.ReadBits(1);
             var maskMask = new BitArray(rawMaskMask);
-            for (var i = 0; i < 2; ++i)
-                if (maskMask[i])
-                    rawChangesMask[i] = (int)packet.ReadBits(32);
+            if (maskMask[0])
+                rawChangesMask[0] = (int)packet.ReadBits(32);
             var changesMask = new BitArray(rawChangesMask);
 
             if (changesMask[0])

--- a/WowPacketParserModule.V2_5_1_38707/Parsers/UpdateFieldsHandler254.cs
+++ b/WowPacketParserModule.V2_5_1_38707/Parsers/UpdateFieldsHandler254.cs
@@ -3157,8 +3157,13 @@ namespace WowPacketParserModule.V2_5_1_38707.UpdateFields.V2_5_4_42800
         public override ICorpseData ReadUpdateCorpseData(Packet packet, params object[] indexes)
         {
             var data = new CorpseData();
-            var rawChangesMask = new int[1];
-            rawChangesMask[0] = (int)packet.ReadBits(32);
+            var rawChangesMask = new int[2];
+            var rawMaskMask = new int[1];
+            rawMaskMask[0] = (int)packet.ReadBits(2);
+            var maskMask = new BitArray(rawMaskMask);
+            for (var i = 0; i < 2; ++i)
+                if (maskMask[i])
+                    rawChangesMask[i] = (int)packet.ReadBits(32);
             var changesMask = new BitArray(rawChangesMask);
 
             if (changesMask[0])


### PR DESCRIPTION
I noticed the update object packet was throwing exceptions when Corpse objects were present, and fixed it by copying this part from the 9.2.5 handler. @mdX7 should verify its actually correct first, but it seems to fix it in the sniffs i tested with.