### PR TITLE
Don't update creature_model_info with pet data

### DIFF
--- a/WowPacketParser/SQL/Builders/UnitMisc.cs
+++ b/WowPacketParser/SQL/Builders/UnitMisc.cs
@@ -178,6 +178,10 @@ namespace WowPacketParser.SQL.Builders
                     if (!(npc.Map.ToString(CultureInfo.InvariantCulture).MatchesFilters(Settings.MapFilters)))
                         continue;
 
+                // Ignore pets
+                if (npc.Guid.GetHighType() == HighGuidType.Pet)
+                    continue;
+
                 uint modelId = (uint)npc.UnitData.DisplayID;
                 if (modelId == 0)
                     continue;


### PR DESCRIPTION
CombatReach and BoundingRadius from pets are not reliable for generating model info:
```
[2] MoverGUID: Full: 0x283AE00000A1514000004C0403B175BF Pet/0 R3768/S76 Map: 0 (Eastern Kingdoms) Entry: 165189 (Generic Hunter Pet) Low: 17241830847
[2] NativeDisplayID: 40147
[2] BoundingRadius: 0.470656096935272216
[2] CombatReach: 1.5
[2] DisplayScale: 1

[3] MoverGUID: Full: 0x2842509880A15140006E820103ADDC7F Pet/0 R4244/S28290 Map: 1220 (Broken Isles) Entry: 165189 (Generic Hunter Pet) Low: 4356693119
[3] NativeDisplayID: 40147
[3] BoundingRadius: 0.504453241825103759
[3] CombatReach: 1.5
[3] DisplayScale: 1
```