### PR TITLE
Fixed sql output generation for temporary spawns

### DIFF
--- a/WowPacketParser/SQL/Builder.cs
+++ b/WowPacketParser/SQL/Builder.cs
@@ -121,10 +121,7 @@ namespace WowPacketParser.SQL
 
             var units = Storage.Objects.IsEmpty()
                 ? new Dictionary<WowGuid, Unit>()                                                               // empty dict if there are no objects
-                : Storage.Objects.Where(
-                    obj =>
-                        obj.Value.Item1.Type == ObjectType.Unit && obj.Key.GetHighType() != HighGuidType.Pet && // remove pets
-                        !obj.Value.Item1.IsTemporarySpawn())                                                    // remove temporary spawns
+                : Storage.Objects.Where(obj => obj.Value.Item1.Type == ObjectType.Unit)
                     .OrderBy(pair => pair.Value.Item2)                                                          // order by spawn time
                     .ToDictionary(obj => obj.Key, obj => obj.Value.Item1 as Unit);
 

--- a/WowPacketParser/SQL/Builders/Spawns.cs
+++ b/WowPacketParser/SQL/Builders/Spawns.cs
@@ -203,7 +203,7 @@ namespace WowPacketParser.SQL.Builders
                     addonRow.Data.Mount = (uint)creature.UnitData.MountDisplayID;
                     addonRow.Data.Bytes1 = creature.Bytes1;
                     addonRow.Data.Bytes2 = creature.Bytes2;
-                    addonRow.Data.Emote = 0;
+                    addonRow.Data.Emote = (uint)creature.UnitData.EmoteState.GetValueOrDefault(0);
                     addonRow.Data.Auras = auras;
                     addonRow.Data.AIAnimKit = creature.AIAnimKit.GetValueOrDefault(0);
                     addonRow.Data.MovementAnimKit = creature.MovementAnimKit.GetValueOrDefault(0);
@@ -220,7 +220,7 @@ namespace WowPacketParser.SQL.Builders
                     }
                 }
 
-                if (creature.IsTemporarySpawn() && !Settings.SaveTempSpawns)
+                if (creature.Guid.GetHighType() == HighGuidType.Pet || creature.IsTemporarySpawn())
                 {
                     row.CommentOut = true;
                     row.Comment += " - !!! might be temporary spawn !!!";


### PR DESCRIPTION
- Currently the parser doesn't generate any SQL output related to temporary spawns: template data, addon, model, scaling, etc.
- Fixed EmoteState SQL output for creature addon