### PR TITLE
Fix SQL files saving location

### DIFF
--- a/WowPacketParser/Loading/SniffFile.cs
+++ b/WowPacketParser/Loading/SniffFile.cs
@@ -562,7 +562,7 @@ namespace WowPacketParser.Loading
 
         private void WriteSQLs()
         {
-            var sqlFileName = string.IsNullOrWhiteSpace(Settings.SQLFileName) ? $"{Utilities.FormattedDateTimeForFiles()}_{Path.GetFileName(FileName)}.sql" : Settings.SQLFileName;
+            var sqlFileName = string.IsNullOrWhiteSpace(Settings.SQLFileName) ? $"{Path.GetDirectoryName(FileName)}/{Utilities.FormattedDateTimeForFiles()}_{Path.GetFileName(FileName)}.sql" : Settings.SQLFileName;
 
             if (!string.IsNullOrWhiteSpace(Settings.SQLFileName))
                 return;


### PR DESCRIPTION
Fix SQL files saving location to same sniff dir, as txt output does IF SQLFileName isn't defined.