### PR TITLE
Fix and simplify dockerfile to SDK 6.0 and increase documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
-WORKDIR /app/src
+FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+WORKDIR /src
 COPY . .
-RUN dotnet build "WowPacketParser.sln" -c Release
+RUN dotnet build -c Release
 
-FROM mcr.microsoft.com/dotnet/runtime:5.0 AS final
-WORKDIR /usr/src/app/build
-COPY --from=build /app/src/WowPacketParser/bin/Release .
+FROM mcr.microsoft.com/dotnet/runtime:6.0
+WORKDIR /app
+COPY --from=build /src/WowPacketParser/bin/Release .
 ENTRYPOINT ["dotnet", "WowPacketParser.dll"]

--- a/README.md
+++ b/README.md
@@ -57,10 +57,22 @@ Nightly Builds
 Docker (experimental)
 ---------------------
 
-It is possible run WPP on Docker using the `trinitycore/wpp` image:
+It is possible run WPP on Docker using the `trinitycore/wpp` image.
+
+To build image:
+```
+docker build . -t trinitycore/wpp
+```
+
+To configure:
+
+Copy WowPacketParser/App.config as template and edit as your needs.
+
+
+To run:
 
 ```
-docker run -v /place/where/sniffs/are/kept:/usr/src/app/build/sniffs trinitycore/wpp sniffs/sniffname.pkt
+docker run -v /place/where/sniffs/are/kept:/sniffs -v App.config:/app/WowPacketparser.dll.config trinitycore/wpp /sniffs/sniffname.pkt
 ```
 
 */place/where/sniffs/are/kept* should your local directory containing the .pkt file and *sniffname.pkt* the file to be parsed.


### PR DESCRIPTION
Now we can run in a docker container again.

Maybe a sync push to dockerhub could be a good thing.