### PR TITLE
Fix areatrigger reading for 5.4.8

### DIFF
--- a/WowPacketParserModule.V5_4_8_18291/Parsers/UpdateHandler.cs
+++ b/WowPacketParserModule.V5_4_8_18291/Parsers/UpdateHandler.cs
@@ -305,7 +305,7 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
                 bit644 = packet.ReadBit();
                 bit560 = packet.ReadBit();
 
-                if (bit664)
+                if (bit644)
                 {
                     bits25C = packet.ReadBits(21); //604
                     bits26C = packet.ReadBits(21); //624


### PR DESCRIPTION
Proof

```
  if ( v3->HasAreaTrigger )
  {
    v3->AreaTrigger.FollowsTerrain = PacketReader::ReadBit(&v119) != 0;
    v3->AreaTrigger.HasAreaTriggerBox = PacketReader::ReadBit(&v119) != 0;
    v3->AreaTrigger.HasMorphCurveID = PacketReader::ReadBit(&v119) != 0;
    v3->AreaTrigger.Attached = PacketReader::ReadBit(&v119) != 0;
    v3->AreaTrigger.HasFacingCurveID = PacketReader::ReadBit(&v119) != 0;
    v3->AreaTrigger.AbsoluteOrientation = PacketReader::ReadBit(&v119) != 0;
    v3->AreaTrigger.HasAreaTriggerSphere = PacketReader::ReadBit(&v119) != 0;
    v3->AreaTrigger.DynamicShape = PacketReader::ReadBit(&v119) != 0;
    v3->AreaTrigger.HasSpline = PacketReader::ReadBit(&v119) != 0;
    v3->AreaTrigger.FaceMovementDir = PacketReader::ReadBit(&v119) != 0;
    if ( v3->AreaTrigger.HasSpline )
    {
      LOBYTE(v121) = 0;
      v72 = sub_695E71(&v119, v121);
      sub_49FC53(v72);
    }
    v3->AreaTrigger.HasScaleCurveID = PacketReader::ReadBit(&v119) != 0;
    v3->AreaTrigger.HasAreaTriggerPolygon = PacketReader::ReadBit(&v119) != 0; // !<<<<<<<<< HERE
    v3->AreaTrigger.HasMoveCurveID = PacketReader::ReadBit(&v119) != 0;
    if ( v3->AreaTrigger.HasAreaTriggerPolygon )
    {
      LOBYTE(v121) = 0;
      v73 = sub_6A29A8(&v119, v121);
      sub_49FCA6(v73);
      LOBYTE(v121) = 0;
      v74 = sub_6A29A8(&v119, v121);
      sub_49FCA6(v74);
    }
  }
```