### PR TITLE
Cache field attributes while getting fields for sql generation.

### DIFF
--- a/WowPacketParser.Tests/Misc/UtilitiesTest.cs
+++ b/WowPacketParser.Tests/Misc/UtilitiesTest.cs
@@ -122,10 +122,10 @@ namespace WowPacketParser.Tests.Misc
         }
 
         [AttributeUsage(AttributeTargets.Field)]
-        private class FieldTestAttribute : Attribute { }
+        private class FieldTestAttribute : Attribute, IAttribute { }
 
         [AttributeUsage(AttributeTargets.Field)]
-        private class FieldDummyTestAttribute : Attribute { }
+        private class FieldDummyTestAttribute : Attribute, IAttribute { }
 
         private class TestFoo
         {

--- a/WowPacketParser/Misc/IAttribute.cs
+++ b/WowPacketParser/Misc/IAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WowPacketParser.Misc
+{
+    public interface IAttribute
+    {
+        bool IsPrimaryKey { get { return false; } set { } }
+        bool IsVisible() => false;
+    }
+}

--- a/WowPacketParser/SQL/DBFieldNameAttribute.cs
+++ b/WowPacketParser/SQL/DBFieldNameAttribute.cs
@@ -11,7 +11,7 @@ namespace WowPacketParser.SQL
     ///  arrays ("dmg_min1, dmg_min2, dmg_min3" -> name = dmg_min, count = 3, startAtZero = false)
     /// </summary>
     [AttributeUsage(AttributeTargets.Field, AllowMultiple = true)]
-    public sealed class DBFieldNameAttribute : Attribute
+    public sealed class DBFieldNameAttribute : Attribute, IAttribute
     {
         /// <summary>
         /// Column name

--- a/WowPacketParser/SQL/SQLUtil.cs
+++ b/WowPacketParser/SQL/SQLUtil.cs
@@ -174,7 +174,7 @@ namespace WowPacketParser.SQL
             return (from field in Utilities.GetFieldsAndAttributes<T, DBFieldNameAttribute>()
                     where field.Value.Any(f => f.IsVisible())
                     let fieldName = field.Value.Single(f => f.IsVisible()).ToString()
-                    let fieldValue = field.Value.FindAll(f => f.IsVisible())
+                    let fieldValue = field.Value.FindAll(f => f.IsVisible()).Cast<DBFieldNameAttribute>().ToList()
                     select new Tuple<string, FieldInfo, List<DBFieldNameAttribute>>(fieldName, field.Key, fieldValue)).ToList();
         }
 
@@ -837,7 +837,7 @@ namespace WowPacketParser.SQL
         {
             return Utilities.GetFieldsAndAttributes<T, DBFieldNameAttribute>()
                 .Where(field => field.Value.Any(f => f.IsVisible() && (!f.IsPrimaryKey || (includePrimaryKeys && f.IsPrimaryKey))))
-                .Select(field => new Tuple<FieldInfo, DBFieldNameAttribute>(field.Key, field.Value.First()))
+                .Select(field => new Tuple<FieldInfo, DBFieldNameAttribute>(field.Key, (DBFieldNameAttribute)field.Value.First()))
                 .ToList();
         }
 


### PR DESCRIPTION
This saves another 20-30% of parsing time when generating sql files.