### PR TITLE
Rework DBFieldName and DBTableName Attributes for version checks

### DIFF
--- a/WowPacketParser/App.config
+++ b/WowPacketParser/App.config
@@ -81,7 +81,8 @@
                           7: Shadowlands
                           8: Dragonflight
 
-                          -1: Classic
+                          20: Classic
+                          21: WotlkClassic
         -->
         <add key="TargetedDatabase" value="2"/>
 

--- a/WowPacketParser/Enums/TargetedDatabase.cs
+++ b/WowPacketParser/Enums/TargetedDatabase.cs
@@ -1,7 +1,8 @@
-﻿
+using System;
+
 namespace WowPacketParser.Enums
 {
-    public enum TargetedDatabase
+    public enum TargetedDatabase : int
     {
         Zero                = 0,
         TheBurningCrusade   = 1,
@@ -13,6 +14,49 @@ namespace WowPacketParser.Enums
         Shadowlands         = 7,
         Dragonflight        = 8,
 
-        Classic             = -1
+        // chose higher value to have some room for future
+        Classic             = 20,
+        WotlkClassic        = 21
+    }
+
+    [Flags]
+    public enum TargetedDatabaseFlag : uint
+    {
+        // Retail
+        Zero                              = 1 << TargetedDatabase.Zero,
+        TheBurningCrusade                 = 1 << TargetedDatabase.TheBurningCrusade,
+        WrathOfTheLichKing                = 1 << TargetedDatabase.WrathOfTheLichKing,
+        Cataclysm                         = 1 << TargetedDatabase.Cataclysm,
+        WarlordsOfDraenor                 = 1 << TargetedDatabase.WarlordsOfDraenor,
+        Legion                            = 1 << TargetedDatabase.Legion,
+        BattleForAzeroth                  = 1 << TargetedDatabase.BattleForAzeroth,
+        Shadowlands                       = 1 << TargetedDatabase.Shadowlands,
+        Dragonflight                      = 1 << TargetedDatabase.Dragonflight,
+        AnyRetail                         = TheBurningCrusade | WrathOfTheLichKing | Cataclysm | WarlordsOfDraenor | Legion | BattleForAzeroth | Shadowlands | Dragonflight,
+
+        // Classic
+        Classic                           = 1 << TargetedDatabase.Classic,
+        WotlkClassic                      = 1 << TargetedDatabase.WotlkClassic,
+        AnyClassic                        = Classic | WotlkClassic,
+
+        Any                               = AnyRetail | AnyClassic,
+
+        // predefines
+        TillWrathOfTheLichKing            = TheBurningCrusade | WrathOfTheLichKing,
+        TillCataclysm                     = TheBurningCrusade | WrathOfTheLichKing | Cataclysm,
+        TillWarlordsOfDraenor             = TheBurningCrusade | WrathOfTheLichKing | Cataclysm | WarlordsOfDraenor,
+        TillLegion                        = TheBurningCrusade | WrathOfTheLichKing | Cataclysm | WarlordsOfDraenor | Legion,
+        TillBattleForAzeroth              = TheBurningCrusade | WrathOfTheLichKing | Cataclysm | WarlordsOfDraenor | Legion | BattleForAzeroth,
+
+        FromCataclysmTillBattleForAzeroth = Cataclysm | WarlordsOfDraenor | Legion | BattleForAzeroth,
+
+        // update us when new expansion arrives
+        SinceCataclysm                    = Cataclysm | WarlordsOfDraenor | Legion | BattleForAzeroth | Shadowlands | Dragonflight,
+        SinceWarlordsOfDraenor            = WarlordsOfDraenor | Legion | BattleForAzeroth | Shadowlands | Dragonflight,
+        SinceLegion                       = Legion | BattleForAzeroth | Shadowlands | Dragonflight,
+        SinceBattleForAzeroth             = BattleForAzeroth | Shadowlands | Dragonflight,
+        SinceShadowlands                  = Shadowlands | Dragonflight,
+
+        // Classic
     }
 }

--- a/WowPacketParser/SQL/Builder.cs
+++ b/WowPacketParser/SQL/Builder.cs
@@ -177,7 +177,7 @@ namespace WowPacketParser.SQL
                 case ClientType.BattleForAzeroth: // == ClientType.Classic
                     return new List<TargetedDatabase> { TargetedDatabase.BattleForAzeroth, TargetedDatabase.Classic };
                 case ClientType.Shadowlands: // == ClientType.BurningCrusadeClassic
-                    return new List<TargetedDatabase> { TargetedDatabase.Shadowlands, TargetedDatabase.Classic };
+                    return new List<TargetedDatabase> { TargetedDatabase.Shadowlands, TargetedDatabase.Classic, TargetedDatabase.WotlkClassic };
                 case ClientType.Dragonflight:
                     return new List<TargetedDatabase> { TargetedDatabase.Dragonflight };
                 default:

--- a/WowPacketParser/SQL/DBFieldNameAttribute.cs
+++ b/WowPacketParser/SQL/DBFieldNameAttribute.cs
@@ -50,9 +50,7 @@ namespace WowPacketParser.SQL
         /// </summary>
         private readonly bool _multipleFields;
 
-        private readonly TargetedDatabase? _addedInVersion;
-
-        private readonly TargetedDatabase? _removedInVersion;
+        private readonly TargetedDatabaseFlag _validForVersion;
 
         /// <summary>
         /// matches any version
@@ -66,6 +64,7 @@ namespace WowPacketParser.SQL
             NoQuotes = noQuotes;
             Nullable = nullable;
             Count = 1;
+            _validForVersion = TargetedDatabaseFlag.Any;
         }
 
         /// <summary>
@@ -82,32 +81,33 @@ namespace WowPacketParser.SQL
             Nullable = nullable;
             Count = 1;
             Locale = locale;
+            _validForVersion = TargetedDatabaseFlag.Any;
         }
 
         /// <summary>
-        /// [addedInVersion, +inf[
+        /// [validForVersion, +inf[
         /// </summary>
         /// <param name="name">database field name</param>
-        /// <param name="addedInVersion">initial version</param>
+        /// <param name="validForVersion">valid versions</param>
         /// <param name="isPrimaryKey">true if field is a primary key</param>
-        public DBFieldNameAttribute(string name, TargetedDatabase addedInVersion, bool isPrimaryKey = false, bool noQuotes = false, bool nullable = false)
+        public DBFieldNameAttribute(string name, TargetedDatabaseFlag validForVersion, bool isPrimaryKey = false, bool noQuotes = false, bool nullable = false)
         {
             Name = name;
             IsPrimaryKey = isPrimaryKey;
             NoQuotes = noQuotes;
             Nullable = nullable;
             Count = 1;
-            _addedInVersion = addedInVersion;
+            _validForVersion = validForVersion;
         }
 
         /// <summary>
-        /// [addedInVersion, +inf[
+        /// [validForVersion, +inf[
         /// </summary>
         /// <param name="name">database field name</param>
-        /// <param name="addedInVersion">initial version</param>
+        /// <param name="validForVersion">valid versions</param>
         /// <param name="locale">initial locale</param>
         /// <param name="isPrimaryKey">true if field is a primary key</param>
-        public DBFieldNameAttribute(string name, TargetedDatabase addedInVersion, LocaleConstant locale, bool isPrimaryKey = false, bool noQuotes = false, bool nullable = false)
+        public DBFieldNameAttribute(string name, TargetedDatabaseFlag validForVersion, LocaleConstant locale, bool isPrimaryKey = false, bool noQuotes = false, bool nullable = false)
         {
             Name = name;
             IsPrimaryKey = isPrimaryKey;
@@ -115,46 +115,7 @@ namespace WowPacketParser.SQL
             Nullable = nullable;
             Count = 1;
             Locale = locale;
-            _addedInVersion = addedInVersion;
-        }
-
-        /// <summary>
-        /// [addedInVersion, removedInVersion[
-        /// </summary>
-        /// <param name="name">database field name</param>
-        /// <param name="addedInVersion">initial version</param>
-        /// <param name="removedInVersion">final version</param>
-        /// <param name="isPrimaryKey">true if field is a primary key</param>
-        public DBFieldNameAttribute(string name, TargetedDatabase addedInVersion, TargetedDatabase removedInVersion, bool isPrimaryKey = false, bool noQuotes = false, bool nullable = false)
-        {
-            Name = name;
-            IsPrimaryKey = isPrimaryKey;
-            NoQuotes = noQuotes;
-            Nullable = nullable;
-            Count = 1;
-            _addedInVersion = addedInVersion;
-            _removedInVersion = removedInVersion;
-
-        }
-
-        /// <summary>
-        /// [addedInVersion, removedInVersion[
-        /// </summary>
-        /// <param name="name">database field name</param>
-        /// <param name="addedInVersion">initial version</param>
-        /// <param name="removedInVersion">final version</param>
-        /// <param name="locale">initial locale</param>
-        /// <param name="isPrimaryKey">true if field is a primary key</param>
-        public DBFieldNameAttribute(string name, TargetedDatabase addedInVersion, TargetedDatabase removedInVersion, LocaleConstant locale, bool isPrimaryKey = false, bool noQuotes = false, bool nullable = false)
-        {
-            Name = name;
-            IsPrimaryKey = isPrimaryKey;
-            NoQuotes = noQuotes;
-            Nullable = nullable;
-            Count = 1;
-            Locale = locale;
-            _addedInVersion = addedInVersion;
-            _removedInVersion = removedInVersion;
+            _validForVersion = validForVersion;
         }
 
         /// <summary>
@@ -173,17 +134,18 @@ namespace WowPacketParser.SQL
             Count = count;
             StartAtZero = startAtZero;
             _multipleFields = true;
+            _validForVersion = TargetedDatabaseFlag.Any;
         }
 
         /// <summary>
         /// [addedInVersion, +inf[
         /// </summary>
         /// <param name="name">database field name</param>
-        /// <param name="addedInVersion">initial version</param>
+        /// <param name="validForVersion">valid versions</param>
         /// <param name="count">number of fields</param>
         /// <param name="startAtZero">true if fields name start at 0</param>
         /// <param name="isPrimaryKey">true if field is a primary key</param>
-        public DBFieldNameAttribute(string name, TargetedDatabase addedInVersion, int count, bool startAtZero = false,
+        public DBFieldNameAttribute(string name, TargetedDatabaseFlag validForVersion, int count, bool startAtZero = false,
             bool isPrimaryKey = false, bool noQuotes = false, bool nullable = false)
         {
             Name = name;
@@ -191,31 +153,7 @@ namespace WowPacketParser.SQL
             NoQuotes = noQuotes;
             Nullable = nullable;
             Count = count;
-            _addedInVersion = addedInVersion;
-
-            StartAtZero = startAtZero;
-            _multipleFields = true;
-        }
-
-        /// <summary>
-        /// [addedInVersion, removedInVersion[
-        /// </summary>
-        /// <param name="name">database field name</param>
-        /// <param name="addedInVersion">initial version</param>
-        /// <param name="removedInVersion">final version</param>
-        /// <param name="count">number of fields</param>
-        /// <param name="startAtZero">true if fields name start at 0</param>
-        /// <param name="isPrimaryKey">true if field is a primary key</param>
-        public DBFieldNameAttribute(string name, TargetedDatabase addedInVersion, TargetedDatabase removedInVersion,
-            int count, bool startAtZero = false, bool isPrimaryKey = false, bool noQuotes = false, bool nullable = false)
-        {
-            Name = name;
-            IsPrimaryKey = isPrimaryKey;
-            NoQuotes = noQuotes;
-            Nullable = nullable;
-            Count = count;
-            _addedInVersion = addedInVersion;
-            _removedInVersion = removedInVersion;
+            _validForVersion = validForVersion;
 
             StartAtZero = startAtZero;
             _multipleFields = true;
@@ -226,15 +164,13 @@ namespace WowPacketParser.SQL
             if (Locale != null && Locale != ClientLocale.PacketLocale)
                 return false;
 
-            TargetedDatabase target = Settings.TargetedDatabase;
+            int target = (int)Settings.TargetedDatabase;
+            TargetedDatabaseFlag targetFlag = (TargetedDatabaseFlag)(1 << target);
 
-            if (_addedInVersion.HasValue && !_removedInVersion.HasValue)
-                return target >= _addedInVersion.Value;
+            if (_validForVersion.HasFlag(targetFlag))
+                return true;
 
-            if (_addedInVersion.HasValue && _removedInVersion.HasValue)
-                return target >= _addedInVersion.Value && target < _removedInVersion.Value;
-
-            return true;
+            return false;
         }
 
         /// <summary>

--- a/WowPacketParser/SQL/DBTableNameAttribute.cs
+++ b/WowPacketParser/SQL/DBTableNameAttribute.cs
@@ -16,9 +16,7 @@ namespace WowPacketParser.SQL
         /// </summary>
         public readonly string Name;
 
-        private readonly TargetedDatabase? _addedInVersion;
-
-        private readonly TargetedDatabase? _removedInVersion;
+        private readonly TargetedDatabaseFlag _validForVersion;
 
         /// <summary>
         /// </summary>
@@ -26,42 +24,28 @@ namespace WowPacketParser.SQL
         public DBTableNameAttribute(string name)
         {
             Name = name;
+            _validForVersion = TargetedDatabaseFlag.Any;
         }
 
         /// <summary>
         /// </summary>
         /// <param name="name">table name</param>
         /// <param name="addedInVersion">initial version</param>
-        public DBTableNameAttribute(string name, TargetedDatabase addedInVersion)
+        public DBTableNameAttribute(string name, TargetedDatabaseFlag validForVersion)
             : this(name)
         {
-            _addedInVersion = addedInVersion;
-        }
-
-        /// <summary>
-        /// </summary>
-        /// <param name="name">table name</param>
-        /// <param name="addedInVersion">initial version</param>
-        /// <param name="removedInVersion">final version</param>
-        public DBTableNameAttribute(string name, TargetedDatabase addedInVersion, TargetedDatabase removedInVersion)
-            : this(name, addedInVersion)
-        {
-            _removedInVersion = removedInVersion;
+            _validForVersion = validForVersion;
         }
 
         public bool IsVisible()
         {
-            TargetedDatabase target = Settings.TargetedDatabase;
+            int target = (int)Settings.TargetedDatabase;
+            TargetedDatabaseFlag targetFlag = (TargetedDatabaseFlag)(1 << target);
 
-            if (_addedInVersion.HasValue)
-                if (_addedInVersion.Value < target)
-                    return false;
+            if (_validForVersion.HasFlag(targetFlag))
+                return true;
 
-            if (_removedInVersion.HasValue)
-                if (target >= _removedInVersion.Value)
-                    return false;
-
-            return true;
+            return false;
         }
     }
 }

--- a/WowPacketParser/Store/Objects/AreaTriggerCreateProperties.cs
+++ b/WowPacketParser/Store/Objects/AreaTriggerCreateProperties.cs
@@ -7,12 +7,12 @@ using WowPacketParser.Store.Objects.UpdateFields.LegacyImplementation;
 
 namespace WowPacketParser.Store.Objects
 {
-    [DBTableName("spell_areatrigger", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
-    [DBTableName("areatrigger_create_properties", TargetedDatabase.Shadowlands)]
+    [DBTableName("spell_areatrigger", TargetedDatabaseFlag.TillBattleForAzeroth)]
+    [DBTableName("areatrigger_create_properties", TargetedDatabaseFlag.SinceShadowlands)]
     public sealed record AreaTriggerCreateProperties : WoWObject, IDataModel
     {
-        [DBFieldName("SpellMiscId", TargetedDatabase.Zero, TargetedDatabase.Shadowlands, true)]
-        [DBFieldName("Id", TargetedDatabase.Shadowlands, true)]
+        [DBFieldName("SpellMiscId", TargetedDatabaseFlag.TillBattleForAzeroth, true)]
+        [DBFieldName("Id", TargetedDatabaseFlag.SinceShadowlands, true)]
         public uint? AreaTriggerCreatePropertiesId;
 
         [DBFieldName("AreaTriggerId")]
@@ -45,10 +45,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("TimeToTargetScale")]
         public uint? TimeToTargetScale = 0;
 
-        [DBFieldName("Shape", TargetedDatabase.Shadowlands)]
+        [DBFieldName("Shape", TargetedDatabaseFlag.SinceShadowlands)]
         public byte? Shape;
 
-        [DBFieldName("ShapeData", TargetedDatabase.Shadowlands, 8, true)]
+        [DBFieldName("ShapeData", TargetedDatabaseFlag.SinceShadowlands, 8, true)]
         public float?[] ShapeData = { 0, 0, 0, 0, 0, 0, 0, 0 };
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/AreaTriggerCreatePropertiesPolygonVertex.cs
+++ b/WowPacketParser/Store/Objects/AreaTriggerCreatePropertiesPolygonVertex.cs
@@ -4,12 +4,12 @@ using WowPacketParser.SQL;
 
 namespace WowPacketParser.Store.Objects
 {
-    [DBTableName("spell_areatrigger_vertices", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
-    [DBTableName("areatrigger_create_properties_polygon_vertex", TargetedDatabase.Shadowlands)]
+    [DBTableName("spell_areatrigger_vertices", TargetedDatabaseFlag.TillBattleForAzeroth)]
+    [DBTableName("areatrigger_create_properties_polygon_vertex", TargetedDatabaseFlag.SinceShadowlands)]
     public sealed record AreaTriggerCreatePropertiesPolygonVertex : IDataModel
     {
-        [DBFieldName("SpellMiscId", TargetedDatabase.Zero, TargetedDatabase.Shadowlands, true)]
-        [DBFieldName("AreaTriggerCreatePropertiesId", TargetedDatabase.Shadowlands, true)]
+        [DBFieldName("SpellMiscId", TargetedDatabaseFlag.TillBattleForAzeroth, true)]
+        [DBFieldName("AreaTriggerCreatePropertiesId", TargetedDatabaseFlag.SinceShadowlands, true)]
         public uint? AreaTriggerCreatePropertiesId;
 
         [DBFieldName("Idx", true)]

--- a/WowPacketParser/Store/Objects/AreaTriggerCreatePropertiesSplinePoint.cs
+++ b/WowPacketParser/Store/Objects/AreaTriggerCreatePropertiesSplinePoint.cs
@@ -4,12 +4,12 @@ using WowPacketParser.SQL;
 
 namespace WowPacketParser.Store.Objects
 {
-    [DBTableName("spell_areatrigger_splines", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
-    [DBTableName("areatrigger_create_properties_spline_point", TargetedDatabase.Shadowlands)]
+    [DBTableName("spell_areatrigger_splines", TargetedDatabaseFlag.TillBattleForAzeroth)]
+    [DBTableName("areatrigger_create_properties_spline_point", TargetedDatabaseFlag.SinceShadowlands)]
     public sealed record AreaTriggerCreatePropertiesSplinePoint : IDataModel
     {
-        [DBFieldName("SpellMiscId", TargetedDatabase.Zero, TargetedDatabase.Shadowlands, true)]
-        [DBFieldName("AreaTriggerCreatePropertiesId", TargetedDatabase.Shadowlands, true)]
+        [DBFieldName("SpellMiscId", TargetedDatabaseFlag.TillBattleForAzeroth, true)]
+        [DBFieldName("AreaTriggerCreatePropertiesId", TargetedDatabaseFlag.SinceShadowlands, true)]
         public uint? AreaTriggerCreatePropertiesId;
 
         [DBFieldName("Idx", true)]

--- a/WowPacketParser/Store/Objects/AreaTriggerTemplate.cs
+++ b/WowPacketParser/Store/Objects/AreaTriggerTemplate.cs
@@ -10,7 +10,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Id", true)]
         public uint? Id;
 
-        [DBFieldName("IsServerSide", TargetedDatabase.Shadowlands, true)]
+        [DBFieldName("IsServerSide", TargetedDatabaseFlag.SinceShadowlands, true)]
         public byte? IsServerSide = 0;
 
         [DBFieldName("Type")] // kept in TargetedDatabase.Shadowlands to preserve data for non-spell areatriggers

--- a/WowPacketParser/Store/Objects/BroadcastText.cs
+++ b/WowPacketParser/Store/Objects/BroadcastText.cs
@@ -46,18 +46,18 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Flags")]
         public byte? Flags;
 
-        [DBFieldName("ChatBubbleDurationMs", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("ChatBubbleDurationMs", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public uint? ChatBubbleDurationMs;
 
-        [DBFieldName("VoiceOverPriorityID", TargetedDatabase.Shadowlands)]
+        [DBFieldName("VoiceOverPriorityID", TargetedDatabaseFlag.SinceShadowlands)]
         public uint? VoiceOverPriorityID;
 
-        [DBFieldName("SoundEntriesID1", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
-        [DBFieldName("SoundKitID1", TargetedDatabase.Shadowlands)]
+        [DBFieldName("SoundEntriesID1", TargetedDatabaseFlag.TillBattleForAzeroth)]
+        [DBFieldName("SoundKitID1", TargetedDatabaseFlag.SinceShadowlands)]
         public uint? SoundEntriesID1;
 
-        [DBFieldName("SoundEntriesID2", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
-        [DBFieldName("SoundKitID2", TargetedDatabase.Shadowlands)]
+        [DBFieldName("SoundEntriesID2", TargetedDatabaseFlag.TillBattleForAzeroth)]
+        [DBFieldName("SoundKitID2", TargetedDatabaseFlag.SinceShadowlands)]
         public uint? SoundEntriesID2;
 
         [DBFieldName("EmoteID1")]

--- a/WowPacketParser/Store/Objects/ConversationActor.cs
+++ b/WowPacketParser/Store/Objects/ConversationActor.cs
@@ -16,16 +16,16 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Idx", true)]
         public uint? Idx;
 
-        [DBFieldName("CreatureId", TargetedDatabase.Shadowlands)]
+        [DBFieldName("CreatureId", TargetedDatabaseFlag.SinceShadowlands)]
         public uint? CreatureId;
 
-        [DBFieldName("CreatureDisplayInfoId", TargetedDatabase.Shadowlands)]
+        [DBFieldName("CreatureDisplayInfoId", TargetedDatabaseFlag.SinceShadowlands)]
         public uint? CreatureDisplayInfoId;
 
-        [DBFieldName("NoActorObject", TargetedDatabase.Shadowlands)]
+        [DBFieldName("NoActorObject", TargetedDatabaseFlag.SinceShadowlands)]
         public bool? NoActorObject;
 
-        [DBFieldName("ActivePlayerObject", TargetedDatabase.Shadowlands)]
+        [DBFieldName("ActivePlayerObject", TargetedDatabaseFlag.SinceShadowlands)]
         public bool? ActivePlayerObject;
 
         public WowGuid Guid;

--- a/WowPacketParser/Store/Objects/ConversationActorTemplate.cs
+++ b/WowPacketParser/Store/Objects/ConversationActorTemplate.cs
@@ -10,7 +10,7 @@ namespace WowPacketParser.Store.Objects
         CreatureActor = 1
     };
 
-    [DBTableName("conversation_actor_template", TargetedDatabase.Zero, TargetedDatabase.BattleForAzeroth)]
+    [DBTableName("conversation_actor_template", TargetedDatabaseFlag.TillLegion)]
     public sealed record ConversationActorTemplate : IDataModel
     {
         [DBFieldName("Id", true)]

--- a/WowPacketParser/Store/Objects/ConversationLineTemplate.cs
+++ b/WowPacketParser/Store/Objects/ConversationLineTemplate.cs
@@ -10,7 +10,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Id", true)]
         public uint? Id;
 
-        [DBFieldName("StartTime", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
+        [DBFieldName("StartTime", TargetedDatabaseFlag.TillBattleForAzeroth)]
         public uint? StartTime;
 
         [DBFieldName("UiCameraID")]

--- a/WowPacketParser/Store/Objects/ConversationTemplate.cs
+++ b/WowPacketParser/Store/Objects/ConversationTemplate.cs
@@ -16,10 +16,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("FirstLineID")]
         public uint? FirstLineID;
 
-        [DBFieldName("LastLineEndTime", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
+        [DBFieldName("LastLineEndTime", TargetedDatabaseFlag.TillBattleForAzeroth)]
         public uint? LastLineEndTime;
 
-        [DBFieldName("TextureKitId", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("TextureKitId", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public uint? TextureKitId;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/Creature.cs
+++ b/WowPacketParser/Store/Objects/Creature.cs
@@ -25,16 +25,16 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("spawnMask", TargetedDatabaseFlag.TillWarlordsOfDraenor)]
         public uint? SpawnMask;
 
-        [DBFieldName("spawnDifficulties", TargetedDatabaseFlag.SinceLegion)]
+        [DBFieldName("spawnDifficulties", TargetedDatabaseFlag.SinceLegion | TargetedDatabaseFlag.AnyClassic)]
         public string spawnDifficulties;
 
         [DBFieldName("phaseMask", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? PhaseMask;
 
-        [DBFieldName("PhaseId", TargetedDatabaseFlag.SinceCataclysm)]
+        [DBFieldName("PhaseId", TargetedDatabaseFlag.SinceCataclysm | TargetedDatabaseFlag.AnyClassic)]
         public string PhaseID;
 
-        [DBFieldName("PhaseGroup", TargetedDatabaseFlag.SinceCataclysm)]
+        [DBFieldName("PhaseGroup", TargetedDatabaseFlag.SinceCataclysm | TargetedDatabaseFlag.AnyClassic)]
         public int? PhaseGroup;
 
         [DBFieldName("modelid")]

--- a/WowPacketParser/Store/Objects/Creature.cs
+++ b/WowPacketParser/Store/Objects/Creature.cs
@@ -22,19 +22,19 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("areaId")]
         public uint? AreaID;
 
-        [DBFieldName("spawnMask", TargetedDatabase.Zero, TargetedDatabase.Legion)]
+        [DBFieldName("spawnMask", TargetedDatabaseFlag.TillWarlordsOfDraenor)]
         public uint? SpawnMask;
 
-        [DBFieldName("spawnDifficulties", TargetedDatabase.Legion)]
+        [DBFieldName("spawnDifficulties", TargetedDatabaseFlag.SinceLegion)]
         public string spawnDifficulties;
 
-        [DBFieldName("phaseMask", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("phaseMask", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? PhaseMask;
 
-        [DBFieldName("PhaseId", TargetedDatabase.Cataclysm)]
+        [DBFieldName("PhaseId", TargetedDatabaseFlag.SinceCataclysm)]
         public string PhaseID;
 
-        [DBFieldName("PhaseGroup", TargetedDatabase.Cataclysm)]
+        [DBFieldName("PhaseGroup", TargetedDatabaseFlag.SinceCataclysm)]
         public int? PhaseGroup;
 
         [DBFieldName("modelid")]

--- a/WowPacketParser/Store/Objects/CreatureAddon.cs
+++ b/WowPacketParser/Store/Objects/CreatureAddon.cs
@@ -24,18 +24,18 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("emote")]
         public uint? Emote;
 
-        [DBFieldName("aiAnimKit", TargetedDatabase.Legion)]
+        [DBFieldName("aiAnimKit", TargetedDatabaseFlag.SinceLegion)]
         public ushort? AIAnimKit;
 
-        [DBFieldName("movementAnimKit", TargetedDatabase.Legion)]
+        [DBFieldName("movementAnimKit", TargetedDatabaseFlag.SinceLegion)]
         public ushort? MovementAnimKit;
 
-        [DBFieldName("meleeAnimKit", TargetedDatabase.Legion)]
+        [DBFieldName("meleeAnimKit", TargetedDatabaseFlag.SinceLegion)]
         public ushort? MeleeAnimKit;
 
         // visibilityDistanceType exists in all database versions but because UnitFlags2 to detect the value from sniff doesn't exist in earlier client version
         // we pretend the field doesn't exist
-        [DBFieldName("visibilityDistanceType", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("visibilityDistanceType", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public byte? VisibilityDistanceType;
 
         [DBFieldName("auras")]

--- a/WowPacketParser/Store/Objects/CreatureEquipment.cs
+++ b/WowPacketParser/Store/Objects/CreatureEquipment.cs
@@ -17,28 +17,28 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("ItemID1")]
         public uint? ItemID1;
 
-        [DBFieldName("AppearanceModID1", TargetedDatabase.Legion)]
+        [DBFieldName("AppearanceModID1", TargetedDatabaseFlag.SinceLegion)]
         public ushort? AppearanceModID1;
 
-        [DBFieldName("ItemVisual1", TargetedDatabase.Legion)]
+        [DBFieldName("ItemVisual1", TargetedDatabaseFlag.SinceLegion)]
         public ushort? ItemVisual1;
 
         [DBFieldName("ItemID2")]
         public uint? ItemID2;
 
-        [DBFieldName("AppearanceModID2", TargetedDatabase.Legion)]
+        [DBFieldName("AppearanceModID2", TargetedDatabaseFlag.SinceLegion)]
         public ushort? AppearanceModID2;
 
-        [DBFieldName("ItemVisual2", TargetedDatabase.Legion)]
+        [DBFieldName("ItemVisual2", TargetedDatabaseFlag.SinceLegion)]
         public ushort? ItemVisual2;
 
         [DBFieldName("ItemID3")]
         public uint? ItemID3;
 
-        [DBFieldName("AppearanceModID3", TargetedDatabase.Legion)]
+        [DBFieldName("AppearanceModID3", TargetedDatabaseFlag.SinceLegion)]
         public ushort? AppearanceModID3;
 
-        [DBFieldName("ItemVisual3", TargetedDatabase.Legion)]
+        [DBFieldName("ItemVisual3", TargetedDatabaseFlag.SinceLegion)]
         public ushort? ItemVisual3;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/CreatureTemplate.cs
+++ b/WowPacketParser/Store/Objects/CreatureTemplate.cs
@@ -1,4 +1,4 @@
-﻿using WowPacketParser.Enums;
+using WowPacketParser.Enums;
 using WowPacketParser.Misc;
 using WowPacketParser.SQL;
 
@@ -10,46 +10,49 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("entry", true)]
         public uint? Entry;
 
+        [DBFieldName("Civilian", TargetedDatabaseFlag.AnyClassic)]
+        public bool? Civilian;
+
         [DBFieldName("KillCredit", 2)]
         public uint?[] KillCredits;
 
-        [DBFieldName("modelid", TargetedDatabase.Zero, TargetedDatabase.BattleForAzeroth, 4)]
+        [DBFieldName("modelid", TargetedDatabaseFlag.TillWarlordsOfDraenor, 4)]
         public uint?[] ModelIDs;
 
         [DBFieldName("name")]
         public string Name;
 
-        [DBFieldName("femaleName", TargetedDatabase.Cataclysm)]
+        [DBFieldName("femaleName", TargetedDatabaseFlag.SinceCataclysm)]
         public string FemaleName;
 
         [DBFieldName("subname", nullable: true)]
         public string SubName;
 
-        [DBFieldName("TitleAlt", TargetedDatabase.WarlordsOfDraenor /*Mists of Pandaria*/, nullable: true)]
+        [DBFieldName("TitleAlt", TargetedDatabaseFlag.SinceWarlordsOfDraenor /*Mists of Pandaria*/, nullable: true)]
         public string TitleAlt;
 
         [DBFieldName("IconName", nullable: true)]
         public string IconName;
 
-        [DBFieldName("HealthScalingExpansion", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("HealthScalingExpansion", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public ClientType? HealthScalingExpansion;
 
-        [DBFieldName("RequiredExpansion", TargetedDatabase.Cataclysm)]
+        [DBFieldName("RequiredExpansion", TargetedDatabaseFlag.SinceCataclysm | TargetedDatabaseFlag.AnyClassic)]
         public ClientType? RequiredExpansion;
 
-        [DBFieldName("VignetteID", TargetedDatabase.Legion)]
+        [DBFieldName("VignetteID", TargetedDatabaseFlag.SinceLegion | TargetedDatabaseFlag.AnyClassic)]
         public uint? VignetteID;
 
-        [DBFieldName("unit_class", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("unit_class", TargetedDatabaseFlag.SinceBattleForAzeroth | TargetedDatabaseFlag.AnyClassic)]
         public uint? UnitClass;
 
-        [DBFieldName("FadeRegionRadius", TargetedDatabase.BattleForAzeroth, TargetedDatabase.Shadowlands)]
+        [DBFieldName("FadeRegionRadius", TargetedDatabaseFlag.BattleForAzeroth)]
         public float? FadeRegionRadius;
 
-        [DBFieldName("WidgetSetID", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("WidgetSetID", TargetedDatabaseFlag.SinceBattleForAzeroth | TargetedDatabaseFlag.AnyClassic)]
         public int? WidgetSetID;
 
-        [DBFieldName("WidgetSetUnitConditionID", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("WidgetSetUnitConditionID", TargetedDatabaseFlag.SinceBattleForAzeroth | TargetedDatabaseFlag.AnyClassic)]
         public int? WidgetSetUnitConditionID;
 
         [DBFieldName("rank")]
@@ -64,10 +67,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("type_flags")]
         public CreatureTypeFlag? TypeFlags;
 
-        [DBFieldName("type_flags2", TargetedDatabase.Cataclysm)]
+        [DBFieldName("type_flags2", TargetedDatabaseFlag.SinceCataclysm)]
         public uint? TypeFlags2;
 
-        [DBFieldName("PetSpellDataId", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("PetSpellDataId", TargetedDatabaseFlag.TillWrathOfTheLichKing | TargetedDatabaseFlag.AnyClassic)]
         public uint? PetSpellDataID;
 
         [DBFieldName("HealthModifier")]
@@ -82,7 +85,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("movementId")]
         public uint? MovementID;
 
-        [DBFieldName("CreatureDifficultyID", TargetedDatabase.Shadowlands)]
+        [DBFieldName("CreatureDifficultyID", TargetedDatabaseFlag.SinceShadowlands | TargetedDatabaseFlag.AnyClassic)]
         public int? CreatureDifficultyID;
 
         [DBFieldName("VerifiedBuild")]
@@ -122,7 +125,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RangeAttackTime")]
         public uint? RangedAttackTime;
 
-        [DBFieldName("unit_class", TargetedDatabase.Zero, TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("unit_class", TargetedDatabaseFlag.TillWarlordsOfDraenor)]
         public uint? UnitClass;
 
         [DBFieldName("unit_flags")]
@@ -131,13 +134,13 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("unit_flags2")]
         public UnitFlags2? UnitFlags2;
 
-        [DBFieldName("unit_flags3", TargetedDatabase.Legion)]
+        [DBFieldName("unit_flags3", TargetedDatabaseFlag.SinceLegion)]
         public UnitFlags3? UnitFlags3;
 
-        [DBFieldName("dynamicflags", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("dynamicflags", TargetedDatabaseFlag.TillCataclysm)]
         public UnitDynamicFlags? DynamicFlags;
 
-        [DBFieldName("dynamicflags", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("dynamicflags", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public UnitDynamicFlagsWOD? DynamicFlagsWod;
 
         [DBFieldName("VehicleId")]
@@ -160,7 +163,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("ItemId")]
         public uint? ItemId;
 
-        [DBFieldName("VerifiedBuild", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("VerifiedBuild", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public int? VerifiedBuild = ClientVersion.BuildInt;
     }
 

--- a/WowPacketParser/Store/Objects/CreatureTemplate.cs
+++ b/WowPacketParser/Store/Objects/CreatureTemplate.cs
@@ -22,13 +22,13 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("name")]
         public string Name;
 
-        [DBFieldName("femaleName", TargetedDatabaseFlag.SinceCataclysm)]
+        [DBFieldName("femaleName", TargetedDatabaseFlag.SinceCataclysm | TargetedDatabaseFlag.AnyClassic)]
         public string FemaleName;
 
         [DBFieldName("subname", nullable: true)]
         public string SubName;
 
-        [DBFieldName("TitleAlt", TargetedDatabaseFlag.SinceWarlordsOfDraenor /*Mists of Pandaria*/, nullable: true)]
+        [DBFieldName("TitleAlt", TargetedDatabaseFlag.SinceWarlordsOfDraenor /*Mists of Pandaria*/ | TargetedDatabaseFlag.AnyClassic, nullable: true)]
         public string TitleAlt;
 
         [DBFieldName("IconName", nullable: true)]
@@ -134,13 +134,13 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("unit_flags2")]
         public UnitFlags2? UnitFlags2;
 
-        [DBFieldName("unit_flags3", TargetedDatabaseFlag.SinceLegion)]
+        [DBFieldName("unit_flags3", TargetedDatabaseFlag.SinceLegion | TargetedDatabaseFlag.AnyClassic)]
         public UnitFlags3? UnitFlags3;
 
         [DBFieldName("dynamicflags", TargetedDatabaseFlag.TillCataclysm)]
         public UnitDynamicFlags? DynamicFlags;
 
-        [DBFieldName("dynamicflags", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("dynamicflags", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public UnitDynamicFlagsWOD? DynamicFlagsWod;
 
         [DBFieldName("VehicleId")]

--- a/WowPacketParser/Store/Objects/CreatureTemplateAddon.cs
+++ b/WowPacketParser/Store/Objects/CreatureTemplateAddon.cs
@@ -24,18 +24,18 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("emote")]
         public uint? Emote;
 
-        [DBFieldName("aiAnimKit", TargetedDatabase.Legion)]
+        [DBFieldName("aiAnimKit", TargetedDatabaseFlag.SinceLegion)]
         public ushort? AIAnimKit;
 
-        [DBFieldName("movementAnimKit", TargetedDatabase.Legion)]
+        [DBFieldName("movementAnimKit", TargetedDatabaseFlag.SinceLegion)]
         public ushort? MovementAnimKit;
 
-        [DBFieldName("meleeAnimKit", TargetedDatabase.Legion)]
+        [DBFieldName("meleeAnimKit", TargetedDatabaseFlag.SinceLegion)]
         public ushort? MeleeAnimKit;
 
         // visibilityDistanceType exists in all database versions but because UnitFlags2 to detect the value from sniff doesn't exist in earlier client version
         // we pretend the field doesn't exist
-        [DBFieldName("visibilityDistanceType", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("visibilityDistanceType", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public byte? VisibilityDistanceType;
 
         [DBFieldName("auras")]

--- a/WowPacketParser/Store/Objects/CreatureTemplateScaling.cs
+++ b/WowPacketParser/Store/Objects/CreatureTemplateScaling.cs
@@ -13,10 +13,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("DifficultyID", true)]
         public uint? DifficultyID;
 
-        [DBFieldName("LevelScalingMin", TargetedDatabase.Legion, TargetedDatabase.Shadowlands)]
+        [DBFieldName("LevelScalingMin", TargetedDatabaseFlag.Legion | TargetedDatabaseFlag.BattleForAzeroth)]
         public uint? LevelScalingMin;
 
-        [DBFieldName("LevelScalingMax", TargetedDatabase.Legion, TargetedDatabase.Shadowlands)]
+        [DBFieldName("LevelScalingMax", TargetedDatabaseFlag.Legion | TargetedDatabaseFlag.BattleForAzeroth)]
         public uint? LevelScalingMax;
 
         [DBFieldName("LevelScalingDeltaMin")]
@@ -25,8 +25,8 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("LevelScalingDeltaMax")]
         public int? LevelScalingDeltaMax;
 
-        [DBFieldName("SandboxScalingID", TargetedDatabase.Legion, TargetedDatabase.BattleForAzeroth)]
-        [DBFieldName("ContentTuningID", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("SandboxScalingID", TargetedDatabaseFlag.Legion)]
+        [DBFieldName("ContentTuningID", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public int? ContentTuningID;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/GameObjectAddon.cs
+++ b/WowPacketParser/Store/Objects/GameObjectAddon.cs
@@ -21,10 +21,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("parent_rotation3")]
         public float? parentRot3;
 
-        [DBFieldName("WorldEffectID", TargetedDatabase.Legion)]
+        [DBFieldName("WorldEffectID", TargetedDatabaseFlag.SinceLegion)]
         public uint? WorldEffectID;
 
-        [DBFieldName("AIAnimKitID", TargetedDatabase.Shadowlands)]
+        [DBFieldName("AIAnimKitID", TargetedDatabaseFlag.SinceShadowlands)]
         public uint? AIAnimKitID;
     }
 }

--- a/WowPacketParser/Store/Objects/GameObjectModel.cs
+++ b/WowPacketParser/Store/Objects/GameObjectModel.cs
@@ -22,19 +22,19 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("areaId")]
         public uint? AreaID;
 
-        [DBFieldName("spawnMask", TargetedDatabase.Zero, TargetedDatabase.Legion)]
+        [DBFieldName("spawnMask", TargetedDatabaseFlag.TillBattleForAzeroth)]
         public uint? SpawnMask;
 
-        [DBFieldName("spawnDifficulties", TargetedDatabase.Legion)]
+        [DBFieldName("spawnDifficulties", TargetedDatabaseFlag.SinceLegion)]
         public string spawnDifficulties;
 
-        [DBFieldName("phaseMask", TargetedDatabase.WrathOfTheLichKing, TargetedDatabase.Cataclysm)]
+        [DBFieldName("phaseMask", TargetedDatabaseFlag.WrathOfTheLichKing)]
         public uint? PhaseMask;
 
-        [DBFieldName("PhaseId", TargetedDatabase.Cataclysm)]
+        [DBFieldName("PhaseId", TargetedDatabaseFlag.SinceCataclysm)]
         public string PhaseID;
 
-        [DBFieldName("PhaseGroup", TargetedDatabase.Cataclysm)]
+        [DBFieldName("PhaseGroup", TargetedDatabaseFlag.SinceCataclysm)]
         public uint? PhaseGroup;
 
         [DBFieldName("position_x")]

--- a/WowPacketParser/Store/Objects/GameObjectTemplate.cs
+++ b/WowPacketParser/Store/Objects/GameObjectTemplate.cs
@@ -34,17 +34,17 @@ namespace WowPacketParser.Store.Objects
         //TODO: move to gameobject_questitem
         public uint?[] QuestItems;
 
-        [DBFieldName("Data", TargetedDatabase.Zero, TargetedDatabase.Cataclysm, 24, true)]
-        [DBFieldName("Data", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor, 32, true)]
-        [DBFieldName("Data", TargetedDatabase.WarlordsOfDraenor, TargetedDatabase.BattleForAzeroth, 33, true)]
-        [DBFieldName("Data", TargetedDatabase.BattleForAzeroth, TargetedDatabase.Shadowlands, 34, true)]
-        [DBFieldName("Data", TargetedDatabase.Shadowlands, 35, true)]
+        [DBFieldName("Data", TargetedDatabaseFlag.TillWrathOfTheLichKing, 24, true)]
+        [DBFieldName("Data", TargetedDatabaseFlag.Cataclysm, 32, true)]
+        [DBFieldName("Data", TargetedDatabaseFlag.WarlordsOfDraenor | TargetedDatabaseFlag.Legion, 33, true)]
+        [DBFieldName("Data", TargetedDatabaseFlag.BattleForAzeroth, 34, true)]
+        [DBFieldName("Data", TargetedDatabaseFlag.SinceShadowlands, 35, true)]
         public int?[] Data;
 
-        [DBFieldName("RequiredLevel", TargetedDatabase.Cataclysm, TargetedDatabase.Shadowlands)]
+        [DBFieldName("RequiredLevel", TargetedDatabaseFlag.FromCataclysmTillBattleForAzeroth)]
         public int? RequiredLevel;
 
-        [DBFieldName("ContentTuningId", TargetedDatabase.Shadowlands)]
+        [DBFieldName("ContentTuningId", TargetedDatabaseFlag.SinceShadowlands)]
         public int? ContentTuningId;
 
         [DBFieldName("VerifiedBuild")]
@@ -63,7 +63,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("ItemId")]
         public uint? ItemId;
 
-        [DBFieldName("VerifiedBuild", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("VerifiedBuild", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public int? VerifiedBuild = ClientVersion.BuildInt;
     }
 }

--- a/WowPacketParser/Store/Objects/GameObjectTemplateAddon.cs
+++ b/WowPacketParser/Store/Objects/GameObjectTemplateAddon.cs
@@ -15,10 +15,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("flags")]
         public GameObjectFlag? Flags;
 
-        [DBFieldName("WorldEffectID", TargetedDatabase.Legion)]
+        [DBFieldName("WorldEffectID", TargetedDatabaseFlag.SinceLegion)]
         public uint? WorldEffectID;
 
-        [DBFieldName("AIAnimKitID", TargetedDatabase.Shadowlands)]
+        [DBFieldName("AIAnimKitID", TargetedDatabaseFlag.SinceShadowlands)]
         public uint? AIAnimKitID;
     }
 }

--- a/WowPacketParser/Store/Objects/GossipMenuOption.cs
+++ b/WowPacketParser/Store/Objects/GossipMenuOption.cs
@@ -17,8 +17,8 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("OptionID", true)]
         public uint? OptionID;
 
-        [DBFieldName("OptionIcon", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
-        [DBFieldName("OptionNpc", TargetedDatabase.Shadowlands)]
+        [DBFieldName("OptionIcon", TargetedDatabaseFlag.TillBattleForAzeroth)]
+        [DBFieldName("OptionNpc", TargetedDatabaseFlag.SinceShadowlands)]
         public GossipOptionNpc? OptionNpc;
 
         [DBFieldName("OptionText")]
@@ -27,13 +27,13 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("OptionBroadcastTextId")]
         public int? OptionBroadcastTextId;
 
-        [DBFieldName("OptionType", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
+        [DBFieldName("OptionType", TargetedDatabaseFlag.TillBattleForAzeroth)]
         public GossipOptionType? OptionType;
 
-        [DBFieldName("OptionNpcFlag", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
+        [DBFieldName("OptionNpcFlag", TargetedDatabaseFlag.TillBattleForAzeroth)]
         public NPCFlags? OptionNpcFlag;
 
-        [DBFieldName("Language", TargetedDatabase.Shadowlands)]
+        [DBFieldName("Language", TargetedDatabaseFlag.SinceShadowlands)]
         public Language? Language;
 
         [DBFieldName("ActionMenuID")]

--- a/WowPacketParser/Store/Objects/GossipMenuOptionAddon.cs
+++ b/WowPacketParser/Store/Objects/GossipMenuOptionAddon.cs
@@ -4,7 +4,7 @@ using WowPacketParser.SQL;
 
 namespace WowPacketParser.Store.Objects
 {
-    [DBTableName("gossip_menu_option_addon", TargetedDatabase.Shadowlands, TargetedDatabase.Dragonflight)]
+    [DBTableName("gossip_menu_option_addon", TargetedDatabaseFlag.Shadowlands)]
     public sealed record GossipMenuOptionAddon : IDataModel
     {
         [DBFieldName("MenuID", true)]

--- a/WowPacketParser/Store/Objects/HotfixData.cs
+++ b/WowPacketParser/Store/Objects/HotfixData.cs
@@ -10,7 +10,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Id", true)]
         public uint? ID;
 
-        [DBFieldName("UniqueID", TargetedDatabase.Shadowlands)]
+        [DBFieldName("UniqueID", TargetedDatabaseFlag.SinceShadowlands)]
         public uint? UniqueID;
 
         [DBFieldName("TableHash", true)]
@@ -19,10 +19,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RecordId", true)]
         public int? RecordID;
 
-        [DBFieldName("Deleted", TargetedDatabase.Zero, TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("Deleted", TargetedDatabaseFlag.TillLegion)]
         public bool? Deleted;
 
-        [DBFieldName("Status", TargetedDatabase.Shadowlands)]
+        [DBFieldName("Status", TargetedDatabaseFlag.SinceShadowlands)]
         public HotfixStatus? Status;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/ItemTemplate.cs
+++ b/WowPacketParser/Store/Objects/ItemTemplate.cs
@@ -34,10 +34,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("FlagsExtra")]
         public ItemFlagExtra? FlagsExtra;
 
-        [DBFieldName("Unk430_1", TargetedDatabase.Cataclysm)]
+        [DBFieldName("Unk430_1", TargetedDatabaseFlag.SinceCataclysm)]
         public float? Unk430_1;
 
-        [DBFieldName("Unk430_2", TargetedDatabase.Cataclysm)]
+        [DBFieldName("Unk430_2", TargetedDatabaseFlag.SinceCataclysm)]
         public float? Unk430_2;
 
         [DBFieldName("BuyCount")]
@@ -94,7 +94,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("ContainerSlots")]
         public uint? ContainerSlots;
 
-        [DBFieldName("StatsCount", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("StatsCount", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? StatsCount;
 
         [DBFieldName("stat_type", 10)]
@@ -103,56 +103,56 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("stat_value", 10)]
         public int?[] StatValues;
 
-        [DBFieldName("scaling_value", TargetedDatabase.Cataclysm, 10)]
+        [DBFieldName("scaling_value", TargetedDatabaseFlag.SinceCataclysm, 10)]
         public int?[] ScalingValue;
 
-        [DBFieldName("socket_cost_rate", TargetedDatabase.Cataclysm, 10)]
+        [DBFieldName("socket_cost_rate", TargetedDatabaseFlag.SinceCataclysm, 10)]
         public int?[] SocketCostRate;
 
         [DBFieldName("ScalingStatDistribution")]
         public int? ScalingStatDistribution;
 
-        [DBFieldName("ScalingStatValue", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("ScalingStatValue", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? ScalingStatValue;
 
-        [DBFieldName("dmg_min", TargetedDatabase.Zero, TargetedDatabase.Cataclysm, 2)]
+        [DBFieldName("dmg_min", TargetedDatabaseFlag.TillWrathOfTheLichKing, 2)]
         public float?[] DamageMins;
 
-        [DBFieldName("dmg_max", TargetedDatabase.Zero, TargetedDatabase.Cataclysm, 2)]
+        [DBFieldName("dmg_max", TargetedDatabaseFlag.TillWrathOfTheLichKing, 2)]
         public float?[] DamageMaxs;
 
-        [DBFieldName("dmg_type", TargetedDatabase.Zero, TargetedDatabase.Cataclysm, 2)]
+        [DBFieldName("dmg_type", TargetedDatabaseFlag.TillWrathOfTheLichKing, 2)]
         public DamageType?[] DamageTypes;
 
 
-        [DBFieldName("armor", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("armor", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? Armor;
 
-        [DBFieldName("holy_res", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("holy_res", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? HolyResistance;
 
-        [DBFieldName("fire_res", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("fire_res", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? FireResistance;
 
-        [DBFieldName("nature_res", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("nature_res", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? NatureResistance;
 
-        [DBFieldName("frost_res", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("frost_res", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? FrostResistance;
 
-        [DBFieldName("shadow_res", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("shadow_res", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? ShadowResistance;
 
-        [DBFieldName("arcane_res", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("arcane_res", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? ArcaneResistance;
 
-        [DBFieldName("DamageType", TargetedDatabase.Cataclysm)]
+        [DBFieldName("DamageType", TargetedDatabaseFlag.SinceCataclysm)]
         public DamageType? DamageType;
 
         [DBFieldName("delay")]
         public uint? Delay;
 
-        [DBFieldName("ammo_type", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("ammo_type", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public AmmoType? AmmoType;
 
         [DBFieldName("RangedModRange")]
@@ -167,7 +167,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("spellcharges_", 5)]
         public int?[] TriggeredSpellCharges;
 
-        [DBFieldName("spellppmRate_", TargetedDatabase.Zero, TargetedDatabase.Cataclysm, 5)]
+        [DBFieldName("spellppmRate_", TargetedDatabaseFlag.TillWrathOfTheLichKing, 5)]
         public float? TriggeredSpellPpmRate;
 
         [DBFieldName("spellcooldown_", 5)]
@@ -212,7 +212,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RandomSuffix")]
         public uint? RandomSuffix;
 
-        [DBFieldName("block", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("block", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? Block;
 
         [DBFieldName("itemset")]
@@ -245,7 +245,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("GemProperties")]
         public int? GemProperties;
 
-        [DBFieldName("RequiredDisenchantSkill", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("RequiredDisenchantSkill", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public int? RequiredDisenchantSkill;
 
         [DBFieldName("ArmorDamageModifier")]
@@ -260,28 +260,28 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("HolidayId")]
         public Holiday? HolidayID;
 
-        [DBFieldName("ScriptName", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("ScriptName", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public string ScriptName;
 
-        [DBFieldName("DisenchantID", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("DisenchantID", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? DisenchantID;
 
-        [DBFieldName("FoodType", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("FoodType", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? FoodType;
 
-        [DBFieldName("minMoneyLoot", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("minMoneyLoot", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint MinMoneyLoot;
 
-        [DBFieldName("maxMoneyLoot", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("maxMoneyLoot", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint MaxMoneyLoot;
 
-        [DBFieldName("StatScalingFactor", TargetedDatabase.Cataclysm)]
+        [DBFieldName("StatScalingFactor", TargetedDatabaseFlag.SinceCataclysm)]
         public float? StatScalingFactor;
 
-        [DBFieldName("CurrencySubstitutionId", TargetedDatabase.Cataclysm)]
+        [DBFieldName("CurrencySubstitutionId", TargetedDatabaseFlag.SinceCataclysm)]
         public uint? CurrencySubstitutionID;
 
-        [DBFieldName("CurrencySubstitutionCount", TargetedDatabase.Cataclysm)]
+        [DBFieldName("CurrencySubstitutionCount", TargetedDatabaseFlag.SinceCataclysm)]
         public uint? CurrencySubstitutionCount;
 
         [DBFieldName("flagsCustom")]

--- a/WowPacketParser/Store/Objects/ModelData.cs
+++ b/WowPacketParser/Store/Objects/ModelData.cs
@@ -16,13 +16,13 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("CombatReach")]
         public float? CombatReach;
 
-        [DBFieldName("Gender", TargetedDatabase.Classic, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("Gender", TargetedDatabaseFlag.TillCataclysm | TargetedDatabaseFlag.AnyClassic)]
         public Gender? Gender;
 
         [DBFieldName("DisplayID_Other_Gender")]
         public uint? DisplayIDOtherGender = 0;
 
-        [DBFieldName("VerifiedBuild", TargetedDatabase.Legion)]
+        [DBFieldName("VerifiedBuild", TargetedDatabaseFlag.SinceLegion)]
         public int? VerifiedBuild = ClientVersion.BuildInt;
     }
 }

--- a/WowPacketParser/Store/Objects/NpcVendor.cs
+++ b/WowPacketParser/Store/Objects/NpcVendor.cs
@@ -25,10 +25,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("type", true)]
         public uint? Type;
 
-        [DBFieldName("PlayerConditionID", TargetedDatabase.Cataclysm)]
+        [DBFieldName("PlayerConditionID", TargetedDatabaseFlag.SinceCataclysm)]
         public uint? PlayerConditionID;
 
-        [DBFieldName("IgnoreFiltering", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("IgnoreFiltering", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public bool? IgnoreFiltering;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/PageText.cs
+++ b/WowPacketParser/Store/Objects/PageText.cs
@@ -16,10 +16,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("NextPageID")]
         public uint? NextPageID;
 
-        [DBFieldName("PlayerConditionID", TargetedDatabase.Legion)]
+        [DBFieldName("PlayerConditionID", TargetedDatabaseFlag.SinceLegion)]
         public int? PlayerConditionID;
 
-        [DBFieldName("Flags", TargetedDatabase.Legion)]
+        [DBFieldName("Flags", TargetedDatabaseFlag.SinceLegion)]
         public byte? Flags;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/PlayerChoice.cs
+++ b/WowPacketParser/Store/Objects/PlayerChoice.cs
@@ -10,28 +10,28 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("ChoiceId", true)]
         public int? ChoiceId;
 
-        [DBFieldName("UiTextureKitId", TargetedDatabase.Legion)]
+        [DBFieldName("UiTextureKitId", TargetedDatabaseFlag.SinceLegion)]
         public int? UiTextureKitId;
 
-        [DBFieldName("SoundKitId", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("SoundKitId", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public uint? SoundKitId;
 
-        [DBFieldName("CloseSoundKitId", TargetedDatabase.Shadowlands)]
+        [DBFieldName("CloseSoundKitId", TargetedDatabaseFlag.SinceShadowlands)]
         public uint? CloseSoundKitId;
 
-        [DBFieldName("Duration", TargetedDatabase.Shadowlands)]
+        [DBFieldName("Duration", TargetedDatabaseFlag.SinceShadowlands)]
         public long? Duration;
 
         [DBFieldName("Question")]
         public string Question;
 
-        [DBFieldName("PendingChoiceText", TargetedDatabase.Shadowlands)]
+        [DBFieldName("PendingChoiceText", TargetedDatabaseFlag.SinceShadowlands)]
         public string PendingChoiceText;
 
-        [DBFieldName("HideWarboardHeader", TargetedDatabase.Legion)]
+        [DBFieldName("HideWarboardHeader", TargetedDatabaseFlag.SinceLegion)]
         public int HideWarboardHeader;
 
-        [DBFieldName("KeepOpenAfterChoice", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("KeepOpenAfterChoice", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public int KeepOpenAfterChoice;
 
         [DBFieldName("VerifiedBuild")]
@@ -47,7 +47,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("ResponseId", true)]
         public int? ResponseId;
 
-        [DBFieldName("ResponseIdentifier", TargetedDatabase.Shadowlands)]
+        [DBFieldName("ResponseIdentifier", TargetedDatabaseFlag.SinceShadowlands)]
         public short? ResponseIdentifier;
 
         [DBFieldName("Index", true)]
@@ -56,28 +56,28 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("ChoiceArtFileId")]
         public int? ChoiceArtFileId;
 
-        [DBFieldName("Flags", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("Flags", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public int? Flags;
 
-        [DBFieldName("WidgetSetId", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("WidgetSetId", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public uint? WidgetSetId;
 
-        [DBFieldName("UiTextureAtlasElementID", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("UiTextureAtlasElementID", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public uint? UiTextureAtlasElementID;
 
-        [DBFieldName("SoundKitId", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("SoundKitId", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public uint? SoundKitId;
 
-        [DBFieldName("GroupId", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("GroupId", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public int? GroupId;
 
-        [DBFieldName("Header", TargetedDatabase.Legion)]
+        [DBFieldName("Header", TargetedDatabaseFlag.SinceLegion)]
         public string Header;
 
-        [DBFieldName("Subheader", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("Subheader", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public string Subheader;
 
-        [DBFieldName("ButtonTooltip", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("ButtonTooltip", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public string ButtonTooltip;
 
         [DBFieldName("Answer")]
@@ -86,13 +86,13 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Description")]
         public string Description;
 
-        [DBFieldName("Confirmation", TargetedDatabase.Legion)]
+        [DBFieldName("Confirmation", TargetedDatabaseFlag.SinceLegion)]
         public string Confirmation;
 
-        [DBFieldName("RewardQuestID", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("RewardQuestID", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public uint? RewardQuestID;
 
-        [DBFieldName("UiTextureKitID", TargetedDatabase.Shadowlands)]
+        [DBFieldName("UiTextureKitID", TargetedDatabaseFlag.SinceShadowlands)]
         public uint? UiTextureKitID;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/PlayerChoiceLocale.cs
+++ b/WowPacketParser/Store/Objects/PlayerChoiceLocale.cs
@@ -32,13 +32,13 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Locale")]
         public string Locale;
 
-        [DBFieldName("Header", TargetedDatabase.Legion)]
+        [DBFieldName("Header", TargetedDatabaseFlag.SinceLegion)]
         public string Header;
 
-        [DBFieldName("Subheader", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("Subheader", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public string Subheader;
 
-        [DBFieldName("ButtonTooltip", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("ButtonTooltip", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public string ButtonTooltip;
 
         [DBFieldName("Answer")]
@@ -47,7 +47,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Description")]
         public string Description;
 
-        [DBFieldName("Confirmation", TargetedDatabase.Legion)]
+        [DBFieldName("Confirmation", TargetedDatabaseFlag.SinceLegion)]
         public string Confirmation;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/PlayerCreateInfo.cs
+++ b/WowPacketParser/Store/Objects/PlayerCreateInfo.cs
@@ -16,7 +16,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("map")]
         public uint? Map;
 
-        [DBFieldName("zone", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
+        [DBFieldName("zone", TargetedDatabaseFlag.TillBattleForAzeroth)]
         public uint? Zone;
 
         [DBFieldName("position_x")]

--- a/WowPacketParser/Store/Objects/PointsOfInterest.cs
+++ b/WowPacketParser/Store/Objects/PointsOfInterest.cs
@@ -16,7 +16,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("PositionY")]
         public float? PositionY;
 
-        [DBFieldName("PositionZ", TargetedDatabase.Shadowlands)]
+        [DBFieldName("PositionZ", TargetedDatabaseFlag.SinceShadowlands)]
         public float? PositionZ;
 
         [DBFieldName("Icon")]
@@ -31,7 +31,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Name")]
         public string Name;
 
-        [DBFieldName("WMOGroupID", TargetedDatabase.Shadowlands)]
+        [DBFieldName("WMOGroupID", TargetedDatabaseFlag.SinceShadowlands)]
         public int? WMOGroupID;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/QuestObjective.cs
+++ b/WowPacketParser/Store/Objects/QuestObjective.cs
@@ -16,7 +16,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Type")]
         public QuestRequirementType? Type;
 
-        [DBFieldName("Order", TargetedDatabase.Legion)]
+        [DBFieldName("Order", TargetedDatabaseFlag.SinceLegion)]
         public uint? Order;
 
         [DBFieldName("StorageIndex")]
@@ -31,7 +31,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Flags")]
         public uint? Flags;
 
-        [DBFieldName("Flags2", TargetedDatabase.Legion)] // 7.1.0
+        [DBFieldName("Flags2", TargetedDatabaseFlag.SinceLegion)] // 7.1.0
         public uint? Flags2;
 
         [DBFieldName("ProgressBarWeight")]

--- a/WowPacketParser/Store/Objects/QuestObjective.cs
+++ b/WowPacketParser/Store/Objects/QuestObjective.cs
@@ -16,7 +16,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Type")]
         public QuestRequirementType? Type;
 
-        [DBFieldName("Order", TargetedDatabaseFlag.SinceLegion)]
+        [DBFieldName("Order", TargetedDatabaseFlag.SinceLegion | TargetedDatabaseFlag.AnyClassic)]
         public uint? Order;
 
         [DBFieldName("StorageIndex")]
@@ -31,7 +31,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Flags")]
         public uint? Flags;
 
-        [DBFieldName("Flags2", TargetedDatabaseFlag.SinceLegion)] // 7.1.0
+        [DBFieldName("Flags2", TargetedDatabaseFlag.SinceLegion | TargetedDatabaseFlag.AnyClassic)] // 7.1.0
         public uint? Flags2;
 
         [DBFieldName("ProgressBarWeight")]

--- a/WowPacketParser/Store/Objects/QuestPOI.cs
+++ b/WowPacketParser/Store/Objects/QuestPOI.cs
@@ -10,32 +10,32 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("QuestID", true)]
         public int? QuestID;
 
-        [DBFieldName("BlobIndex", TargetedDatabase.WarlordsOfDraenor, true)]
+        [DBFieldName("BlobIndex", TargetedDatabaseFlag.SinceWarlordsOfDraenor, true)]
         public int? BlobIndex;
 
-        [DBFieldName("id", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor, true)]
-        [DBFieldName("Idx1", TargetedDatabase.WarlordsOfDraenor, true)]
+        [DBFieldName("id", TargetedDatabaseFlag.TillCataclysm, true)]
+        [DBFieldName("Idx1", TargetedDatabaseFlag.SinceWarlordsOfDraenor, true)]
         public int? ID;
 
         [DBFieldName("ObjectiveIndex")]
         public int? ObjectiveIndex;
 
-        [DBFieldName("QuestObjectiveID", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("QuestObjectiveID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public int? QuestObjectiveID;
 
-        [DBFieldName("QuestObjectID", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("QuestObjectID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public int? QuestObjectID;
 
         [DBFieldName("MapID")]
         public int? MapID;
 
-        [DBFieldName("UiMapID", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("UiMapID", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public int? UiMapID;
 
-        [DBFieldName("WorldMapAreaId", TargetedDatabase.Zero, TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("WorldMapAreaId", TargetedDatabaseFlag.TillLegion)]
         public int? WorldMapAreaId;
 
-        [DBFieldName("Floor", TargetedDatabase.Zero, TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("Floor", TargetedDatabaseFlag.TillLegion)]
         public int? Floor;
 
         [DBFieldName("Priority")]
@@ -44,19 +44,19 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Flags")]
         public int? Flags;
 
-        [DBFieldName("WorldEffectID", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("WorldEffectID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public int? WorldEffectID;
 
-        [DBFieldName("PlayerConditionID", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("PlayerConditionID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public int? PlayerConditionID;
 
-        [DBFieldName("NavigationPlayerConditionID", TargetedDatabase.Shadowlands)]
+        [DBFieldName("NavigationPlayerConditionID", TargetedDatabaseFlag.SinceShadowlands)]
         public int? NavigationPlayerConditionID;
 
-        [DBFieldName("SpawnTrackingID", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("SpawnTrackingID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public int? SpawnTrackingID;
 
-        [DBFieldName("AlwaysAllowMergingBlobs", TargetedDatabase.Legion)]
+        [DBFieldName("AlwaysAllowMergingBlobs", TargetedDatabaseFlag.SinceLegion)]
         public bool? AlwaysAllowMergingBlobs;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/QuestPOIPoint.cs
+++ b/WowPacketParser/Store/Objects/QuestPOIPoint.cs
@@ -22,7 +22,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("Y")]
         public int? Y;
 
-        [DBFieldName("Z", TargetedDatabase.Shadowlands)]
+        [DBFieldName("Z", TargetedDatabaseFlag.SinceShadowlands)]
         public int? Z;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/QuestRequestItems.cs
+++ b/WowPacketParser/Store/Objects/QuestRequestItems.cs
@@ -15,10 +15,10 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("EmoteOnIncomplete")]
         public uint? EmoteOnIncomplete;
 
-        [DBFieldName("EmoteOnCompleteDelay", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("EmoteOnCompleteDelay", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? EmoteOnCompleteDelay;
 
-        [DBFieldName("EmoteOnIncompleteDelay", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("EmoteOnIncompleteDelay", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? EmoteOnIncompleteDelay;
 
         [DBFieldName("CompletionText")]

--- a/WowPacketParser/Store/Objects/QuestTemplate.cs
+++ b/WowPacketParser/Store/Objects/QuestTemplate.cs
@@ -13,25 +13,25 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("QuestType")]
         public QuestType? QuestType;
 
-        [DBFieldName("QuestLevel", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
+        [DBFieldName("QuestLevel", TargetedDatabaseFlag.TillBattleForAzeroth)]
         public int? QuestLevel;
 
-        [DBFieldName("ScalingFactionGroup", TargetedDatabase.BattleForAzeroth, TargetedDatabase.Shadowlands)]
+        [DBFieldName("ScalingFactionGroup", TargetedDatabaseFlag.BattleForAzeroth)]
         public int? QuestScalingFactionGroup;
 
-        [DBFieldName("MaxScalingLevel", TargetedDatabase.Legion, TargetedDatabase.Shadowlands)]
+        [DBFieldName("MaxScalingLevel", TargetedDatabaseFlag.Legion | TargetedDatabaseFlag.BattleForAzeroth)]
         public int? QuestMaxScalingLevel;
 
-        [DBFieldName("QuestPackageID", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("QuestPackageID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? QuestPackageID;
 
-        [DBFieldName("ContentTuningID", TargetedDatabase.Shadowlands)]
+        [DBFieldName("ContentTuningID", TargetedDatabaseFlag.SinceShadowlands)]
         public int? ContentTuningID;
 
-        [DBFieldName("MinLevel", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
+        [DBFieldName("MinLevel", TargetedDatabaseFlag.TillBattleForAzeroth)]
         public int? MinLevel;
 
-        [DBFieldName("MaxLevel", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("MaxLevel", TargetedDatabaseFlag.Cataclysm)]
         public uint? MaxLevel;
 
         [DBFieldName("QuestSortID")]
@@ -43,19 +43,19 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("SuggestedGroupNum")]
         public uint? SuggestedGroupNum;
 
-        [DBFieldName("RequiredClasses", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RequiredClasses", TargetedDatabaseFlag.Cataclysm)]
         public uint? RequiredClasses;
 
-        [DBFieldName("RequiredSkillId", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RequiredSkillId", TargetedDatabaseFlag.Cataclysm)]
         public uint? RequriedSkillID;
 
-        [DBFieldName("RequiredSkillPoints", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RequiredSkillPoints", TargetedDatabaseFlag.Cataclysm)]
         public uint? RequiredSkillPoints;
 
-        [DBFieldName("RequiredFactionId", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor, 2)]
+        [DBFieldName("RequiredFactionId", TargetedDatabaseFlag.TillCataclysm, 2)]
         public uint?[] RequiredFactionID;
 
-        [DBFieldName("RequiredFactionValue",TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor, 2)]
+        [DBFieldName("RequiredFactionValue", TargetedDatabaseFlag.TillCataclysm, 2)]
         public int?[] RequiredFactionValue;
 
         [DBFieldName("RewardNextQuest")]
@@ -64,58 +64,58 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RewardXPDifficulty")]
         public uint? RewardXPDifficulty;
 
-        [DBFieldName("RewardXPMultiplier", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardXPMultiplier", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public float? RewardXPMultiplier;
 
-        [DBFieldName("RewardMoney", TargetedDatabase.Zero, TargetedDatabase.Shadowlands)]
+        [DBFieldName("RewardMoney", TargetedDatabaseFlag.TillBattleForAzeroth)]
         public int? RewardMoney;
 
-        [DBFieldName("RewardMoneyDifficulty", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardMoneyDifficulty", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? RewardMoneyDifficulty;
 
-        [DBFieldName("RewardMoneyMultiplier", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardMoneyMultiplier", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public float? RewardMoneyMultiplier;
 
         [DBFieldName("RewardBonusMoney")]
         public uint? RewardBonusMoney;
 
-        [DBFieldName("RewardDisplaySpell", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardDisplaySpell", TargetedDatabaseFlag.TillCataclysm)]
         public uint? RewardDisplaySpell;
 
-        [DBFieldName("RewardDisplaySpell", TargetedDatabase.Legion, TargetedDatabase.Shadowlands, 3)]
+        [DBFieldName("RewardDisplaySpell", TargetedDatabaseFlag.Legion | TargetedDatabaseFlag.BattleForAzeroth, 3)]
         public uint?[] RewardDisplaySpellLegion;
 
-        [DBFieldName("RewardSpell", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("RewardSpell", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public int? RewardSpell;
 
-        [DBFieldName("RewardSpell", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardSpell", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? RewardSpellWod;
 
-        [DBFieldName("RequiredMinRepFaction", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RequiredMinRepFaction", TargetedDatabaseFlag.Cataclysm)]
         public uint? RequiredMinRepFaction;
 
-        [DBFieldName("RequiredMaxRepFaction", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RequiredMaxRepFaction", TargetedDatabaseFlag.Cataclysm)]
         public uint? RequiredMaxRepFaction;
 
-        [DBFieldName("RequiredMinRepValue", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RequiredMinRepValue", TargetedDatabaseFlag.Cataclysm)]
         public int? RequiredMinRepValue;
 
-        [DBFieldName("RequiredMaxRepValue", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RequiredMaxRepValue", TargetedDatabaseFlag.Cataclysm)]
         public int? RequiredMaxRepValue;
 
-        [DBFieldName("PrevQuestId", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("PrevQuestId", TargetedDatabaseFlag.Cataclysm)]
         public int? PrevQuestID;
 
-        [DBFieldName("NextQuestId", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("NextQuestId", TargetedDatabaseFlag.Cataclysm)]
         public int? NextQuestID;
 
-        [DBFieldName("ExclusiveGroup", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("ExclusiveGroup", TargetedDatabaseFlag.Cataclysm)]
         public int? ExclusiveGroup;
 
-        [DBFieldName("RewardHonor", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardHonor", TargetedDatabaseFlag.TillCataclysm)]
         public int? RewardHonor;
 
-        [DBFieldName("RewardHonor", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardHonor", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? RewardHonorWod;
 
         [DBFieldName("RewardKillHonor")]
@@ -124,66 +124,66 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("StartItem")]
         public uint? StartItem;
 
-        [DBFieldName("RewardArtifactXPDifficulty", TargetedDatabase.Legion)]
+        [DBFieldName("RewardArtifactXPDifficulty", TargetedDatabaseFlag.SinceLegion)]
         public uint? RewardArtifactXPDifficulty;
 
-        [DBFieldName("RewardArtifactXPMultiplier", TargetedDatabase.Legion)]
+        [DBFieldName("RewardArtifactXPMultiplier", TargetedDatabaseFlag.SinceLegion)]
         public float? RewardArtifactXPMultiplier;
 
-        [DBFieldName("RewardArtifactCategoryID", TargetedDatabase.Legion)]
+        [DBFieldName("RewardArtifactCategoryID", TargetedDatabaseFlag.SinceLegion)]
         public uint? RewardArtifactCategoryID;
 
-        [DBFieldName("RewardMailTemplateId", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardMailTemplateId", TargetedDatabaseFlag.Cataclysm)]
         public uint? RewardMailTemplateID;
 
-        [DBFieldName("RewardMailDelay", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardMailDelay", TargetedDatabaseFlag.Cataclysm)]
         public int? RewardMailDelay;
 
-        [DBFieldName("SourceItemCount", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("SourceItemCount", TargetedDatabaseFlag.Cataclysm)]
         public uint? SourceItemCount;
 
-        [DBFieldName("SourceSpellId", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("SourceSpellId", TargetedDatabaseFlag.Cataclysm)]
         public uint? SourceSpellID;
 
         [DBFieldName("Flags")]
         public QuestFlags? Flags;
 
-        [DBFieldName("SpecialFlags", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("FlagsEx", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("SpecialFlags", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("FlagsEx", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public QuestFlagsEx? FlagsEx;
 
-        [DBFieldName("FlagsEx2", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("FlagsEx2", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public QuestFlagsEx2? FlagsEx2;
 
-        [DBFieldName("MinimapTargetMark", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("MinimapTargetMark", TargetedDatabaseFlag.Cataclysm)]
         public uint? MinimapTargetMark;
 
-        [DBFieldName("RequiredPlayerKills", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RequiredPlayerKills", TargetedDatabaseFlag.TillCataclysm)]
         public uint? RequiredPlayerKills;
 
-        [DBFieldName("RewardSkillId", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("RewardSkillLineID", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardSkillId", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("RewardSkillLineID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? RewardSkillLineID;
 
-        [DBFieldName("RewardSkillPoints", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("RewardNumSkillUps", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardSkillPoints", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("RewardNumSkillUps", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? RewardNumSkillUps;
 
-        [DBFieldName("RewardReputationMask", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardReputationMask", TargetedDatabaseFlag.Cataclysm)]
         public uint? RewardReputationMask;
 
-        [DBFieldName("QuestGiverPortrait", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("PortraitGiver", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("QuestGiverPortrait", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("PortraitGiver", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? QuestGiverPortrait;
 
-        [DBFieldName("PortraitGiverMount", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("PortraitGiverMount", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public uint? PortraitGiverMount;
 
-        [DBFieldName("PortraitGiverModelSceneID", TargetedDatabase.Shadowlands)]
+        [DBFieldName("PortraitGiverModelSceneID", TargetedDatabaseFlag.SinceShadowlands)]
         public int? PortraitGiverModelSceneID;
 
-        [DBFieldName("QuestTurnInPortrait", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("PortraitTurnIn", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("QuestTurnInPortrait", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("PortraitTurnIn", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? QuestTurnInPortrait;
 
         [DBFieldName("RewardItem", 4)]
@@ -204,7 +204,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RewardChoiceItemQuantity", 6)]
         public uint?[] RewardChoiceItemQuantity;
 
-        [DBFieldName("RewardChoiceItemDisplayID", TargetedDatabase.WarlordsOfDraenor, 6)]
+        [DBFieldName("RewardChoiceItemDisplayID", TargetedDatabaseFlag.SinceWarlordsOfDraenor, 6)]
         public uint?[] RewardChoiceItemDisplayID;
 
         [DBFieldName("POIContinent")]
@@ -216,16 +216,16 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("POIy")]
         public float? POIy;
 
-        [DBFieldName("POIPriority", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("POIPriority", TargetedDatabaseFlag.TillCataclysm)]
         public uint? POIPriority;
 
-        [DBFieldName("POIPriority", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("POIPriority", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public int? POIPriorityWod;
 
         [DBFieldName("RewardTitle")]
         public uint? RewardTitle;
 
-        [DBFieldName("RewardTalents", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardTalents", TargetedDatabaseFlag.TillCataclysm)]
         public uint? RewardTalents;
 
         [DBFieldName("RewardArenaPoints")]
@@ -237,38 +237,38 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RewardFactionValue", 5)]
         public int?[] RewardFactionValue;
 
-        [DBFieldName("RewardFactionCapIn", TargetedDatabase.Legion, 5)]
+        [DBFieldName("RewardFactionCapIn", TargetedDatabaseFlag.SinceLegion, 5)]
         public int?[] RewardFactionCapIn;
 
         [DBFieldName("RewardFactionOverride", 5)]
         public int?[] RewardFactionOverride;
 
-        [DBFieldName("RewardFactionFlags", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RewardFactionFlags", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? RewardFactionFlags;
 
-        [DBFieldName("AreaGroupID", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("AreaGroupID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? AreaGroupID;
 
         [DBFieldName("TimeAllowed")]
         public uint? TimeAllowed;
 
-        [DBFieldName("AllowableRaces", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("AllowableRaces", TargetedDatabaseFlag.TillCataclysm)]
         public RaceMask? AllowableRaces;
 
-        [DBFieldName("AllowableRaces", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("AllowableRaces", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public ulong? AllowableRacesWod;
 
-        [DBFieldName("QuestRewardID", TargetedDatabase.Legion, TargetedDatabase.BattleForAzeroth)]
-        [DBFieldName("TreasurePickerID", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("QuestRewardID", TargetedDatabaseFlag.Legion)]
+        [DBFieldName("TreasurePickerID", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public int? QuestRewardID;
 
-        [DBFieldName("Expansion", TargetedDatabase.Legion)]
+        [DBFieldName("Expansion", TargetedDatabaseFlag.SinceLegion)]
         public int? Expansion;
 
-        [DBFieldName("ManagedWorldStateID", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("ManagedWorldStateID", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public int? ManagedWorldStateID;
 
-        [DBFieldName("QuestSessionBonus", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("QuestSessionBonus", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public int? QuestSessionBonus;
 
         [DBFieldName("LogTitle", LocaleConstant.enUS)]
@@ -286,63 +286,63 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("QuestCompletionLog", LocaleConstant.enUS)]
         public string QuestCompletionLog;
 
-        [DBFieldName("RequiredNpcOrGo", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor, 4)]
+        [DBFieldName("RequiredNpcOrGo", TargetedDatabaseFlag.TillCataclysm, 4)]
         public int?[] RequiredNpcOrGo;
 
-        [DBFieldName("RequiredNpcOrGoCount", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor, 4)]
+        [DBFieldName("RequiredNpcOrGoCount", TargetedDatabaseFlag.TillCataclysm, 4)]
         public uint?[] RequiredNpcOrGoCount;
 
-        [DBFieldName("RequiredItemId", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor, 6)]
+        [DBFieldName("RequiredItemId", TargetedDatabaseFlag.TillCataclysm, 6)]
         public uint?[] RequiredItemID;
 
-        [DBFieldName("RequiredItemCount", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor, 6)]
+        [DBFieldName("RequiredItemCount", TargetedDatabaseFlag.TillCataclysm, 6)]
         public uint?[] RequiredItemCount;
 
-        [DBFieldName("Unknown0", TargetedDatabase.Zero, TargetedDatabase.Cataclysm)]
+        [DBFieldName("Unknown0", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public uint? Unk0;
 
-        [DBFieldName("RequiredSpell", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("RequiredSpell", TargetedDatabaseFlag.Cataclysm)]
         public uint? RequiredSpell;
 
-        [DBFieldName("ObjectiveText", TargetedDatabase.Zero, TargetedDatabase.WarlordsOfDraenor, 4)]
+        [DBFieldName("ObjectiveText", TargetedDatabaseFlag.TillCataclysm, 4)]
         public string[] ObjectiveText;
 
-        [DBFieldName("RewardCurrencyId", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor, 4)]
-        [DBFieldName("RewardCurrencyID", TargetedDatabase.WarlordsOfDraenor, 4)]
+        [DBFieldName("RewardCurrencyId", TargetedDatabaseFlag.Cataclysm, 4)]
+        [DBFieldName("RewardCurrencyID", TargetedDatabaseFlag.SinceWarlordsOfDraenor, 4)]
         public uint?[] RewardCurrencyID;
 
-        [DBFieldName("RewardCurrencyCount", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor, 4)]
-        [DBFieldName("RewardCurrencyQty", TargetedDatabase.WarlordsOfDraenor, 4)]
+        [DBFieldName("RewardCurrencyCount", TargetedDatabaseFlag.Cataclysm, 4)]
+        [DBFieldName("RewardCurrencyQty", TargetedDatabaseFlag.SinceWarlordsOfDraenor, 4)]
         public uint?[] RewardCurrencyCount;
 
-        [DBFieldName("RequiredCurrencyId", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor, 4)]
+        [DBFieldName("RequiredCurrencyId", TargetedDatabaseFlag.Cataclysm, 4)]
         public uint?[] RequiredCurrencyID;
 
-        [DBFieldName("RequiredCurrencyCount", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor, 4)]
+        [DBFieldName("RequiredCurrencyCount", TargetedDatabaseFlag.Cataclysm, 4)]
         public uint?[] RequiredCurrencyCount;
 
-        [DBFieldName("QuestGiverTextWindow", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("PortraitGiverText", TargetedDatabase.WarlordsOfDraenor, LocaleConstant.enUS)]
+        [DBFieldName("QuestGiverTextWindow", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("PortraitGiverText", TargetedDatabaseFlag.SinceWarlordsOfDraenor, LocaleConstant.enUS)]
         public string QuestGiverTextWindow;
 
-        [DBFieldName("QuestGiverTargetName", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("PortraitGiverName", TargetedDatabase.WarlordsOfDraenor, LocaleConstant.enUS)]
+        [DBFieldName("QuestGiverTargetName", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("PortraitGiverName", TargetedDatabaseFlag.SinceWarlordsOfDraenor, LocaleConstant.enUS)]
         public string QuestGiverTargetName;
 
-        [DBFieldName("QuestTurnTextWindow", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("PortraitTurnInText", TargetedDatabase.WarlordsOfDraenor, LocaleConstant.enUS)]
+        [DBFieldName("QuestTurnTextWindow", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("PortraitTurnInText", TargetedDatabaseFlag.SinceWarlordsOfDraenor, LocaleConstant.enUS)]
         public string QuestTurnTextWindow;
 
-        [DBFieldName("QuestTurnTargetName", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("PortraitTurnInName", TargetedDatabase.WarlordsOfDraenor, LocaleConstant.enUS)]
+        [DBFieldName("QuestTurnTargetName", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("PortraitTurnInName", TargetedDatabaseFlag.SinceWarlordsOfDraenor, LocaleConstant.enUS)]
         public string QuestTurnTargetName;
 
-        [DBFieldName("SoundAccept", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("AcceptedSoundKitID", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("SoundAccept", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("AcceptedSoundKitID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? SoundAccept;
 
-        [DBFieldName("SoundTurnIn", TargetedDatabase.Cataclysm, TargetedDatabase.WarlordsOfDraenor)]
-        [DBFieldName("CompleteSoundKitID", TargetedDatabase.WarlordsOfDraenor)]
+        [DBFieldName("SoundTurnIn", TargetedDatabaseFlag.Cataclysm)]
+        [DBFieldName("CompleteSoundKitID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
         public uint? SoundTurnIn;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/QuestTemplate.cs
+++ b/WowPacketParser/Store/Objects/QuestTemplate.cs
@@ -13,22 +13,22 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("QuestType")]
         public QuestType? QuestType;
 
-        [DBFieldName("QuestLevel", TargetedDatabaseFlag.TillBattleForAzeroth)]
+        [DBFieldName("QuestLevel", TargetedDatabaseFlag.TillBattleForAzeroth | TargetedDatabaseFlag.AnyClassic)]
         public int? QuestLevel;
 
-        [DBFieldName("ScalingFactionGroup", TargetedDatabaseFlag.BattleForAzeroth)]
+        [DBFieldName("ScalingFactionGroup", TargetedDatabaseFlag.BattleForAzeroth | TargetedDatabaseFlag.AnyClassic)]
         public int? QuestScalingFactionGroup;
 
-        [DBFieldName("MaxScalingLevel", TargetedDatabaseFlag.Legion | TargetedDatabaseFlag.BattleForAzeroth)]
+        [DBFieldName("MaxScalingLevel", TargetedDatabaseFlag.Legion | TargetedDatabaseFlag.BattleForAzeroth | TargetedDatabaseFlag.AnyClassic)]
         public int? QuestMaxScalingLevel;
 
-        [DBFieldName("QuestPackageID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("QuestPackageID", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? QuestPackageID;
 
         [DBFieldName("ContentTuningID", TargetedDatabaseFlag.SinceShadowlands)]
         public int? ContentTuningID;
 
-        [DBFieldName("MinLevel", TargetedDatabaseFlag.TillBattleForAzeroth)]
+        [DBFieldName("MinLevel", TargetedDatabaseFlag.TillBattleForAzeroth | TargetedDatabaseFlag.AnyClassic)]
         public int? MinLevel;
 
         [DBFieldName("MaxLevel", TargetedDatabaseFlag.Cataclysm)]
@@ -64,16 +64,16 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RewardXPDifficulty")]
         public uint? RewardXPDifficulty;
 
-        [DBFieldName("RewardXPMultiplier", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("RewardXPMultiplier", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public float? RewardXPMultiplier;
 
         [DBFieldName("RewardMoney", TargetedDatabaseFlag.TillBattleForAzeroth)]
         public int? RewardMoney;
 
-        [DBFieldName("RewardMoneyDifficulty", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("RewardMoneyDifficulty", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? RewardMoneyDifficulty;
 
-        [DBFieldName("RewardMoneyMultiplier", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("RewardMoneyMultiplier", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public float? RewardMoneyMultiplier;
 
         [DBFieldName("RewardBonusMoney")]
@@ -82,13 +82,13 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RewardDisplaySpell", TargetedDatabaseFlag.TillCataclysm)]
         public uint? RewardDisplaySpell;
 
-        [DBFieldName("RewardDisplaySpell", TargetedDatabaseFlag.Legion | TargetedDatabaseFlag.BattleForAzeroth, 3)]
+        [DBFieldName("RewardDisplaySpell", TargetedDatabaseFlag.Legion | TargetedDatabaseFlag.BattleForAzeroth | TargetedDatabaseFlag.AnyClassic, 3)]
         public uint?[] RewardDisplaySpellLegion;
 
         [DBFieldName("RewardSpell", TargetedDatabaseFlag.TillWrathOfTheLichKing)]
         public int? RewardSpell;
 
-        [DBFieldName("RewardSpell", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("RewardSpell", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? RewardSpellWod;
 
         [DBFieldName("RequiredMinRepFaction", TargetedDatabaseFlag.Cataclysm)]
@@ -115,7 +115,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RewardHonor", TargetedDatabaseFlag.TillCataclysm)]
         public int? RewardHonor;
 
-        [DBFieldName("RewardHonor", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("RewardHonor", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? RewardHonorWod;
 
         [DBFieldName("RewardKillHonor")]
@@ -124,13 +124,13 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("StartItem")]
         public uint? StartItem;
 
-        [DBFieldName("RewardArtifactXPDifficulty", TargetedDatabaseFlag.SinceLegion)]
+        [DBFieldName("RewardArtifactXPDifficulty", TargetedDatabaseFlag.SinceLegion | TargetedDatabaseFlag.AnyClassic)]
         public uint? RewardArtifactXPDifficulty;
 
-        [DBFieldName("RewardArtifactXPMultiplier", TargetedDatabaseFlag.SinceLegion)]
+        [DBFieldName("RewardArtifactXPMultiplier", TargetedDatabaseFlag.SinceLegion | TargetedDatabaseFlag.AnyClassic)]
         public float? RewardArtifactXPMultiplier;
 
-        [DBFieldName("RewardArtifactCategoryID", TargetedDatabaseFlag.SinceLegion)]
+        [DBFieldName("RewardArtifactCategoryID", TargetedDatabaseFlag.SinceLegion | TargetedDatabaseFlag.AnyClassic)]
         public uint? RewardArtifactCategoryID;
 
         [DBFieldName("RewardMailTemplateId", TargetedDatabaseFlag.Cataclysm)]
@@ -149,10 +149,10 @@ namespace WowPacketParser.Store.Objects
         public QuestFlags? Flags;
 
         [DBFieldName("SpecialFlags", TargetedDatabaseFlag.Cataclysm)]
-        [DBFieldName("FlagsEx", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("FlagsEx", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public QuestFlagsEx? FlagsEx;
 
-        [DBFieldName("FlagsEx2", TargetedDatabaseFlag.SinceBattleForAzeroth)]
+        [DBFieldName("FlagsEx2", TargetedDatabaseFlag.SinceBattleForAzeroth | TargetedDatabaseFlag.AnyClassic)]
         public QuestFlagsEx2? FlagsEx2;
 
         [DBFieldName("MinimapTargetMark", TargetedDatabaseFlag.Cataclysm)]
@@ -162,28 +162,28 @@ namespace WowPacketParser.Store.Objects
         public uint? RequiredPlayerKills;
 
         [DBFieldName("RewardSkillId", TargetedDatabaseFlag.Cataclysm)]
-        [DBFieldName("RewardSkillLineID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("RewardSkillLineID", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? RewardSkillLineID;
 
         [DBFieldName("RewardSkillPoints", TargetedDatabaseFlag.Cataclysm)]
-        [DBFieldName("RewardNumSkillUps", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("RewardNumSkillUps", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? RewardNumSkillUps;
 
         [DBFieldName("RewardReputationMask", TargetedDatabaseFlag.Cataclysm)]
         public uint? RewardReputationMask;
 
         [DBFieldName("QuestGiverPortrait", TargetedDatabaseFlag.Cataclysm)]
-        [DBFieldName("PortraitGiver", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("PortraitGiver", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? QuestGiverPortrait;
 
-        [DBFieldName("PortraitGiverMount", TargetedDatabaseFlag.SinceBattleForAzeroth)]
+        [DBFieldName("PortraitGiverMount", TargetedDatabaseFlag.SinceBattleForAzeroth | TargetedDatabaseFlag.AnyClassic)]
         public uint? PortraitGiverMount;
 
-        [DBFieldName("PortraitGiverModelSceneID", TargetedDatabaseFlag.SinceShadowlands)]
+        [DBFieldName("PortraitGiverModelSceneID", TargetedDatabaseFlag.SinceShadowlands | TargetedDatabaseFlag.AnyClassic)]
         public int? PortraitGiverModelSceneID;
 
         [DBFieldName("QuestTurnInPortrait", TargetedDatabaseFlag.Cataclysm)]
-        [DBFieldName("PortraitTurnIn", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("PortraitTurnIn", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? QuestTurnInPortrait;
 
         [DBFieldName("RewardItem", 4)]
@@ -204,7 +204,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RewardChoiceItemQuantity", 6)]
         public uint?[] RewardChoiceItemQuantity;
 
-        [DBFieldName("RewardChoiceItemDisplayID", TargetedDatabaseFlag.SinceWarlordsOfDraenor, 6)]
+        [DBFieldName("RewardChoiceItemDisplayID", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic, 6)]
         public uint?[] RewardChoiceItemDisplayID;
 
         [DBFieldName("POIContinent")]
@@ -219,7 +219,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("POIPriority", TargetedDatabaseFlag.TillCataclysm)]
         public uint? POIPriority;
 
-        [DBFieldName("POIPriority", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("POIPriority", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public int? POIPriorityWod;
 
         [DBFieldName("RewardTitle")]
@@ -237,16 +237,16 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("RewardFactionValue", 5)]
         public int?[] RewardFactionValue;
 
-        [DBFieldName("RewardFactionCapIn", TargetedDatabaseFlag.SinceLegion, 5)]
+        [DBFieldName("RewardFactionCapIn", TargetedDatabaseFlag.SinceLegion | TargetedDatabaseFlag.AnyClassic, 5)]
         public int?[] RewardFactionCapIn;
 
         [DBFieldName("RewardFactionOverride", 5)]
         public int?[] RewardFactionOverride;
 
-        [DBFieldName("RewardFactionFlags", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("RewardFactionFlags", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? RewardFactionFlags;
 
-        [DBFieldName("AreaGroupID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("AreaGroupID", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? AreaGroupID;
 
         [DBFieldName("TimeAllowed")]
@@ -255,14 +255,14 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("AllowableRaces", TargetedDatabaseFlag.TillCataclysm)]
         public RaceMask? AllowableRaces;
 
-        [DBFieldName("AllowableRaces", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("AllowableRaces", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public ulong? AllowableRacesWod;
 
         [DBFieldName("QuestRewardID", TargetedDatabaseFlag.Legion)]
-        [DBFieldName("TreasurePickerID", TargetedDatabaseFlag.SinceBattleForAzeroth)]
+        [DBFieldName("TreasurePickerID", TargetedDatabaseFlag.SinceBattleForAzeroth | TargetedDatabaseFlag.AnyClassic)]
         public int? QuestRewardID;
 
-        [DBFieldName("Expansion", TargetedDatabaseFlag.SinceLegion)]
+        [DBFieldName("Expansion", TargetedDatabaseFlag.SinceLegion | TargetedDatabaseFlag.AnyClassic)]
         public int? Expansion;
 
         [DBFieldName("ManagedWorldStateID", TargetedDatabaseFlag.SinceBattleForAzeroth)]
@@ -308,11 +308,11 @@ namespace WowPacketParser.Store.Objects
         public string[] ObjectiveText;
 
         [DBFieldName("RewardCurrencyId", TargetedDatabaseFlag.Cataclysm, 4)]
-        [DBFieldName("RewardCurrencyID", TargetedDatabaseFlag.SinceWarlordsOfDraenor, 4)]
+        [DBFieldName("RewardCurrencyID", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic, 4)]
         public uint?[] RewardCurrencyID;
 
         [DBFieldName("RewardCurrencyCount", TargetedDatabaseFlag.Cataclysm, 4)]
-        [DBFieldName("RewardCurrencyQty", TargetedDatabaseFlag.SinceWarlordsOfDraenor, 4)]
+        [DBFieldName("RewardCurrencyQty", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic, 4)]
         public uint?[] RewardCurrencyCount;
 
         [DBFieldName("RequiredCurrencyId", TargetedDatabaseFlag.Cataclysm, 4)]
@@ -338,11 +338,11 @@ namespace WowPacketParser.Store.Objects
         public string QuestTurnTargetName;
 
         [DBFieldName("SoundAccept", TargetedDatabaseFlag.Cataclysm)]
-        [DBFieldName("AcceptedSoundKitID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("AcceptedSoundKitID", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? SoundAccept;
 
         [DBFieldName("SoundTurnIn", TargetedDatabaseFlag.Cataclysm)]
-        [DBFieldName("CompleteSoundKitID", TargetedDatabaseFlag.SinceWarlordsOfDraenor)]
+        [DBFieldName("CompleteSoundKitID", TargetedDatabaseFlag.SinceWarlordsOfDraenor | TargetedDatabaseFlag.AnyClassic)]
         public uint? SoundTurnIn;
 
         [DBFieldName("VerifiedBuild")]

--- a/WowPacketParser/Store/Objects/ScenarioPOI.cs
+++ b/WowPacketParser/Store/Objects/ScenarioPOI.cs
@@ -19,11 +19,11 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("MapID")]
         public int? MapID;
 
-        [DBFieldName("WorldMapAreaId", TargetedDatabase.Zero, TargetedDatabase.BattleForAzeroth)]
-        [DBFieldName("UiMapID", TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("WorldMapAreaId", TargetedDatabaseFlag.TillLegion)]
+        [DBFieldName("UiMapID", TargetedDatabaseFlag.SinceBattleForAzeroth)]
         public int? WorldMapAreaId;
 
-        [DBFieldName("Floor", TargetedDatabase.Zero, TargetedDatabase.BattleForAzeroth)]
+        [DBFieldName("Floor", TargetedDatabaseFlag.TillLegion)]
         public int? Floor;
 
         [DBFieldName("Priority")]

--- a/WowPacketParser/Store/Objects/SceneTemplate.cs
+++ b/WowPacketParser/Store/Objects/SceneTemplate.cs
@@ -15,7 +15,7 @@ namespace WowPacketParser.Store.Objects
         [DBFieldName("ScriptPackageID")]
         public uint? ScriptPackageID;
 
-        [DBFieldName("Encrypted", TargetedDatabase.Shadowlands)]
+        [DBFieldName("Encrypted", TargetedDatabaseFlag.SinceShadowlands)]
         public bool? Encrypted;
     }
 }

--- a/WowPacketParserModule.V3_4_0_45166/Parsers/QueryHandler.cs
+++ b/WowPacketParserModule.V3_4_0_45166/Parsers/QueryHandler.cs
@@ -1,0 +1,487 @@
+﻿using WowPacketParser.Enums;
+using WowPacketParser.Misc;
+using WowPacketParser.Parsing;
+using WowPacketParser.Proto;
+using WowPacketParser.Store;
+using WowPacketParser.Store.Objects;
+
+namespace WowPacketParserModule.V3_4_0_45166.Parsers
+{
+    public static class QueryHandler
+    {
+        [HasSniffData]
+        [Parser(Opcode.SMSG_QUERY_CREATURE_RESPONSE)]
+        public static void HandleCreatureQueryResponse(Packet packet)
+        {
+            PacketQueryCreatureResponse response = packet.Holder.QueryCreatureResponse = new PacketQueryCreatureResponse();
+            var entry = packet.ReadEntry("Entry");
+
+            CreatureTemplate creature = new CreatureTemplate
+            {
+                Entry = (uint)entry.Key
+            };
+            response.Entry = (uint)entry.Key;
+
+            Bit hasData = packet.ReadBit();
+            response.HasData = hasData;
+            if (!hasData)
+                return; // nothing to do
+
+            packet.ResetBitReader();
+            uint titleLen = packet.ReadBits(11);
+            uint titleAltLen = packet.ReadBits(11);
+            uint cursorNameLen = packet.ReadBits(6);
+            creature.Civilian = packet.ReadBit("Civilian");
+            creature.RacialLeader = response.Leader = packet.ReadBit("Leader");
+
+            var stringLens = new int[4][];
+            for (int i = 0; i < 4; i++)
+            {
+                stringLens[i] = new int[2];
+                stringLens[i][0] = (int)packet.ReadBits(11);
+                stringLens[i][1] = (int)packet.ReadBits(11);
+            }
+
+            for (var i = 0; i < 4; ++i)
+            {
+                if (stringLens[i][0] > 1)
+                {
+                    string name = packet.ReadDynamicString("Name", stringLens[i][0], i);
+                    if (i == 0)
+                        creature.Name = response.Name = name;
+                }
+                if (stringLens[i][1] > 1)
+                {
+                    string nameAlt = packet.ReadDynamicString("NameAlt", stringLens[i][1], i);
+                    if (i == 0)
+                        creature.FemaleName = response.NameAlt = nameAlt;
+                }
+            }
+
+            creature.TypeFlags = packet.ReadUInt32E<CreatureTypeFlag>("Type Flags");
+            response.TypeFlags = (uint?)creature.TypeFlags ?? 0;
+            creature.TypeFlags2 = response.TypeFlags2 = packet.ReadUInt32("Creature Type Flags 2");
+
+            creature.Type = packet.ReadInt32E<CreatureType>("CreatureType");
+            creature.Family = packet.ReadInt32E<CreatureFamily>("CreatureFamily");
+            creature.Rank = packet.ReadInt32E<CreatureRank>("Classification");
+            creature.PetSpellDataID = packet.ReadUInt32("PetSpellDataId");
+            response.Type = (int?)creature.Type ?? 0;
+            response.Family = (int?)creature.Family ?? 0;
+            response.Rank = (int?)creature.Rank ?? 0;
+
+            creature.KillCredits = new uint?[2];
+            for (int i = 0; i < 2; ++i)
+            {
+                creature.KillCredits[i] = (uint)packet.ReadInt32("ProxyCreatureID", i);
+                response.KillCredits.Add(creature.KillCredits[i] ?? 0);
+            }
+
+            var displayIdCount = packet.ReadUInt32("DisplayIdCount");
+            packet.ReadSingle("TotalProbability");
+
+            for (var i = 0; i < displayIdCount; ++i)
+            {
+                CreatureTemplateModel model = new CreatureTemplateModel
+                {
+                    CreatureID = (uint)entry.Key,
+                    Idx = (uint)i
+                };
+
+                model.CreatureDisplayID = (uint)packet.ReadInt32("CreatureDisplayID", i);
+                model.DisplayScale = packet.ReadSingle("DisplayScale", i);
+                model.Probability = packet.ReadSingle("Probability", i);
+
+                response.Models.Add(model.CreatureDisplayID ?? 0);
+                Storage.CreatureTemplateModels.Add(model, packet.TimeSpan);
+            }
+
+            creature.HealthModifier = response.HpMod = packet.ReadSingle("HpMulti");
+            creature.ManaModifier = response.ManaMod = packet.ReadSingle("EnergyMulti");
+            uint questItems = packet.ReadUInt32("QuestItems");
+            creature.MovementID = response.MovementId = (uint)packet.ReadInt32("CreatureMovementInfoID");
+            creature.HealthScalingExpansion = packet.ReadInt32E<ClientType>("HealthScalingExpansion");
+            response.HpScalingExp = (uint?)creature.HealthScalingExpansion ?? 0;
+            creature.RequiredExpansion = packet.ReadInt32E<ClientType>("RequiredExpansion");
+            response.Expansion = (uint?)creature.RequiredExpansion ?? 0;
+            creature.VignetteID = (uint)packet.ReadInt32("VignetteID");
+            creature.UnitClass = (uint)packet.ReadInt32E<Class>("UnitClass");
+            creature.CreatureDifficultyID = packet.ReadInt32("CreatureDifficultyID");
+            creature.WidgetSetID = packet.ReadInt32("WidgetSetID");
+            creature.WidgetSetUnitConditionID = packet.ReadInt32("WidgetSetUnitConditionID");
+
+            if (titleLen > 1)
+                creature.SubName = response.Title = packet.ReadCString("Title");
+
+            if (titleAltLen > 1)
+                creature.TitleAlt = response.TitleAlt = packet.ReadCString("TitleAlt");
+
+            if (cursorNameLen > 1)
+                creature.IconName = response.IconName = packet.ReadCString("CursorName");
+
+            for (uint i = 0; i < questItems; ++i)
+            {
+                CreatureTemplateQuestItem questItem = new CreatureTemplateQuestItem
+                {
+                    CreatureEntry = (uint)entry.Key,
+                    Idx = i,
+                    ItemId = (uint)packet.ReadInt32<ItemId>("QuestItem", i)
+                };
+
+                Storage.CreatureTemplateQuestItems.Add(questItem, packet.TimeSpan);
+                response.QuestItems.Add(questItem.ItemId ?? 0);
+            }
+
+            packet.AddSniffData(StoreNameType.Unit, entry.Key, "QUERY_RESPONSE");
+
+            if (ClientLocale.PacketLocale != LocaleConstant.enUS)
+            {
+                CreatureTemplateLocale localesCreature = new CreatureTemplateLocale
+                {
+                    ID = (uint)entry.Key,
+                    Name = creature.Name,
+                    NameAlt = creature.FemaleName,
+                    Title = creature.SubName,
+                    TitleAlt = creature.TitleAlt
+                };
+
+                Storage.LocalesCreatures.Add(localesCreature, packet.TimeSpan);
+            }
+            else
+                Storage.CreatureTemplates.Add(creature.Entry.Value, creature, packet.TimeSpan);
+
+            ObjectName objectName = new ObjectName
+            {
+                ObjectType = StoreNameType.Unit,
+                ID = entry.Key,
+                Name = creature.Name
+            };
+            Storage.ObjectNames.Add(objectName, packet.TimeSpan);
+        }
+
+        [Parser(Opcode.SMSG_QUERY_PET_NAME_RESPONSE)]
+        public static void HandlePetNameQueryResponse(Packet packet)
+        {
+            packet.ReadPackedGuid128("PetID");
+
+            var hasData = packet.ReadBit("HasData");
+            if (!hasData)
+                return;
+
+            var len = packet.ReadBits(8);
+            packet.ReadBit("HasDeclined");
+
+            const int maxDeclinedNameCases = 5;
+            var declinedNameLen = new int[maxDeclinedNameCases];
+            for (var i = 0; i < maxDeclinedNameCases; ++i)
+                declinedNameLen[i] = (int)packet.ReadBits(7);
+
+            for (var i = 0; i < maxDeclinedNameCases; ++i)
+                packet.ReadWoWString("DeclinedNames", declinedNameLen[i], i);
+
+            packet.ReadTime64("Timestamp");
+            packet.ReadWoWString("Petname", len);
+        }
+
+        [HasSniffData]
+        [Parser(Opcode.SMSG_QUERY_GAME_OBJECT_RESPONSE, ClientBranch.Classic, ClientVersionBuild.V1_14_0_39802, ClientVersionBuild.V1_14_1_40666)]
+        [Parser(Opcode.SMSG_QUERY_GAME_OBJECT_RESPONSE, ClientBranch.TBC, ClientVersionBuild.V2_5_1_38598, ClientVersionBuild.V2_5_3_41812)]
+        public static void HandleGameObjectQueryResponse(Packet packet)
+        {
+            WowPacketParserModule.V8_0_1_27101.Parsers.GameObjectHandler.HandleGameObjectQueryResponse(packet);
+        }
+
+        [HasSniffData]
+        [Parser(Opcode.SMSG_QUERY_GAME_OBJECT_RESPONSE, ClientBranch.Classic, ClientVersionBuild.V1_14_1_40666)]
+        [Parser(Opcode.SMSG_QUERY_GAME_OBJECT_RESPONSE, ClientBranch.TBC, ClientVersionBuild.V2_5_3_41812)]
+        [Parser(Opcode.SMSG_QUERY_GAME_OBJECT_RESPONSE, ClientBranch.WotLK, ClientVersionBuild.V3_4_0_45166)]
+        public static void HandleGameObjectQueryResponse1141(Packet packet)
+        {
+            var entry = packet.ReadEntry("Entry");
+            if (entry.Value) // entry is masked
+                return;
+
+            packet.ReadPackedGuid128("GUID");
+
+            GameObjectTemplate gameObject = new GameObjectTemplate
+            {
+                Entry = (uint)entry.Key
+            };
+
+            packet.ReadBit("Allow");
+
+            int dataSize = packet.ReadInt32("DataSize");
+            if (dataSize == 0)
+                return;
+
+            gameObject.Type = packet.ReadInt32E<GameObjectType>("Type");
+
+            gameObject.DisplayID = (uint)packet.ReadInt32("Display ID");
+
+            var name = new string[4];
+            for (int i = 0; i < 4; i++)
+                name[i] = packet.ReadCString("Name", i);
+            gameObject.Name = name[0];
+
+            gameObject.IconName = packet.ReadCString("Icon Name");
+            gameObject.CastCaption = packet.ReadCString("Cast Caption");
+            gameObject.UnkString = packet.ReadCString("Unk String");
+
+            gameObject.Data = new int?[35];
+            for (int i = 0; i < gameObject.Data.Length; i++)
+                gameObject.Data[i] = packet.ReadInt32("Data", i);
+
+            gameObject.Size = packet.ReadSingle("Size");
+
+            byte questItemsCount = packet.ReadByte("QuestItemsCount");
+            for (uint i = 0; i < questItemsCount; i++)
+            {
+                GameObjectTemplateQuestItem questItem = new GameObjectTemplateQuestItem
+                {
+                    GameObjectEntry = (uint)entry.Key,
+                    Idx = i,
+                    ItemId = (uint)packet.ReadInt32<ItemId>("QuestItem", i)
+                };
+
+                Storage.GameObjectTemplateQuestItems.Add(questItem, packet.TimeSpan);
+            }
+
+            gameObject.ContentTuningId = packet.ReadInt32("ContentTuningId");
+
+            packet.AddSniffData(StoreNameType.GameObject, entry.Key, "QUERY_RESPONSE");
+
+            Storage.GameObjectTemplates.Add(gameObject, packet.TimeSpan);
+
+            ObjectName objectName = new ObjectName
+            {
+                ObjectType = StoreNameType.GameObject,
+                ID = entry.Key,
+                Name = gameObject.Name
+            };
+
+            Storage.ObjectNames.Add(objectName, packet.TimeSpan);
+        }
+
+        [HasSniffData]
+        [Parser(Opcode.SMSG_QUERY_QUEST_INFO_RESPONSE)]
+        public static void HandleQuestQueryResponse(Packet packet)
+        {
+            packet.ReadInt32("Entry");
+
+            Bit hasData = packet.ReadBit("Has Data");
+            if (!hasData)
+                return; // nothing to do
+
+            var id = packet.ReadEntry("Quest ID");
+
+            QuestTemplate quest = new QuestTemplate
+            {
+                ID = (uint)id.Key
+            };
+
+            quest.QuestType = packet.ReadInt32E<QuestType>("QuestType");
+            quest.QuestLevel = packet.ReadInt32("QuestLevel");
+            quest.QuestScalingFactionGroup = packet.ReadInt32("QuestScalingFactionGroup");
+            quest.QuestMaxScalingLevel = packet.ReadInt32("QuestMaxScalingLevel");
+            quest.QuestPackageID = (uint)packet.ReadInt32("QuestPackageID");
+            quest.MinLevel = packet.ReadInt32("QuestMinLevel");
+            quest.QuestSortID = (QuestSort)packet.ReadInt32("QuestSortID");
+            quest.QuestInfoID = packet.ReadInt32E<QuestInfo>("QuestInfoID");
+            quest.SuggestedGroupNum = (uint)packet.ReadInt32("SuggestedGroupNum");
+            quest.RewardNextQuest = (uint)packet.ReadInt32("RewardNextQuest");
+            quest.RewardXPDifficulty = (uint)packet.ReadInt32("RewardXPDifficulty");
+
+            quest.RewardXPMultiplier = packet.ReadSingle("RewardXPMultiplier");
+
+            quest.RewardMoney = packet.ReadInt32("RewardMoney");
+            quest.RewardMoneyDifficulty = (uint)packet.ReadInt32("RewardMoneyDifficulty");
+
+            quest.RewardMoneyMultiplier = packet.ReadSingle("RewardMoneyMultiplier");
+
+            quest.RewardBonusMoney = (uint)packet.ReadInt32("RewardBonusMoney");
+
+            quest.RewardDisplaySpellLegion = new uint?[3];
+            for (int i = 0; i < 3; ++i)
+                quest.RewardDisplaySpellLegion[i] = (uint)packet.ReadInt32("RewardDisplaySpell", i);
+
+            quest.RewardSpellWod = (uint)packet.ReadInt32("RewardSpell");
+            quest.RewardHonorWod = (uint)packet.ReadInt32("RewardHonor");
+
+            quest.RewardKillHonor = packet.ReadSingle("RewardKillHonor");
+
+            quest.RewardArtifactXPDifficulty = (uint)packet.ReadInt32("RewardArtifactXPDifficulty");
+            quest.RewardArtifactXPMultiplier = packet.ReadSingle("RewardArtifactXPMultiplier");
+            quest.RewardArtifactCategoryID = (uint)packet.ReadInt32("RewardArtifactCategoryID");
+
+            quest.StartItem = (uint)packet.ReadInt32("StartItem");
+            quest.Flags = packet.ReadInt32E<QuestFlags>("Flags");
+            quest.FlagsEx = packet.ReadInt32E<QuestFlagsEx>("FlagsEx");
+            quest.FlagsEx2 = packet.ReadInt32E<QuestFlagsEx2>("FlagsEx2");
+
+            quest.RewardItem = new uint?[4];
+            quest.RewardAmount = new uint?[4];
+            quest.ItemDrop = new uint?[4];
+            quest.ItemDropQuantity = new uint?[4];
+            for (int i = 0; i < 4; ++i)
+            {
+                quest.RewardItem[i] = (uint)packet.ReadInt32("RewardItems", i);
+                quest.RewardAmount[i] = (uint)packet.ReadInt32("RewardAmount", i);
+                quest.ItemDrop[i] = (uint)packet.ReadInt32("ItemDrop", i);
+                quest.ItemDropQuantity[i] = (uint)packet.ReadInt32("ItemDropQuantity", i);
+            }
+
+            quest.RewardChoiceItemID = new uint?[6];
+            quest.RewardChoiceItemQuantity = new uint?[6];
+            quest.RewardChoiceItemDisplayID = new uint?[6];
+            for (int i = 0; i < 6; ++i) // CliQuestInfoChoiceItem
+            {
+                quest.RewardChoiceItemID[i] = (uint)packet.ReadInt32("RewardChoiceItemID", i);
+                quest.RewardChoiceItemQuantity[i] = (uint)packet.ReadInt32("RewardChoiceItemQuantity", i);
+                quest.RewardChoiceItemDisplayID[i] = (uint)packet.ReadInt32("RewardChoiceItemDisplayID", i);
+            }
+
+            quest.POIContinent = (uint)packet.ReadInt32("POIContinent");
+
+            quest.POIx = packet.ReadSingle("POIx");
+            quest.POIy = packet.ReadSingle("POIy");
+
+            quest.POIPriorityWod = packet.ReadInt32("POIPriority");
+            quest.RewardTitle = (uint)packet.ReadInt32("RewardTitle");
+            quest.RewardArenaPoints = (uint)packet.ReadInt32("RewardArenaPoints");
+            quest.RewardSkillLineID = (uint)packet.ReadInt32("RewardSkillLineID");
+            quest.RewardNumSkillUps = (uint)packet.ReadInt32("RewardNumSkillUps");
+            quest.QuestGiverPortrait = (uint)packet.ReadInt32("PortraitGiver");
+            quest.PortraitGiverMount = (uint)packet.ReadInt32("PortraitGiverMount");
+
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V2_5_2_39926))
+                packet.ReadInt32("PortraitGiverModelSceneID");
+
+            quest.QuestTurnInPortrait = (uint)packet.ReadInt32("PortraitTurnIn");
+
+            quest.RewardFactionID = new uint?[5];
+            quest.RewardFactionOverride = new int?[5];
+            quest.RewardFactionValue = new int?[5];
+            quest.RewardFactionCapIn = new int?[5];
+            for (int i = 0; i < 5; ++i)
+            {
+                quest.RewardFactionID[i] = (uint)packet.ReadInt32("RewardFactionID", i);
+                quest.RewardFactionValue[i] = packet.ReadInt32("RewardFactionValue", i);
+                quest.RewardFactionOverride[i] = packet.ReadInt32("RewardFactionOverride", i);
+                quest.RewardFactionCapIn[i] = packet.ReadInt32("RewardFactionCapIn", i);
+            }
+
+            quest.RewardFactionFlags = (uint)packet.ReadInt32("RewardFactionFlags");
+
+            quest.RewardCurrencyID = new uint?[4];
+            quest.RewardCurrencyCount = new uint?[4];
+            for (int i = 0; i < 4; ++i)
+            {
+                quest.RewardCurrencyID[i] = (uint)packet.ReadInt32("RewardCurrencyID", i);
+                quest.RewardCurrencyCount[i] = (uint)packet.ReadInt32("RewardCurrencyQty", i);
+            }
+
+            quest.SoundAccept = (uint)packet.ReadInt32("AcceptedSoundKitID");
+            quest.SoundTurnIn = (uint)packet.ReadInt32("CompleteSoundKitID");
+            quest.AreaGroupID = (uint)packet.ReadInt32("AreaGroupID");
+            quest.TimeAllowed = (uint)packet.ReadInt32("TimeAllowed");
+            uint objectiveCount = packet.ReadUInt32("ObjectiveCount");
+            quest.AllowableRacesWod = packet.ReadUInt64("AllowableRaces");
+            quest.QuestRewardID = packet.ReadInt32("TreasurePickerID");
+            quest.Expansion = packet.ReadInt32("Expansion");
+
+            packet.ResetBitReader();
+            uint logTitleLen = packet.ReadBits(9);
+            uint logDescriptionLen = packet.ReadBits(12);
+            uint questDescriptionLen = packet.ReadBits(12);
+            uint areaDescriptionLen = packet.ReadBits(9);
+            uint questGiverTextWindowLen = packet.ReadBits(10);
+            uint questGiverTargetNameLen = packet.ReadBits(8);
+            uint questTurnTextWindowLen = packet.ReadBits(10);
+            uint questTurnTargetNameLen = packet.ReadBits(8);
+            uint questCompletionLogLen = packet.ReadBits(11);
+
+            for (uint i = 0; i < objectiveCount; ++i)
+            {
+                var objectiveId = packet.ReadEntry("Id", i);
+
+                QuestObjective questInfoObjective = new QuestObjective
+                {
+                    ID = (uint)objectiveId.Key,
+                    QuestID = (uint)id.Key
+                };
+                questInfoObjective.Type = packet.ReadByteE<QuestRequirementType>("Quest Requirement Type", i);
+                questInfoObjective.StorageIndex = packet.ReadSByte("StorageIndex", i);
+                questInfoObjective.Order = i;
+                questInfoObjective.ObjectID = packet.ReadInt32("ObjectID", i);
+                questInfoObjective.Amount = packet.ReadInt32("Amount", i);
+                questInfoObjective.Flags = (uint)packet.ReadInt32("Flags", i);
+                questInfoObjective.Flags2 = packet.ReadUInt32("Flags2", i);
+                questInfoObjective.ProgressBarWeight = packet.ReadSingle("ProgressBarWeight", i);
+
+                var visualEffectsCount = packet.ReadUInt32("VisualEffects", i);
+                for (var j = 0; j < visualEffectsCount; ++j)
+                {
+                    QuestVisualEffect questVisualEffect = new QuestVisualEffect
+                    {
+                        ID = questInfoObjective.ID,
+                        Index = (uint)j,
+                        VisualEffect = packet.ReadInt32("VisualEffectId", i, j)
+                    };
+
+                    Storage.QuestVisualEffects.Add(questVisualEffect, packet.TimeSpan);
+                }
+
+                packet.ResetBitReader();
+
+                uint descriptionLength = packet.ReadBits(8);
+                questInfoObjective.Description = packet.ReadWoWString("Description", descriptionLength, i);
+
+                if (ClientLocale.PacketLocale != LocaleConstant.enUS && questInfoObjective.Description != string.Empty)
+                {
+                    QuestObjectivesLocale localesQuestObjectives = new QuestObjectivesLocale
+                    {
+                        ID = (uint)objectiveId.Key,
+                        QuestId = (uint)id.Key,
+                        StorageIndex = questInfoObjective.StorageIndex,
+                        Description = questInfoObjective.Description
+                    };
+
+                    Storage.LocalesQuestObjectives.Add(localesQuestObjectives, packet.TimeSpan);
+                }
+
+                Storage.QuestObjectives.Add(questInfoObjective, packet.TimeSpan);
+            }
+
+            quest.LogTitle = packet.ReadWoWString("LogTitle", logTitleLen);
+            quest.LogDescription = packet.ReadWoWString("LogDescription", logDescriptionLen);
+            quest.QuestDescription = packet.ReadWoWString("QuestDescription", questDescriptionLen);
+            quest.AreaDescription = packet.ReadWoWString("AreaDescription", areaDescriptionLen);
+            quest.QuestGiverTextWindow = packet.ReadWoWString("PortraitGiverText", questGiverTextWindowLen);
+            quest.QuestGiverTargetName = packet.ReadWoWString("PortraitGiverName", questGiverTargetNameLen);
+            quest.QuestTurnTextWindow = packet.ReadWoWString("PortraitTurnInText", questTurnTextWindowLen);
+            quest.QuestTurnTargetName = packet.ReadWoWString("PortraitTurnInName", questTurnTargetNameLen);
+            quest.QuestCompletionLog = packet.ReadWoWString("QuestCompletionLog", questCompletionLogLen);
+
+            if (ClientLocale.PacketLocale != LocaleConstant.enUS)
+            {
+                LocalesQuest localesQuest = new LocalesQuest
+                {
+                    ID = (uint)id.Key,
+                    LogTitle = quest.LogTitle,
+                    LogDescription = quest.LogDescription,
+                    QuestDescription = quest.QuestDescription,
+                    AreaDescription = quest.AreaDescription,
+                    PortraitGiverText = quest.QuestGiverTextWindow,
+                    PortraitGiverName = quest.QuestGiverTargetName,
+                    PortraitTurnInText = quest.QuestTurnTextWindow,
+                    PortraitTurnInName = quest.QuestTurnTargetName,
+                    QuestCompletionLog = quest.QuestCompletionLog
+                };
+
+                Storage.LocalesQuests.Add(localesQuest, packet.TimeSpan);
+            }
+
+            Storage.QuestTemplates.Add(quest, packet.TimeSpan);
+        }
+    }
+}


### PR DESCRIPTION
Change behavior to check TargetedDatabase.
Since classic we had problems to clearly define which fields are used in which DB.

Intead of ranges (which was okay as long blizzard only moved forward) we now set flags for the supported database version.
Tho it's still a lot of manual work for classic, because we have to add the AnyClassic/Classic/WotlkClassic flag to any field which has retail flags set (if they are valid for Classic too).

I also added CreatureTemplate parsing for 3.4.0 as example and to test