### PR TITLE
Sanitizing packets

### DIFF
--- a/WowPacketParser/App.config
+++ b/WowPacketParser/App.config
@@ -105,6 +105,8 @@
                           13: Binary (.pkt) merge output in a file (fusion.pkt)
                           14: UniversalProto (.dat)
                           15: UniversalProto with text (.dat)
+                          16: UniversalProto with separate text (.dat)
+                          17: SanitizedPkt (.pkt) removes personal data (e.g. guid, realmid, chat message, guild, name, ...) and dumps a new pkt (<name>_sanitized.pkt)
         -->
         <add key="DumpFormat" value="1"/>
 

--- a/WowPacketParser/Enums/DumpFormatType.cs
+++ b/WowPacketParser/Enums/DumpFormatType.cs
@@ -18,6 +18,7 @@
         Fusion,
         UniversalProto,
         UniversalProtoWithText,
-        UniversalProtoWithSeparateText
+        UniversalProtoWithSeparateText,
+        SanitizedPkt
     }
 }

--- a/WowPacketParser/Loading/IPacketReader.cs
+++ b/WowPacketParser/Loading/IPacketReader.cs
@@ -9,5 +9,6 @@ namespace WowPacketParser.Loading
         Packet Read(int number, string fileName);
         long GetTotalSize();
         long GetCurrentSize();
+        byte[] GetFileHeader();
     }
 }

--- a/WowPacketParser/Loading/SqLitePacketReader.cs
+++ b/WowPacketParser/Loading/SqLitePacketReader.cs
@@ -63,6 +63,11 @@ namespace WowPacketParser.Loading
             return _count;
         }
 
+        public byte[] GetFileHeader()
+        {
+            return new byte[0];
+        }
+
         public void Dispose()
         {
             if (_reader != null)

--- a/WowPacketParser/Misc/Packet.cs
+++ b/WowPacketParser/Misc/Packet.cs
@@ -33,6 +33,7 @@ namespace WowPacketParser.Misc
             FileName = fileName;
             Status = ParsedStatus.None;
             WriteToFile = true;
+            BinaryWriter = new BinaryWriter(BaseStream);
 
             if (number == 0)
                 _firstPacketTime = Time;
@@ -54,6 +55,20 @@ namespace WowPacketParser.Misc
         public Packet(byte[] input, int opcode, DateTime time, Direction direction, int number, string fileName)
             : this(input, opcode, time, direction, number, null, fileName)
         {
+            Opcode = opcode;
+            Time = time;
+            Direction = direction;
+            Number = number;
+            Writer = null;
+            FileName = fileName;
+            Status = ParsedStatus.None;
+            WriteToFile = true;
+            BinaryWriter = new BinaryWriter(BaseStream);
+
+            if (number == 0)
+                _firstPacketTime = Time;
+
+            TimeSpan = Time - _firstPacketTime;
         }
 
         public int Opcode { get; set; } // setter can't be private because it's used in multiple_packets
@@ -67,6 +82,8 @@ namespace WowPacketParser.Misc
         public bool WriteToFile { get; private set; }
         public int ConnectionIndex { get; set; }
         public IPEndPoint EndPoint { get; set; }
+        public byte[] Header { get; set; }
+        public BinaryWriter BinaryWriter { get; }
 
         public PacketHolder Holder { get; set; }
 

--- a/WowPacketParser/Misc/PacketReads.cs
+++ b/WowPacketParser/Misc/PacketReads.cs
@@ -1,11 +1,13 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Runtime.InteropServices;
 using System.Text;
 using WowPacketParser.Enums;
+using WowPacketParser.Loading;
 
 namespace WowPacketParser.Misc
 {
@@ -33,8 +35,12 @@ namespace WowPacketParser.Misc
         {
             var guidLowMask = ReadByte();
             var guidHighMask = ReadByte();
+            WowGuid128 guid;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+                guid = new WowGuid128(ReadPackedUInt64_Sanitize(guidLowMask, true, true), ReadPackedUInt64_Sanitize(guidHighMask, true));
+            else
+                guid = new WowGuid128(ReadPackedUInt64(guidLowMask), ReadPackedUInt64(guidHighMask));
 
-            var guid = new WowGuid128(ReadPackedUInt64(guidLowMask), ReadPackedUInt64(guidHighMask));
             if (WriteToFile)
                 WriteToFile = Filters.CheckFilter(guid);
 
@@ -761,5 +767,358 @@ namespace WowPacketParser.Misc
                     return current + (s[0] + value.ToString() + s[1] + ' ');
                 });
         }
+
+#region Sanitizing
+        public byte ReadByte_Sanitize(string name, params object[] indexes)
+        {
+            byte val = 0;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadByte();
+            AddValue(name, FormatInteger(val), indexes);
+            return val;
+        }
+
+        public sbyte ReadSByte_Sanitize(string name, params object[] indexes)
+        {
+            sbyte val = 0;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadSByte();
+            AddValue(name, FormatInteger(val), indexes);
+            return val;
+        }
+
+        public short ReadInt16_Sanitize(string name, params object[] indexes)
+        {
+            short val = 0;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadInt16();
+            AddValue(name, FormatInteger(val), indexes);
+            return val;
+        }
+
+        public ushort ReadUInt16_Sanitize(string name, params object[] indexes)
+        {
+            ushort val = 0;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadUInt16();
+            AddValue(name, FormatInteger(val), indexes);
+            return val;
+        }
+
+        public float ReadSingle_Sanitize(string name, params object[] indexes)
+        {
+            float val = 0;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadSingle();
+            AddValue(name, FormatFloat(val), indexes);
+            return val;
+        }
+
+        public double ReadDouble_Sanitize(string name, params object[] indexes)
+        {
+            double val = 0;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadDouble();
+            AddValue(name, FormatFloat(val), indexes);
+            return val;
+        }
+
+        public int ReadInt32_Sanitize(string name, params object[] indexes)
+        {
+            int val = 0;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadInt32();
+            AddValue(name, FormatInteger(val), indexes);
+            return val;
+        }
+
+        public uint ReadUInt32_Sanitize(string name, params object[] indexes)
+        {
+            uint val = 0;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadUInt32();
+            AddValue(name, FormatInteger(val), indexes);
+            return val;
+        }
+
+        public long ReadInt64_Sanitize(string name, params object[] indexes)
+        {
+            long val = 0;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadInt64();
+            AddValue(name, FormatInteger(val), indexes);
+            return val;
+        }
+
+        public ulong ReadUInt64_Sanitize(string name, params object[] indexes)
+        {
+            ulong val = 0;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadUInt64();
+            AddValue(name, FormatInteger(val), indexes);
+            return val;
+        }
+
+        public WowGuid ReadGuid_Sanitize(string name, params object[] indexes)
+        {
+            // TODO: Create sanitize ReadGuid() function which generates a new guid an replaces all -> store original and replacement in a map
+            return AddValue(name, ReadGuid(), indexes);
+        }
+        public string ReadWoWString_Sanitize(int len)
+        {
+            Encoding encoding = Encoding.UTF8;
+            byte[] bytes;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                var str = new string('X', len);
+                BinaryWriter.Write(encoding.GetBytes(str));
+                return str;
+            }
+            else
+                bytes = ReadBytes(len).Where(b => b != 0).ToArray();
+
+            string s = encoding.GetString(bytes);
+            return s;
+        }
+
+        public string ReadWoWString_Sanitize(string name, int len, params object[] indexes)
+        {
+            return AddValue(name, ReadWoWString_Sanitize(len), indexes);
+        }
+
+        public string ReadWoWString_Sanitize(string name, uint len, params object[] indexes)
+        {
+            return AddValue(name, ReadWoWString_Sanitize((int)len), indexes);
+        }
+
+        public string ReadDynamicString_Sanitize(int len)
+        {
+            if (len == 1)
+                return string.Empty;
+
+            return ReadWoWString_Sanitize(len);
+        }
+
+        public string ReadDynamicString_Sanitize(string name, int len, params object[] indexes)
+        {
+            return AddValue(name, ReadDynamicString_Sanitize(len), indexes);
+        }
+
+        public string ReadDynamicString_Sanitize(string name, uint len, params object[] indexes)
+        {
+            return AddValue(name, ReadDynamicString_Sanitize((int)len), indexes);
+        }
+
+        public string ReadCString_Sanitize(Encoding encoding)
+        {
+            var bytes = new List<byte>();
+
+            byte b;
+            // store position of BaseStream so we can jump back when writing
+            var startPosition = BaseStream.Position;
+
+            while (CanRead() && (b = ReadByte()) != 0)  // CDataStore::GetCString calls CanRead too
+                bytes.Add(b);
+
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                // jump back before Read
+                BaseStream.Position = startPosition;
+                // replace CString by X with same length
+                var str = new string('X', bytes.Count);
+                BinaryWriter.Write(encoding.GetBytes(str));
+                return str;
+            }
+
+            return encoding.GetString(bytes.ToArray());
+        }
+
+        public string ReadCString_Sanitize()
+        {
+            return ReadCString_Sanitize(Encoding.UTF8);
+        }
+
+        public string ReadCString_Sanitize(string name, params object[] indexes)
+        {
+            return AddValue(name, ReadCString_Sanitize(), indexes);
+        }
+
+        public WowGuid ReadPackedGuid_Sanitize(string name, params object[] indexes)
+        {
+            // TODO: Create sanitize ReadPackedGuid() function which generates a new guid an replaces all -> store original and replacement in a map
+            return AddValue(name, ReadPackedGuid(), indexes);
+        }
+
+        private ulong ReadPackedUInt64_Sanitize(byte mask, bool guid = false, bool xor = false)
+        {
+            if (mask == 0)
+                return 0;
+
+            ulong res = 0;
+
+            int i = 0;
+            while (i < 8)
+            {
+                if ((mask & 1 << i) != 0)
+                {
+                    byte val = 0;
+                    if (guid)
+                    {
+                        // packed uint64 contains RealmID in this range
+                        if (!xor && (i >= 5 && i <= 6))
+                        {
+                            BinaryWriter.Write(val);
+                            res += (ulong)val << (i * 8);
+                        }
+                        else if (xor)
+                        {
+                            var position = BaseStream.Position;
+
+                            byte original = ReadByte();
+                            val = (byte)(original ^ SniffFile.GetXORSeed());
+                            res += (ulong)val << (i * 8);
+
+                            BaseStream.Position = position;
+                            BinaryWriter.Write(val);
+                        }
+                        else
+                            res += (ulong)ReadByte() << (i * 8);
+                    }
+                    else
+                    {
+                        BinaryWriter.Write(val);
+                        res += (ulong)val << (i * 8);
+                    }
+                }
+
+                i++;
+            }
+
+            return res;
+        }
+
+        public byte[] ReadBytesString_Sanitize(string name, int length, params object[] indexes)
+        {
+            byte[] val;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                var str = new string('X', length);
+                val = Encoding.UTF8.GetBytes(str);
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadBytes(length);
+
+            AddValue(name, Encoding.UTF8.GetString(val), indexes);
+            return val;
+        }
+
+        public byte[] ReadBytesTable_Sanitize(string name, int length, params object[] indexes)
+        {
+            byte[] val;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                val = new byte[length];
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadBytes(length);
+
+            AddValue(name, Utilities.ByteArrayToHexTable(val, true,
+                GetIndexString(indexes).Length + name.Length + ": ".Length),
+                indexes);
+            return val;
+        }
+
+        public byte[] ReadBytes_Sanitize(string name, int length, params object[] indexes)
+        {
+            byte[] val;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                val = new byte[length];
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadBytes(length);
+            AddValue(name, Convert.ToHexString(val), indexes);
+            return val;
+        }
+
+        public IPAddress ReadIPAddress_Sanitize()
+        {
+            byte[] val;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                val = new byte[4];
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadBytes(4);
+
+            return new IPAddress(val);
+        }
+
+        public IPAddress ReadIPv6Address_Sanitize()
+        {
+            byte[] val;
+            if (Settings.DumpFormat == DumpFormatType.SanitizedPkt)
+            {
+                val = new byte[16];
+                BinaryWriter.Write(val);
+            }
+            else
+                val = ReadBytes(16);
+            return new IPAddress(val);
+        }
+
+        public IPAddress ReadIPAddress_Sanitize(string name, params object[] indexes)
+        {
+            return AddValue(name, ReadIPAddress_Sanitize(), indexes);
+        }
+        public IPAddress ReadIPv6Address_Sanitize(string name, params object[] indexes)
+        {
+            return AddValue(name, ReadIPv6Address_Sanitize(), indexes);
+        }
+        #endregion
     }
 }

--- a/WowPacketParser/Saving/SanitizedBinaryPacketWriter.cs
+++ b/WowPacketParser/Saving/SanitizedBinaryPacketWriter.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Text;
+using WowPacketParser.Enums;
+using WowPacketParser.Misc;
+
+namespace WowPacketParser.Saving
+{
+    public static class SanitizedBinaryPacketWriter
+    {
+        [SuppressMessage("Microsoft.Reliability", "CA2000", Justification = "fileStream is disposed when writer is disposed.")]
+        public static void Write(SniffType type, string fileName, Encoding encoding, byte[] fileHeader, IEnumerable<Packet> packets)
+        {
+            var fileStream = new FileStream(fileName, FileMode.Create, FileAccess.Write, FileShare.None);
+            using (var writer = new BinaryWriter(fileStream, encoding))
+            {
+                writer.Write(fileHeader);
+                foreach (var packet in packets)
+                {
+                    writer.Write(packet.Header);
+                    writer.Write(packet.GetStream(0));
+                }
+            }
+        }
+    }
+}

--- a/WowPacketParserModule.Substructures/MythicPlusHandler.cs
+++ b/WowPacketParserModule.Substructures/MythicPlusHandler.cs
@@ -41,8 +41,8 @@ namespace WowPacketParserModule.Substructures
             packet.ReadUInt64("GuildClubMemberID", indexes);
             packet.ReadPackedGuid128("GUID", indexes);
             packet.ReadPackedGuid128("GuildGUID", indexes);
-            packet.ReadUInt32("NativeRealmAddress", indexes);
-            packet.ReadUInt32("VirtualRealmAddress", indexes);
+            packet.ReadUInt32_Sanitize("NativeRealmAddress", indexes);
+            packet.ReadUInt32_Sanitize("VirtualRealmAddress", indexes);
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_2_0_42423))
                 packet.ReadInt32("ChrSpecializationID", indexes);
             else

--- a/WowPacketParserModule.V1_13_2_31446/Parsers/GuildHandler.cs
+++ b/WowPacketParserModule.V1_13_2_31446/Parsers/GuildHandler.cs
@@ -15,7 +15,7 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
             if (hasData)
             {
                 packet.ReadPackedGuid128("GuildGUID");
-                packet.ReadInt32("VirtualRealmAddress");
+                packet.ReadInt32_Sanitize("VirtualRealmAddress");
                 var rankCount = packet.ReadUInt32("RankCount");
                 packet.ReadInt32("EmblemColor");
                 packet.ReadInt32("EmblemStyle");

--- a/WowPacketParserModule.V1_13_2_31446/Parsers/GuildHandler.cs
+++ b/WowPacketParserModule.V1_13_2_31446/Parsers/GuildHandler.cs
@@ -58,7 +58,7 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
                 packet.ReadUInt32("Step", idx, j);
             }
 
-            packet.ReadUInt32("VirtualRealmAddress", idx);
+            packet.ReadUInt32_Sanitize("VirtualRealmAddress", idx);
 
             packet.ReadByteE<GuildMemberFlag>("Status", idx);
             packet.ReadByte("Level", idx);
@@ -74,7 +74,7 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
             packet.ReadBit("Authenticated", idx);
             packet.ReadBit("SorEligible", idx);
 
-            packet.ReadWoWString("Name", nameLen, idx);
+            packet.ReadWoWString_Sanitize("Name", nameLen, idx);
             packet.ReadWoWString("Note", noteLen, idx);
             packet.ReadWoWString("OfficerNote", officersNoteLen, idx);
         }

--- a/WowPacketParserModule.V2_5_1_38707/Parsers/AuthenticationHandler.cs
+++ b/WowPacketParserModule.V2_5_1_38707/Parsers/AuthenticationHandler.cs
@@ -15,7 +15,7 @@ namespace WowPacketParserModule.V2_5_1_38707.Parsers
             var queued = packet.ReadBit("Queued");
             if (ok)
             {
-                packet.ReadUInt32("VirtualRealmAddress");
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress");
                 var realms = packet.ReadUInt32();
                 packet.ReadUInt32("TimeRested");
                 packet.ReadByte("ActiveExpansionLevel");

--- a/WowPacketParserModule.V2_5_1_38707/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V2_5_1_38707/Parsers/HotfixHandler.cs
@@ -149,7 +149,7 @@ namespace WowPacketParserModule.V2_5_1_38835.Parsers
         [Parser(Opcode.SMSG_AVAILABLE_HOTFIXES)]
         public static void HandleAvailableHotfixes(Packet packet)
         {
-            packet.ReadUInt32("VirtualRealmAddress");
+            packet.ReadUInt32_Sanitize("VirtualRealmAddress");
 
             var uniqueIDCount = packet.ReadUInt32("UniqueIDCount");
             for (var i = 0; i < uniqueIDCount; ++i)

--- a/WowPacketParserModule.V2_5_1_38707/Parsers/SystemHandler.cs
+++ b/WowPacketParserModule.V2_5_1_38707/Parsers/SystemHandler.cs
@@ -13,8 +13,8 @@ namespace WowPacketParserModule.V2_5_1_38835.Parsers
 
             packet.ReadUInt32("ScrollOfResurrectionRequestsRemaining");
             packet.ReadUInt32("ScrollOfResurrectionMaxRequestsPerDay");
-            packet.ReadUInt32("CfgRealmID");
-            packet.ReadInt32("CfgRealmRecID");
+            packet.ReadUInt32_Sanitize("CfgRealmID");
+            packet.ReadInt32_Sanitize("CfgRealmRecID");
             packet.ReadUInt32("MaxRecruits", "RAFSystem");
             packet.ReadUInt32("MaxRecruitMonths", "RAFSystem");
             packet.ReadUInt32("MaxRecruitmentUses", "RAFSystem");

--- a/WowPacketParserModule.V3_4_0_45166/Parsers/AccountDataHandler.cs
+++ b/WowPacketParserModule.V3_4_0_45166/Parsers/AccountDataHandler.cs
@@ -10,7 +10,7 @@ namespace WowPacketParserModule.V3_4_0_45166.Parsers
         {
             packet.ReadPackedGuid128("WowAccountGUID", idx);
             packet.ReadPackedGuid128("CharacterGUID", idx);
-            packet.ReadUInt32("VirtualRealmAddress", idx);
+            packet.ReadUInt32_Sanitize("VirtualRealmAddress", idx);
             packet.ReadByteE<Race>("Race" ,idx);
             packet.ReadByteE<Class>("Class", idx);
             packet.ReadByteE<Gender>("Gender", idx);
@@ -23,8 +23,8 @@ namespace WowPacketParserModule.V3_4_0_45166.Parsers
             uint characterNameLength = packet.ReadBits(6);
             uint realmNameLength = packet.ReadBits(9);
 
-            packet.ReadWoWString("CharacterName", characterNameLength, idx);
-            packet.ReadWoWString("RealmName", realmNameLength, idx);
+            packet.ReadWoWString_Sanitize("CharacterName", characterNameLength, idx);
+            packet.ReadWoWString_Sanitize("RealmName", realmNameLength, idx);
         }
 
         [Parser(Opcode.SMSG_GET_ACCOUNT_CHARACTER_LIST_RESULT)]

--- a/WowPacketParserModule.V3_4_0_45166/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParserModule.V3_4_0_45166/Parsers/MiscellaneousHandler.cs
@@ -90,8 +90,8 @@ namespace WowPacketParserModule.V3_4_0_45166.Parsers
 
             packet.ReadUInt32("ScrollOfResurrectionRequestsRemaining");
             packet.ReadUInt32("ScrollOfResurrectionMaxRequestsPerDay");
-            packet.ReadUInt32("CfgRealmID");
-            packet.ReadInt32("CfgRealmRecID");
+            packet.ReadUInt32_Sanitize("CfgRealmID");
+            packet.ReadInt32_Sanitize("CfgRealmRecID");
             packet.ReadUInt32("MaxRecruits", "RAFSystem");
             packet.ReadUInt32("MaxRecruitMonths", "RAFSystem");
             packet.ReadUInt32("MaxRecruitmentUses", "RAFSystem");

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/AchievementHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/AchievementHandler.cs
@@ -54,8 +54,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadInt32<AchievementId>("Id", idx);
             packet.ReadPackedTime("Date", idx);
             packet.ReadPackedGuid128("Owner", idx);
-            packet.ReadInt32("VirtualRealmAddress", idx);
-            packet.ReadInt32("NativeRealmAddress", idx);
+            packet.ReadInt32_Sanitize("VirtualRealmAddress", idx);
+            packet.ReadInt32_Sanitize("NativeRealmAddress", idx);
         }
 
         [Parser(Opcode.SMSG_ALL_ACCOUNT_CRITERIA)]
@@ -92,8 +92,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadPackedGuid128("Earner");
             packet.ReadUInt32<AchievementId>("AchievementID");
             packet.ReadPackedTime("Time");
-            packet.ReadUInt32("EarnerNativeRealm");
-            packet.ReadUInt32("EarnerVirtualRealm");
+            packet.ReadUInt32_Sanitize("EarnerNativeRealm");
+            packet.ReadUInt32_Sanitize("EarnerVirtualRealm");
             packet.ReadBit("Initial");
         }
 

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/BattlePayHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/BattlePayHandler.cs
@@ -126,8 +126,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadInt32("ProductID", index);
 
             packet.ReadPackedGuid128("TargetPlayer", index);
-            packet.ReadInt32("TargetVirtualRealm", index);
-            packet.ReadInt32("TargetNativeRealm", index);
+            packet.ReadInt32_Sanitize("TargetVirtualRealm", index);
+            packet.ReadInt32_Sanitize("TargetNativeRealm", index);
 
             packet.ReadInt64("PurchaseID", index);
 

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/BattlePetHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/BattlePetHandler.cs
@@ -66,8 +66,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         public static void ReadClientBattlePetOwnerInfo(Packet packet, params object[] idx)
         {
             packet.ReadPackedGuid128("Guid", idx);
-            packet.ReadUInt32("PlayerVirtualRealm", idx);
-            packet.ReadUInt32("PlayerNativeRealm", idx);
+            packet.ReadUInt32_Sanitize("PlayerVirtualRealm", idx);
+            packet.ReadUInt32_Sanitize("PlayerNativeRealm", idx);
         }
 
         [Parser(Opcode.SMSG_BATTLE_PET_JOURNAL)]

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/ChallengeModeHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/ChallengeModeHandler.cs
@@ -8,7 +8,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
     {
         public static void ReadChallengeModeAttempt(Packet packet, params object[] indexes)
         {
-            packet.ReadUInt32("InstanceRealmAddress", indexes);
+            packet.ReadUInt32_Sanitize("InstanceRealmAddress", indexes);
             packet.ReadUInt32("AttemptID", indexes);
             packet.ReadInt32("CompletionTime", indexes);
             packet.ReadPackedTime("CompletionDate", indexes);
@@ -17,8 +17,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var int12 = packet.ReadUInt32("MembersCount", indexes);
             for (int i = 0; i < int12; i++)
             {
-                packet.ReadUInt32("VirtualRealmAddress", indexes, i);
-                packet.ReadUInt32("NativeRealmAddress", indexes, i);
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress", indexes, i);
+                packet.ReadUInt32_Sanitize("NativeRealmAddress", indexes, i);
                 packet.ReadPackedGuid128("Guid", indexes, i);
                 packet.ReadInt32("SpecializationID", indexes, i);
             }

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/ChannelHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/ChannelHandler.cs
@@ -63,11 +63,11 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadPackedGuid128("SenderGuid");
             packet.ReadPackedGuid128("BnetAccountID");
 
-            packet.ReadInt32("SenderVirtualRealm");
+            packet.ReadInt32_Sanitize("SenderVirtualRealm");
 
             packet.ReadPackedGuid128("TargetGuid");
 
-            packet.ReadUInt32("TargetVirtualRealm");
+            packet.ReadUInt32_Sanitize("TargetVirtualRealm");
             packet.ReadInt32("ChatChannelID");
 
             if (type == ChatNotificationType.ModeChange)
@@ -94,7 +94,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             for (var i = 0; i < int20; i++)
             {
                 packet.ReadPackedGuid128("Guid", i);
-                packet.ReadUInt32("VirtualRealmAddress", i);
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress", i);
                 packet.ReadByte("Flags", i);
             }
         }

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/CharacterHandler.cs
@@ -381,10 +381,10 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var bit12 = packet.ReadBit();
 
             if (bit4)
-                packet.ReadInt32("VirtualRealmAddress");
+                packet.ReadInt32_Sanitize("VirtualRealmAddress");
 
             if (bit12)
-                packet.ReadInt32("NativeRealmAddress");
+                packet.ReadInt32_Sanitize("NativeRealmAddress");
         }
 
         [Parser(Opcode.SMSG_QUERY_PLAYER_NAME_RESPONSE)]
@@ -413,7 +413,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 packet.ReadPackedGuid128("BnetAccountID");
                 packet.ReadPackedGuid128("Player Guid");
 
-                packet.ReadUInt32("VirtualRealmAddress");
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress");
 
                 response.Race = (uint)packet.ReadByteE<Race>("Race");
                 response.Gender = (uint)packet.ReadByteE<Gender>("Gender");
@@ -573,7 +573,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         public static void HandleRequestInspectPVP(Packet packet)
         {
             packet.ReadPackedGuid128("InspectTarget");
-            packet.ReadInt32("InspectRealmAddress");
+            packet.ReadInt32_Sanitize("InspectRealmAddress");
         }
 
         [Parser(Opcode.SMSG_INSPECT_PVP)]

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/CombatHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/CombatHandler.cs
@@ -188,12 +188,12 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadBit("Fled");
 
             // Order guessed
-            packet.ReadUInt32("BeatenVirtualRealmAddress");
-            packet.ReadUInt32("WinnerVirtualRealmAddress");
+            packet.ReadUInt32_Sanitize("BeatenVirtualRealmAddress");
+            packet.ReadUInt32_Sanitize("WinnerVirtualRealmAddress");
 
             // Order guessed
-            packet.ReadWoWString("BeatenName", bits80);
-            packet.ReadWoWString("WinnerName", bits24);
+            packet.ReadWoWString_Sanitize("BeatenName", bits80);
+            packet.ReadWoWString_Sanitize("WinnerName", bits24);
         }
 
         [Parser(Opcode.SMSG_CAN_DUEL_RESULT)]

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/ContactHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/ContactHandler.cs
@@ -28,7 +28,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
         public static void ReadQualifiedGUID(Packet packet, params object[] indexes)
         {
-            packet.ReadInt32("VirtualRealmAddress", indexes);
+            packet.ReadInt32_Sanitize("VirtualRealmAddress", indexes);
             packet.ReadPackedGuid128("Guid", indexes);
         }
 
@@ -48,7 +48,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadPackedGuid128("Guid");
             packet.ReadPackedGuid128("WowAccount");
 
-            packet.ReadInt32("VirtualRealmAddress");
+            packet.ReadInt32_Sanitize("VirtualRealmAddress");
 
             packet.ReadByteE<ContactStatus>("Status");
 
@@ -69,8 +69,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadPackedGuid128("Guid", index);
             packet.ReadPackedGuid128("WowAccount", index);
 
-            packet.ReadUInt32("VirtualRealmAddr", index);
-            packet.ReadUInt32("NativeRealmAddr", index);
+            packet.ReadUInt32_Sanitize("VirtualRealmAddr", index);
+            packet.ReadUInt32_Sanitize("NativeRealmAddr", index);
             packet.ReadUInt32("TypeFlags", index);
 
             packet.ReadByte("Status", index);

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/GroupHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/GroupHandler.cs
@@ -366,7 +366,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadPackedGuid128("InviterGuid");
             packet.ReadPackedGuid128("InviterBNetAccountID");
 
-            packet.ReadInt32("InviterCfgRealmID");
+            packet.ReadInt32_Sanitize("InviterCfgRealmID");
             packet.ReadInt16("Unk1");
 
             packet.ResetBitReader();
@@ -376,14 +376,14 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             var bits2 = packet.ReadBits(8);
             var bits258 = packet.ReadBits(8);
-            packet.ReadWoWString("InviterRealmNameActual", bits2);
-            packet.ReadWoWString("InviterRealmNameNormalized", bits258);
+            packet.ReadWoWString_Sanitize("InviterRealmNameActual", bits2);
+            packet.ReadWoWString_Sanitize("InviterRealmNameNormalized", bits258);
 
             packet.ReadInt32("ProposedRoles");
             var int32 = packet.ReadInt32("LfgSlotsCount");
             packet.ReadInt32("LfgCompletedMask");
 
-            packet.ReadWoWString("InviterName", len);
+            packet.ReadWoWString_Sanitize("InviterName", len);
 
             for (int i = 0; i < int32; i++)
                 packet.ReadInt32("LfgSlots", i);
@@ -537,15 +537,15 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadByte("PartyIndex");
             packet.ReadInt32("ProposedRoles");
             packet.ReadPackedGuid128("TargetGuid");
-            packet.ReadInt32("TargetCfgRealmID");
+            packet.ReadInt32_Sanitize("TargetCfgRealmID");
 
             packet.ResetBitReader();
 
             var lenTargetName = packet.ReadBits(9);
             var lenTargetRealm = packet.ReadBits(9);
 
-            packet.ReadWoWString("TargetName", lenTargetName);
-            packet.ReadWoWString("TargetRealm", lenTargetRealm);
+            packet.ReadWoWString_Sanitize("TargetName", lenTargetName);
+            packet.ReadWoWString_Sanitize("TargetRealm", lenTargetRealm);
         }
 
         [Parser(Opcode.CMSG_CONVERT_RAID)]

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/GuildHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/GuildHandler.cs
@@ -40,7 +40,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             if (hasData)
             {
                 packet.ReadPackedGuid128("Guild Guid");
-                packet.ReadInt32("VirtualRealmAddress");
+                packet.ReadInt32_Sanitize("VirtualRealmAddress");
                 var rankCount = packet.ReadInt32("RankCount");
                 packet.ReadInt32("EmblemColor");
                 packet.ReadInt32("EmblemStyle");
@@ -60,7 +60,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
                 packet.ResetBitReader();
                 var nameLen = packet.ReadBits(7);
-                packet.ReadWoWString("Guild Name", nameLen);
+                packet.ReadWoWString_Sanitize("Guild Name", nameLen);
             }
         }
 
@@ -140,7 +140,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                     packet.ReadUInt32("Step", i, j);
                 }
 
-                packet.ReadUInt32("VirtualRealmAddress", i);
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress", i);
 
                 packet.ReadByteE<GuildMemberFlag>("Status", i);
                 packet.ReadByte("Level", i);
@@ -156,9 +156,9 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 packet.ReadBit("Authenticated", i);
                 packet.ReadBit("SorEligible", i);
 
-                packet.ReadWoWString("Name", bits36, i);
-                packet.ReadWoWString("Note", bits92, i);
-                packet.ReadWoWString("OfficerNote", bits221, i);
+                packet.ReadWoWString_Sanitize("Name", bits36, i);
+                packet.ReadWoWString_Sanitize("Note", bits92, i);
+                packet.ReadWoWString_Sanitize("OfficerNote", bits221, i);
             }
 
             packet.ResetBitReader();
@@ -203,14 +203,14 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         public static void HandleGuildEventPresenceChange(Packet packet)
         {
             packet.ReadPackedGuid128("Guid");
-            packet.ReadInt32("VirtualRealmAddress");
+            packet.ReadInt32_Sanitize("VirtualRealmAddress");
 
             packet.ResetBitReader();
             var bits38 = packet.ReadBits(6);
             packet.ReadBit("LoggedOn");
             packet.ReadBit("Mobile");
 
-            packet.ReadWoWString("Name", bits38);
+            packet.ReadWoWString_Sanitize("Name", bits38);
         }
 
         [Parser(Opcode.SMSG_GUILD_KNOWN_RECIPES)]
@@ -269,7 +269,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         public static void HandleGuildInviteByName(Packet packet)
         {
             var bits16 = packet.ReadBits(9);
-            packet.ReadWoWString("Name", bits16);
+            packet.ReadWoWString_Sanitize("Name", bits16);
         }
 
         [Parser(Opcode.SMSG_GUILD_CRITERIA_UPDATE)]
@@ -326,10 +326,10 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var bits216 = packet.ReadBits(7);
             var bits52 = packet.ReadBits(7);
 
-            packet.ReadInt32("InviterVirtualRealmAddress");
-            packet.ReadUInt32("GuildVirtualRealmAddress");
+            packet.ReadInt32_Sanitize("InviterVirtualRealmAddress");
+            packet.ReadUInt32_Sanitize("GuildVirtualRealmAddress");
             packet.ReadPackedGuid128("GuildGUID");
-            packet.ReadUInt32("OldGuildVirtualRealmAddress");
+            packet.ReadUInt32_Sanitize("OldGuildVirtualRealmAddress");
             packet.ReadPackedGuid128("OldGuildGUID");
             packet.ReadUInt32("EmblemStyle");
             packet.ReadUInt32("EmblemColor");
@@ -338,9 +338,9 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadUInt32("Background");
             packet.ReadUInt32("AchievementPoints");
 
-            packet.ReadWoWString("InviterName", bits149);
-            packet.ReadWoWString("OldGuildName", bits216);
-            packet.ReadWoWString("GuildName", bits52);
+            packet.ReadWoWString_Sanitize("InviterName", bits149);
+            packet.ReadWoWString_Sanitize("OldGuildName", bits216);
+            packet.ReadWoWString_Sanitize("GuildName", bits52);
         }
 
         [Parser(Opcode.SMSG_GUILD_BANK_QUERY_RESULTS)]
@@ -475,7 +475,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadUInt32E<GuildCommandError>("Result");
             packet.ReadUInt32E<GuildCommandType>("Command");
             var len = packet.ReadBits(8);
-            packet.ReadWoWString("Name", len);
+            packet.ReadWoWString_Sanitize("Name", len);
         }
 
         [Parser(Opcode.SMSG_GUILD_NAME_CHANGED)]
@@ -484,7 +484,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadPackedGuid128("GuildGUID");
 
             var len = packet.ReadBits(7);
-            packet.ReadWoWString("GuildName", len);
+            packet.ReadWoWString_Sanitize("GuildName", len);
         }
 
         [Parser(Opcode.CMSG_GUILD_BANK_QUERY_TAB)]
@@ -614,10 +614,10 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         public static void HandleGuildEventPlayerJoined(Packet packet)
         {
             packet.ReadPackedGuid128("Guid");
-            packet.ReadInt32("VirtualRealmAddress");
+            packet.ReadInt32_Sanitize("VirtualRealmAddress");
 
             var len = packet.ReadBits(6);
-            packet.ReadWoWString("Name", len);
+            packet.ReadWoWString_Sanitize("Name", len);
         }
 
         [Parser(Opcode.SMSG_GUILD_EVENT_PLAYER_LEFT)]
@@ -630,20 +630,20 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             {
                 var lenRemoverName = packet.ReadBits(6);
                 packet.ReadPackedGuid128("RemoverGUID");
-                packet.ReadInt32("RemoverVirtualRealmAddress");
-                packet.ReadWoWString("RemoverName", lenRemoverName);
+                packet.ReadInt32_Sanitize("RemoverVirtualRealmAddress");
+                packet.ReadWoWString_Sanitize("RemoverName", lenRemoverName);
             }
 
             packet.ReadPackedGuid128("LeaverGUID");
-            packet.ReadInt32("LeaverVirtualRealmAddress");
-            packet.ReadWoWString("LeaverName", lenLeaverName);
+            packet.ReadInt32_Sanitize("LeaverVirtualRealmAddress");
+            packet.ReadWoWString_Sanitize("LeaverName", lenLeaverName);
         }
 
         public static void ReadLFGuildRecruitData(Packet packet, params object[] indexes)
         {
             packet.ReadPackedGuid128("RecruitGUID", indexes);
 
-            packet.ReadUInt32("RecruitVirtualRealm", indexes);
+            packet.ReadUInt32_Sanitize("RecruitVirtualRealm", indexes);
 
             packet.ReadInt32("CharacterClass", indexes);
             packet.ReadInt32("CharacterGender", indexes);
@@ -660,14 +660,14 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var lenName = packet.ReadBits(6);
             var lenComment = packet.ReadBits(10);
 
-            packet.ReadWoWString("Name", lenName, indexes);
+            packet.ReadWoWString_Sanitize("Name", lenName, indexes);
             packet.ReadWoWString("Comment", lenComment, indexes);
         }
 
         public static void ReadLFGuildApplicationData(Packet packet, params object[] indexes)
         {
             packet.ReadPackedGuid128("GuildGUID", indexes);
-            packet.ReadUInt32("GuildVirtualRealm", indexes);
+            packet.ReadUInt32_Sanitize("GuildVirtualRealm", indexes);
 
             packet.ReadInt32("ClassRoles", indexes);
             packet.ReadInt32("PlayStyle", indexes);
@@ -679,7 +679,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var lenName = packet.ReadBits(7);
             var lenComment = packet.ReadBits(10);
 
-            packet.ReadWoWString("GuildName", lenName, indexes);
+            packet.ReadWoWString_Sanitize("GuildName", lenName, indexes);
             packet.ReadWoWString("Comment", lenComment, indexes);
         }
 
@@ -732,7 +732,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         [Parser(Opcode.CMSG_QUERY_PETITION)]
         public static void HandleQueryPetition(Packet packet)
         {
-            packet.ReadUInt32("PetitionID");
+            packet.ReadUInt32_Sanitize("PetitionID");
             packet.ReadPackedGuid128("ItemGUID");
         }
 
@@ -770,7 +770,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadPackedGuid128("Item");
             packet.ReadPackedGuid128("Owner");
             packet.ReadPackedGuid128("OwnerWoWAccount");
-            packet.ReadInt32("PetitionID");
+            packet.ReadInt32_Sanitize("PetitionID");
 
             var signaturesCount = packet.ReadInt32("SignaturesCount");
             for (int i = 0; i < signaturesCount; i++)
@@ -779,7 +779,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
         public static void ReadPetitionInfo(Packet packet, params object[] indexes)
         {
-            packet.ReadInt32("PetitionID", indexes);
+            packet.ReadInt32_Sanitize("PetitionID", indexes);
             packet.ReadPackedGuid128("Petitioner", indexes);
 
             packet.ReadInt32("MinSignatures", indexes);
@@ -816,7 +816,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         [Parser(Opcode.SMSG_QUERY_PETITION_RESPONSE)]
         public static void HandleQueryPetitionResponse(Packet packet)
         {
-            packet.ReadInt32("PetitionID");
+            packet.ReadInt32_Sanitize("PetitionID");
 
             packet.ResetBitReader();
             var hasAllow = packet.ReadBit("Allow");
@@ -848,7 +848,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ResetBitReader();
             var length = packet.ReadBits("NewGuildNameLength", 7);
 
-            packet.ReadWoWString("NewGuildName", length);
+            packet.ReadWoWString_Sanitize("NewGuildName", length);
         }
 
         [Parser(Opcode.SMSG_TURN_IN_PETITION_RESULT)]
@@ -865,8 +865,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             packet.ResetBitReader();
 
-            packet.ReadUInt32("VirtualRealmAddress");
-            packet.ReadWoWString("Name", nameLength);
+            packet.ReadUInt32_Sanitize("VirtualRealmAddress");
+            packet.ReadWoWString_Sanitize("Name", nameLength);
         }
 
         [Parser(Opcode.SMSG_GUILD_BANK_TEXT_QUERY_RESULT)]
@@ -901,7 +901,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             packet.ReadPackedGuid128("GuildGUID", idx);
 
-            packet.ReadUInt32("GuildVirtualRealm", idx);
+            packet.ReadUInt32_Sanitize("GuildVirtualRealm", idx);
             // packet.ReadInt32("GuildLevel", idx);
             packet.ReadInt32("GuildMembers", idx);
             packet.ReadInt32("GuildAchievementPoints", idx);
@@ -918,7 +918,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadSByte("Cached", idx);
             packet.ReadSByte("MembershipRequested", idx);
 
-            packet.ReadWoWString("GuildName", guildNameLength);
+            packet.ReadWoWString_Sanitize("GuildName", guildNameLength);
             packet.ReadWoWString("CommentLength", commentLength);
         }
 

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/InstanceHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/InstanceHandler.cs
@@ -72,7 +72,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 packet.ReadInt16("BottomOffset", i);
                 packet.ReadInt16("LeftOffset", i);
 
-                packet.ReadWoWString("Name", strlen, i);
+                packet.ReadWoWString_Sanitize("Name", strlen, i);
             }
         }
 

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/MailHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/MailHandler.cs
@@ -24,7 +24,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
         public static void ReadMailListEntry(Packet packet, params object[] idx)
         {
-            packet.ReadInt32("MailID", idx);
+            packet.ReadInt32_Sanitize("MailID", idx);
             packet.ReadByteE<MailType>("SenderType", idx);
 
             if (!ClientVersion.AddedInVersion(ClientVersionBuild.V6_1_0_19678))
@@ -35,10 +35,10 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 var bit12 = packet.ReadBit();
 
                 if (bit4)
-                    packet.ReadInt32("VirtualRealmAddress", idx);
+                    packet.ReadInt32_Sanitize("VirtualRealmAddress", idx);
 
                 if (bit12)
-                    packet.ReadInt32("NativeRealmAddress", idx);
+                    packet.ReadInt32_Sanitize("NativeRealmAddress", idx);
             }
 
             packet.ReadInt64("Cod", idx);
@@ -139,10 +139,10 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 var bit12 = packet.ReadBit("HasNativeRealmAddress", i);
 
                 if (bit4)
-                    packet.ReadInt32("VirtualRealmAddress", i);
+                    packet.ReadInt32_Sanitize("VirtualRealmAddress", i);
 
                 if (bit12)
-                    packet.ReadInt32("NativeRealmAddress", i);
+                    packet.ReadInt32_Sanitize("NativeRealmAddress", i);
 
                 packet.ReadSingle("TimeLeft", i);
                 packet.ReadInt32("AltSenderID", i);
@@ -193,7 +193,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var itemCount = packet.ReadBits(5);
             packet.ResetBitReader();
 
-            packet.ReadWoWString("Target", nameLength);
+            packet.ReadWoWString_Sanitize("Target", nameLength);
             packet.ReadWoWString("Subject", subjectLength);
             packet.ReadWoWString("Body", bodyLength);
 

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/MiscellaneousHandler.cs
@@ -119,8 +119,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             packet.ReadInt32("ScrollOfResurrectionRequestsRemaining");
             packet.ReadInt32("ScrollOfResurrectionMaxRequestsPerDay");
-            packet.ReadInt32("CfgRealmID");
-            packet.ReadInt32("CfgRealmRecID");
+            packet.ReadInt32_Sanitize("CfgRealmID");
+            packet.ReadInt32_Sanitize("CfgRealmRecID");
 
             packet.ResetBitReader();
 
@@ -153,8 +153,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             packet.ReadInt32("ScrollOfResurrectionRequestsRemaining");
             packet.ReadInt32("ScrollOfResurrectionMaxRequestsPerDay");
-            packet.ReadInt32("CfgRealmID");
-            packet.ReadInt32("CfgRealmRecID");
+            packet.ReadInt32_Sanitize("CfgRealmID");
+            packet.ReadInt32_Sanitize("CfgRealmRecID");
             packet.ReadInt32("Int27");
             packet.ReadInt32("Int29");
 
@@ -200,8 +200,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             packet.ReadInt32("ScrollOfResurrectionRequestsRemaining");
             packet.ReadInt32("ScrollOfResurrectionMaxRequestsPerDay");
-            packet.ReadInt32("CfgRealmID");
-            packet.ReadInt32("CfgRealmRecID");
+            packet.ReadInt32_Sanitize("CfgRealmID");
+            packet.ReadInt32_Sanitize("CfgRealmRecID");
             packet.ReadInt32("TwitterPostThrottleLimit");
             packet.ReadInt32("TwitterPostThrottleCooldown");
             packet.ReadInt32("TokenPollTimeSeconds");
@@ -296,10 +296,10 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadBit("ExactName");
             var bit708 = packet.ReadBit("HasServerInfo");
 
-            packet.ReadWoWString("Name", bits2);
-            packet.ReadWoWString("VirtualRealmName", bits57);
-            packet.ReadWoWString("Guild", bits314);
-            packet.ReadWoWString("GuildVirtualRealmName", bits411);
+            packet.ReadWoWString_Sanitize("Name", bits2);
+            packet.ReadWoWString_Sanitize("VirtualRealmName", bits57);
+            packet.ReadWoWString_Sanitize("Guild", bits314);
+            packet.ReadWoWString_Sanitize("GuildVirtualRealmName", bits411);
 
             for (var i = 0; i < bit169; ++i)
             {
@@ -313,7 +313,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             {
                 packet.ReadInt32("FactionGroup");
                 packet.ReadInt32("Locale");
-                packet.ReadInt32("RequesterVirtualRealmAddress");
+                packet.ReadInt32_Sanitize("RequesterVirtualRealmAddress");
             }
 
             for (var i = 0; i < bits728; ++i)
@@ -339,31 +339,31 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 }
 
                 for (var j = 0; j < 5; ++j)
-                    packet.ReadWoWString("DeclinedNames", declinedNamesLen[j], i, j);
+                    packet.ReadWoWString_Sanitize("DeclinedNames", declinedNamesLen[j], i, j);
 
                 packet.ReadPackedGuid128("AccountID", i);
                 packet.ReadPackedGuid128("BnetAccountID", i);
                 packet.ReadPackedGuid128("GuidActual", i);
 
-                packet.ReadInt32("VirtualRealmAddress", i);
+                packet.ReadInt32_Sanitize("VirtualRealmAddress", i);
 
                 packet.ReadByteE<Race>("Race", i);
                 packet.ReadByteE<Gender>("Sex", i);
                 packet.ReadByteE<Class>("ClassId", i);
                 packet.ReadByte("Level", i);
 
-                packet.ReadWoWString("Name", bits15, i);
+                packet.ReadWoWString_Sanitize("Name", bits15, i);
 
                 packet.ReadPackedGuid128("GuildGUID", i);
 
-                packet.ReadInt32("GuildVirtualRealmAddress", i);
+                packet.ReadInt32_Sanitize("GuildVirtualRealmAddress", i);
                 packet.ReadInt32<AreaId>("AreaID", i);
 
                 packet.ResetBitReader();
                 var bits460 = packet.ReadBits(7);
                 packet.ReadBit("IsGM", i);
 
-                packet.ReadWoWString("GuildName", bits460, i);
+                packet.ReadWoWString_Sanitize("GuildName", bits460, i);
             }
         }
 
@@ -675,8 +675,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var len1 = packet.ReadBits(12);
             var len2 = packet.ReadBits(10);
 
-            packet.ReadWoWString("DiagInfo", len1);
-            packet.ReadWoWString("Text", len2);
+            packet.ReadWoWString_Sanitize("DiagInfo", len1);
+            packet.ReadWoWString_Sanitize("Text", len2);
         }
 
         [Parser(Opcode.SMSG_RESURRECT_REQUEST)]
@@ -684,7 +684,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         {
             packet.ReadPackedGuid128("ResurrectOffererGUID");
 
-            packet.ReadUInt32("ResurrectOffererVirtualRealmAddress");
+            packet.ReadUInt32_Sanitize("ResurrectOffererVirtualRealmAddress");
             packet.ReadUInt32("PetNumber");
             packet.ReadInt32<SpellId>("SpellID");
 
@@ -693,7 +693,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadBit("UseTimer");
             packet.ReadBit("Sickness");
 
-            packet.ReadWoWString("Name", len);
+            packet.ReadWoWString_Sanitize("Name", len);
         }
 
         [Parser(Opcode.CMSG_RESURRECT_RESPONSE)]
@@ -823,7 +823,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         public static void HandleSummonRequest(Packet packet)
         {
             packet.ReadPackedGuid128("SummonerGUID");
-            packet.ReadUInt32("SummonerVirtualRealmAddress");
+            packet.ReadUInt32_Sanitize("SummonerVirtualRealmAddress");
             packet.ReadInt32<AreaId>("AreaID");
             packet.ReadBit("ConfirmSummon_NC");
         }
@@ -883,14 +883,14 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         public static void HandleWhoIsRequest(Packet packet)
         {
             var len = packet.ReadBits(6);
-            packet.ReadWoWString("CharName", len);
+            packet.ReadWoWString_Sanitize("CharName", len);
         }
 
         [Parser(Opcode.SMSG_WHO_IS)]
         public static void HandleWhoIsResponse(Packet packet)
         {
             var accNameLen = packet.ReadBits(11);
-            packet.ReadWoWString("AccountName", accNameLen);
+            packet.ReadWoWString_Sanitize("AccountName", accNameLen);
         }
 
         [Parser(Opcode.CMSG_COLLECTION_ITEM_SET_FAVORITE)]

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/PetHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/PetHandler.cs
@@ -32,14 +32,14 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 declinedNameLen[i] = (int)packet.ReadBits(7);
 
             for (var i = 0; i < maxDeclinedNameCases; ++i)
-                packet.ReadWoWString("DeclinedNames", declinedNameLen[i], i);
+                packet.ReadWoWString_Sanitize("DeclinedNames", declinedNameLen[i], i);
 
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
                 packet.ReadTime64("Timestamp");
             else
                 packet.ReadTime("Timestamp");
 
-            packet.ReadWoWString("Pet name", len);
+            packet.ReadWoWString_Sanitize("Pet name", len);
         }
 
         public static (uint, uint) ReadPetAction(Packet packet, params object[] indexes)
@@ -150,10 +150,10 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                     count[i] = (int)packet.ReadBits(7);
 
                 for (var i = 0; i < 5; ++i)
-                    packet.ReadWoWString("DeclinedNames", count[i], i);
+                    packet.ReadWoWString_Sanitize("DeclinedNames", count[i], i);
             }
 
-            packet.ReadWoWString("NewName", bits20);
+            packet.ReadWoWString_Sanitize("NewName", bits20);
         }
 
         [Parser(Opcode.SMSG_PET_NAME_INVALID)]
@@ -247,7 +247,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ResetBitReader();
 
             var len = packet.ReadBits(8);
-            packet.ReadWoWString("PetName", len, indexes);
+            packet.ReadWoWString_Sanitize("PetName", len, indexes);
         }
 
         [Parser(Opcode.SMSG_PET_STABLE_LIST)]

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/RecruitAFriendHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/RecruitAFriendHandler.cs
@@ -13,9 +13,9 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var bits273 = packet.ReadBits(9);
             var bits338 = packet.ReadBits(10);
 
-            packet.ReadWoWString("Name", bits16);
-            packet.ReadWoWString("Email", bits273);
-            packet.ReadWoWString("Text", bits338);
+            packet.ReadWoWString_Sanitize("Name", bits16);
+            packet.ReadWoWString_Sanitize("Email", bits273);
+            packet.ReadWoWString_Sanitize("Text", bits338);
         }
 
         [Parser(Opcode.SMSG_RECRUIT_A_FRIEND_RESPONSE)]

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/SessionHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/SessionHandler.cs
@@ -25,7 +25,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var queued = packet.ReadBit("Queued");
             if (ok)
             {
-                packet.ReadUInt32("VirtualRealmAddress");
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress");
                 var realms = packet.ReadUInt32();
                 if (ClientVersion.RemovedInVersion(ClientVersionBuild.V6_2_4_21315))
                 {
@@ -53,14 +53,14 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
                 for (var i = 0; i < realms; ++i)
                 {
-                    packet.ReadUInt32("VirtualRealmAddress", i);
+                    packet.ReadUInt32_Sanitize("VirtualRealmAddress", i);
                     packet.ResetBitReader();
                     packet.ReadBit("IsLocal", i);
                     packet.ReadBit("unk", i);
                     var nameLen1 = packet.ReadBits(8);
                     var nameLen2 = packet.ReadBits(8);
-                    packet.ReadWoWString("RealmNameActual", nameLen1, i);
-                    packet.ReadWoWString("RealmNameNormalized", nameLen2, i);
+                    packet.ReadWoWString_Sanitize("RealmNameActual", nameLen1, i);
+                    packet.ReadWoWString_Sanitize("RealmNameNormalized", nameLen2, i);
                 }
 
                 for (var i = 0; i < races; ++i)
@@ -145,22 +145,22 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         public static void HandleAuthSession(Packet packet)
         {
             var sha = new byte[20];
-            packet.ReadUInt32("Grunt ServerId");
+            packet.ReadUInt32_Sanitize("Grunt ServerId");
             packet.ReadInt16E<ClientVersionBuild>("Client Build");
             packet.ReadUInt32("Region");
             packet.ReadUInt32("Battlegroup");
-            packet.ReadUInt32("RealmIndex");
+            packet.ReadUInt32_Sanitize("RealmIndex");
             packet.ReadByte("Login Server Type");
             packet.ReadByte("Unk");
-            packet.ReadUInt32("Client Seed");
-            packet.ReadUInt64("DosResponse");
+            packet.ReadUInt32_Sanitize("Client Seed");
+            packet.ReadUInt64_Sanitize("DosResponse");
 
             for (uint i = 0; i < 20; ++i)
                 sha[i] = packet.ReadByte();
 
             var accountNameLength = packet.ReadBits("Account Name Length", 11);
             packet.ResetBitReader();
-            packet.ReadWoWString("Account Name", accountNameLength);
+            packet.ReadWoWString_Sanitize("Account Name", accountNameLength);
             packet.ReadBit("UseIPv6");
 
             var addonSize = packet.ReadInt32("Addons Size");
@@ -183,10 +183,10 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             packet.ReadByte("BuildType");
             packet.ReadUInt32("RegionID");
             packet.ReadUInt32("BattlegroupID");
-            packet.ReadUInt32("RealmID");
-            packet.ReadBytes("LocalChallenge", 16);
-            packet.ReadBytes("Digest", 24);
-            packet.ReadUInt64("DosResponse");
+            packet.ReadUInt32_Sanitize("RealmID");
+            packet.ReadBytes_Sanitize("LocalChallenge", 16);
+            packet.ReadBytes_Sanitize("Digest", 24);
+            packet.ReadUInt64_Sanitize("DosResponse");
 
             var addonSize = packet.ReadInt32();
             if (addonSize > 0)
@@ -215,23 +215,23 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         [Parser(Opcode.CMSG_AUTH_CONTINUED_SESSION)]
         public static void HandleRedirectAuthProof(Packet packet)
         {
-            packet.ReadInt64("DosResponse");
-            packet.ReadInt64("Key");
+            packet.ReadInt64_Sanitize("DosResponse");
+            packet.ReadInt64_Sanitize("Key");
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V6_2_4_21315))
             {
-                packet.ReadBytes("LocalChallenge", 16);
-                packet.ReadBytes("Digest", 24);
+                packet.ReadBytes_Sanitize("LocalChallenge", 16);
+                packet.ReadBytes_Sanitize("Digest", 24);
             }
             else
-                packet.ReadBytes("Digest", 20);
+                packet.ReadBytes_Sanitize("Digest", 20);
         }
 
         [Parser(Opcode.SMSG_CONNECT_TO)]
         public static void HandleRedirectClient422(Packet packet)
         {
-            packet.ReadUInt64("Key");
+            packet.ReadUInt64_Sanitize("Key");
             packet.ReadUInt32("Serial");
-            packet.ReadBytes("Where (RSA encrypted)", 256);
+            packet.ReadBytes_Sanitize("Where (RSA encrypted)", 256);
             packet.ReadByte("Con");
         }
 
@@ -241,9 +241,9 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             if (ClientVersion.RemovedInVersion(ClientVersionBuild.V6_2_4_21315))
                 packet.ReadUInt32("Challenge");
             for (uint i = 0; i < 8; ++i)
-                packet.ReadUInt32("DosChallenge", i);
+                packet.ReadUInt32_Sanitize("DosChallenge", i);
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V6_2_4_21315))
-                packet.ReadBytes("Challenge", 16);
+                packet.ReadBytes_Sanitize("Challenge", 16);
             packet.ReadByte("DosZeroBits");
         }
 
@@ -290,13 +290,13 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         [Parser(Opcode.CMSG_QUERY_REALM_NAME)]
         public static void HandleRealmQuery(Packet packet)
         {
-            packet.ReadInt32("VirtualRealmAddress");
+            packet.ReadInt32_Sanitize("VirtualRealmAddress");
         }
 
         [Parser(Opcode.SMSG_REALM_QUERY_RESPONSE)]
         public static void HandleRealmQueryResponse(Packet packet)
         {
-            packet.ReadUInt32("VirtualRealmAddress");
+            packet.ReadUInt32_Sanitize("VirtualRealmAddress");
 
             var state = packet.ReadByte("LookupState");
             if (state == 0)
@@ -310,8 +310,8 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 var bits258 = packet.ReadBits(8);
                 packet.ReadBit();
 
-                packet.ReadWoWString("RealmNameActual", bits2);
-                packet.ReadWoWString("RealmNameNormalized", bits258);
+                packet.ReadWoWString_Sanitize("RealmNameActual", bits2);
+                packet.ReadWoWString_Sanitize("RealmNameNormalized", bits258);
             }
         }
 
@@ -325,21 +325,21 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         [Parser(Opcode.CMSG_CONNECT_TO_FAILED)]
         public static void HandleRedirectFailed(Packet packet)
         {
-            packet.ReadUInt32("Serial");
+            packet.ReadUInt32_Sanitize("Serial");
             packet.ReadSByte("Con");
         }
 
         [Parser(Opcode.CMSG_SUSPEND_TOKEN_RESPONSE)]
         public static void HandleSuspendToken(Packet packet)
         {
-            packet.ReadUInt32("Sequence");
+            packet.ReadUInt32_Sanitize("Sequence");
         }
 
         [Parser(Opcode.SMSG_SUSPEND_TOKEN)]
         [Parser(Opcode.SMSG_RESUME_TOKEN)]
         public static void HandleResumeTokenPacket(Packet packet)
         {
-            packet.ReadUInt32("Sequence");
+            packet.ReadUInt32_Sanitize("Sequence");
             packet.ReadBits("Reason", 2);
         }
 
@@ -353,15 +353,15 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         [Parser(Opcode.SMSG_BATTLENET_CHALLENGE_START)]
         public static void HandleBattlenetChallengeStart(Packet packet)
         {
-            packet.ReadUInt32("Token");
+            packet.ReadUInt32_Sanitize("Token");
             var bits16 = packet.ReadBits(9);
-            packet.ReadWoWString("ChallengeURL", bits16);
+            packet.ReadWoWString_Sanitize("ChallengeURL", bits16);
         }
 
         [Parser(Opcode.CMSG_BATTLENET_CHALLENGE_RESPONSE)]
         public static void HandleBattlenetChallengeResponse(Packet packet)
         {
-            packet.ReadUInt32("Token");
+            packet.ReadUInt32_Sanitize("Token");
             var result = packet.ReadBits(3);
             if (result == 3)
             {
@@ -373,15 +373,15 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         [Parser(Opcode.SMSG_BATTLENET_CHALLENGE_ABORT)]
         public static void HandleBattlenetChallengeAbort(Packet packet)
         {
-            packet.ReadUInt32("Token");
+            packet.ReadUInt32_Sanitize("Token");
             packet.ReadBit("Timeout");
         }
 
         public static void ReadMethodCall(Packet packet, params object[] idx)
         {
             packet.ReadUInt64("Type", idx);
-            packet.ReadUInt64("ObjectId", idx);
-            packet.ReadUInt32("Token", idx);
+            packet.ReadUInt64_Sanitize("ObjectId", idx);
+            packet.ReadUInt32_Sanitize("Token", idx);
         }
 
         [Parser(Opcode.CMSG_BATTLENET_REQUEST)]
@@ -390,7 +390,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             ReadMethodCall(packet, "Method");
 
             int protoSize = packet.ReadInt32();
-            packet.ReadBytesTable("Data", protoSize);
+            packet.ReadBytesTable_Sanitize("Data", protoSize);
         }
 
         [Parser(Opcode.SMSG_BATTLENET_NOTIFICATION)]
@@ -399,7 +399,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             ReadMethodCall(packet, "Method");
 
             int protoSize = packet.ReadInt32();
-            packet.ReadBytesTable("Data", protoSize);
+            packet.ReadBytesTable_Sanitize("Data", protoSize);
         }
 
         [Parser(Opcode.SMSG_BATTLENET_RESPONSE)]
@@ -409,7 +409,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             ReadMethodCall(packet, "Method");
 
             int protoSize = packet.ReadInt32();
-            packet.ReadBytesTable("Data", protoSize);
+            packet.ReadBytesTable_Sanitize("Data", protoSize);
         }
 
         [Parser(Opcode.SMSG_BATTLE_NET_CONNECTION_STATUS)]
@@ -427,18 +427,18 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         [Parser(Opcode.SMSG_CHANGE_REALM_TICKET_RESPONSE)]
         public static void HandleChangeRealmTicketResponse(Packet packet)
         {
-            packet.ReadUInt32("Token");
+            packet.ReadUInt32_Sanitize("Token");
             packet.ResetBitReader();
             packet.ReadBit("Allow");
 
             int protoSize = packet.ReadInt32();
-            packet.ReadBytesTable("Data", protoSize);
+            packet.ReadBytesTable_Sanitize("Data", protoSize);
         }
 
         [Parser(Opcode.CMSG_CHANGE_REALM_TICKET)]
         public static void HandleChangeRealmTicket(Packet packet)
         {
-            packet.ReadUInt32("Token");
+            packet.ReadUInt32_Sanitize("Token");
             packet.ReadBytes("Secret", 32);
         }
     }

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/TicketHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/TicketHandler.cs
@@ -26,19 +26,19 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var int24 = packet.ReadInt32("CasesCount");
             for (int i = 0; i < int24; i++)
             {
-                packet.ReadInt32("CaseID", i);
+                packet.ReadInt32_Sanitize("CaseID", i);
                 packet.ReadInt32("CaseOpened", i);
                 packet.ReadInt32("CaseStatus", i);
-                packet.ReadInt16("CfgRealmID", i);
-                packet.ReadInt64("CharacterID", i);
+                packet.ReadInt16_Sanitize("CfgRealmID", i);
+                packet.ReadInt64_Sanitize("CharacterID", i);
                 packet.ReadInt32("WaitTimeOverrideMinutes", i);
 
                 packet.ResetBitReader();
                 var bits12 = packet.ReadBits(11);
                 var bits262 = packet.ReadBits(10);
 
-                packet.ReadWoWString("Url", bits12, i);
-                packet.ReadWoWString("WaitTimeOverrideMessage", bits262, i);
+                packet.ReadWoWString_Sanitize("Url", bits12, i);
+                packet.ReadWoWString_Sanitize("WaitTimeOverrideMessage", bits262, i);
             }
         }
 
@@ -58,7 +58,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             // ClientGMTicketInfo
             if (hasInfo)
             {
-                packet.ReadInt32("TicketID");
+                packet.ReadInt32_Sanitize("TicketID");
                 packet.ReadByte("Category");
                 packet.ReadTime("TicketOpenTime");
                 packet.ReadTime("OldestTicketTime");
@@ -72,27 +72,27 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
                 var bits1 = packet.ReadBits(11);
                 var bits2022 = packet.ReadBits(10);
 
-                packet.ReadWoWString("TicketDescription", bits1);
-                packet.ReadWoWString("WaitTimeOverrideMessage", bits2022);
+                packet.ReadWoWString_Sanitize("TicketDescription", bits1);
+                packet.ReadWoWString_Sanitize("WaitTimeOverrideMessage", bits2022);
             }
         }
 
         public static void ReadComplaintOffender(Packet packet, params object[] indexes)
         {
             packet.ReadPackedGuid128("PlayerGuid", indexes);
-            packet.ReadInt32("RealmAddress", indexes);
+            packet.ReadInt32_Sanitize("RealmAddress", indexes);
             packet.ReadInt32("TimeSinceOffence", indexes);
         }
 
         public static void ReadComplaintChat(Packet packet, params object[] indexes)
         {
-            packet.ReadInt32("Command");
-            packet.ReadInt32("ChannelID");
+            packet.ReadInt32_Sanitize("Command");
+            packet.ReadInt32_Sanitize("ChannelID");
 
             packet.ResetBitReader();
 
             var len = packet.ReadBits(12);
-            packet.ReadWoWString("MessageLog", len);
+            packet.ReadWoWString_Sanitize("MessageLog", len);
         }
 
         [Parser(Opcode.CMSG_COMPLAINT)]
@@ -105,15 +105,15 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             switch (result)
             {
                 case 0: // Mail
-                    packet.ReadInt32("MailID");
+                    packet.ReadInt32_Sanitize("MailID");
                     break;
                 case 1: // Chat
                     ReadComplaintChat(packet, "Chat");
                     break;
                 case 2: // Calendar
                     // Order guessed
-                    packet.ReadInt64("EventGuid");
-                    packet.ReadInt64("InviteGuid");
+                    packet.ReadInt64_Sanitize("EventGuid");
+                    packet.ReadInt64_Sanitize("InviteGuid");
                     break;
             }
         }
@@ -121,7 +121,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         [Parser(Opcode.CMSG_GM_TICKET_ACKNOWLEDGE_SURVEY)]
         public static void HandleGMTicketAcknowledgeSurvey(Packet packet)
         {
-            packet.ReadInt32("CaseID");
+            packet.ReadInt32_Sanitize("CaseID");
         }
 
         [Parser(Opcode.CMSG_GM_TICKET_CREATE)]
@@ -133,7 +133,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             var descriptionLength = packet.ReadBits("DescriptionLength", 11);
             packet.ResetBitReader();
-            packet.ReadWoWString("Description", descriptionLength);
+            packet.ReadWoWString_Sanitize("Description", descriptionLength);
 
             packet.ReadBit("NeedResponse");
             packet.ReadBit("NeedMoreHelp");
@@ -150,7 +150,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
                 var decompCount = packet.ReadInt32();
                 var pkt = packet.Inflate(decompCount);
-                pkt.ReadCString("Text");
+                pkt.ReadCString_Sanitize("Text");
                 pkt.ClosePacket(false);
             }
         }
@@ -161,25 +161,25 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             var length = packet.ReadBits("DescriptionLength", 11);
             packet.ResetBitReader();
 
-            packet.ReadWoWString("Description", length);
+            packet.ReadWoWString_Sanitize("Description", length);
         }
 
         public static void ReadClientGMSurveyQuestion(Packet packet, params object[] idx)
         {
-            packet.ReadInt32("QuestionID", idx);
+            packet.ReadInt32_Sanitize("QuestionID", idx);
             packet.ReadByte("Answer", idx);
 
             packet.ResetBitReader();
             var length = packet.ReadBits("AnswerCommentLength", 11, idx);
             packet.ResetBitReader();
 
-            packet.ReadWoWString("AnswerComment", length, idx);
+            packet.ReadWoWString_Sanitize("AnswerComment", length, idx);
         }
 
         [Parser(Opcode.CMSG_GM_SURVEY_SUBMIT)]
         public static void HandleGMSurveySubmit(Packet packet)
         {
-            packet.ReadInt32("SurveyID");
+            packet.ReadInt32_Sanitize("SurveyID");
 
             var questionCount = packet.ReadBits("SurveyQuestionCount", 4);
             var commentLenght = packet.ReadBits("CommentLength", 11);
@@ -189,7 +189,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             for (var i = 0; i < questionCount; ++i)
                 ReadClientGMSurveyQuestion(packet, "SurveyQuestion", i);
 
-            packet.ReadWoWString("Comment", commentLenght);
+            packet.ReadWoWString_Sanitize("Comment", commentLenght);
         }
 
         public static void ReadCliSupportTicketHeader(Packet packet, params object[] idx)
@@ -207,7 +207,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             var noteLength = packet.ReadBits("NoteLength", 10);
             packet.ResetBitReader();
-            packet.ReadWoWString("Note", noteLength);
+            packet.ReadWoWString_Sanitize("Note", noteLength);
         }
 
         public static void ReadCliSupportTicketChatLine(Packet packet, params object[] idx)
@@ -216,7 +216,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
                 var textLength = packet.ReadBits("TextLength", 12, idx);
                 packet.ResetBitReader();
-                packet.ReadWoWString("Text", textLength, idx);
+                packet.ReadWoWString_Sanitize("Text", textLength, idx);
         }
 
         public static void ReadCliSupportTicketChatLog(Packet packet, params object[] idx)
@@ -234,21 +234,21 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
         public static void ReadCliSupportTicketMailInfo(Packet packet, params object[] idx)
         {
-            packet.ReadInt32("MailID", idx);
+            packet.ReadInt32_Sanitize("MailID", idx);
 
             var bodyLength = packet.ReadBits("MailBodyLength", 13, idx);
             var subjectLength = packet.ReadBits("MailSubjectLength", 9, idx);
 
             packet.ResetBitReader();
 
-            packet.ReadWoWString("MailBody", bodyLength, idx);
-            packet.ReadWoWString("MailSubject", subjectLength, idx);
+            packet.ReadWoWString_Sanitize("MailBody", bodyLength, idx);
+            packet.ReadWoWString_Sanitize("MailSubject", subjectLength, idx);
         }
 
         public static void ReadCliSupportTicketCalendarEventInfo(Packet packet, params object[] idx)
         {
-            packet.ReadUInt64("EventID", idx); // order not confirmed
-            packet.ReadUInt64("InviteID", idx); // order not confirmed
+            packet.ReadUInt64_Sanitize("EventID", idx); // order not confirmed
+            packet.ReadUInt64_Sanitize("InviteID", idx); // order not confirmed
 
             var eventTitleLength = packet.ReadBits("EventTitleLength", 8, idx);
 
@@ -265,7 +265,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             packet.ResetBitReader();
 
-            packet.ReadWoWString("PetName", petNameLength, idx);
+            packet.ReadWoWString_Sanitize("PetName", petNameLength, idx);
         }
 
         public static void ReadCliSupportTicketGuildInfo(Packet packet, params object[] idx)
@@ -276,7 +276,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             packet.ResetBitReader();
 
-            packet.ReadWoWString("GuildName", guildNameLength, idx);
+            packet.ReadWoWString_Sanitize("GuildName", guildNameLength, idx);
         }
 
         public static void ReadCliSupportTicketLFGListSearchResult(Packet packet, params object[] idx)
@@ -293,9 +293,9 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             packet.ResetBitReader();
 
-            packet.ReadWoWString("Title", titleLength, idx);
-            packet.ReadWoWString("Description", descriptionLength, idx);
-            packet.ReadWoWString("VoiceChat", voiceChatLength, idx);
+            packet.ReadWoWString_Sanitize("Title", titleLength, idx);
+            packet.ReadWoWString_Sanitize("Description", descriptionLength, idx);
+            packet.ReadWoWString_Sanitize("VoiceChat", voiceChatLength, idx);
         }
 
         public static void ReadCliSupportTicketLFGListApplicant(Packet packet, params object[] idx)
@@ -304,7 +304,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
 
             var length = packet.ReadBits(9);
             packet.ResetBitReader();
-            packet.ReadWoWString("Comment", length, idx);
+            packet.ReadWoWString_Sanitize("Comment", length, idx);
         }
 
         [Parser(Opcode.CMSG_SUPPORT_TICKET_SUBMIT_COMPLAINT)]
@@ -379,14 +379,14 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         {
             // TODO: confirm order
 
-            packet.ReadUInt32("TicketID");
-            packet.ReadUInt32("ResponseID");
+            packet.ReadUInt32_Sanitize("TicketID");
+            packet.ReadUInt32_Sanitize("ResponseID");
 
             var descriptionLength = packet.ReadBits(11);
             var responseTextLength = packet.ReadBits(14);
 
-            packet.ReadWoWString("Description", descriptionLength);
-            packet.ReadWoWString("ResponseText", responseTextLength);
+            packet.ReadWoWString_Sanitize("Description", descriptionLength);
+            packet.ReadWoWString_Sanitize("ResponseText", responseTextLength);
         }
 
     }

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/AuthenticationHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/AuthenticationHandler.cs
@@ -14,7 +14,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ReadByte("BuildType");
             packet.ReadUInt32("RegionID");
             packet.ReadUInt32("BattlegroupID");
-            packet.ReadUInt32("RealmID");
+            packet.ReadUInt32_Sanitize("RealmID");
             packet.ReadBytes("LocalChallenge", 16);
             packet.ReadBytes("Digest", 24);
             packet.ReadBit("UseIPv6");
@@ -32,7 +32,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             var queued = packet.ReadBit("Queued");
             if (ok)
             {
-                packet.ReadUInt32("VirtualRealmAddress");
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress");
                 var realms = packet.ReadUInt32();
                 packet.ReadUInt32("TimeRested");
                 packet.ReadByte("ActiveExpansionLevel");
@@ -87,14 +87,14 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
                 for (var i = 0; i < realms; ++i)
                 {
-                    packet.ReadUInt32("RealmAddress", "VirtualRealms", i);
+                    packet.ReadUInt32_Sanitize("RealmAddress", "VirtualRealms", i);
                     packet.ResetBitReader();
                     packet.ReadBit("IsLocal", "VirtualRealms", i);
                     packet.ReadBit("IsInternalRealm", "VirtualRealms", i);
                     var nameLen1 = packet.ReadBits(8);
                     var nameLen2 = packet.ReadBits(8);
-                    packet.ReadWoWString("RealmNameActual", nameLen1, "VirtualRealms", i);
-                    packet.ReadWoWString("RealmNameNormalized", nameLen2, "VirtualRealms", i);
+                    packet.ReadWoWString_Sanitize("RealmNameActual", nameLen1, "VirtualRealms", i);
+                    packet.ReadWoWString_Sanitize("RealmNameNormalized", nameLen2, "VirtualRealms", i);
                 }
 
                 for (var i = 0; i < templates; ++i)

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/BattlePetHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/BattlePetHandler.cs
@@ -32,7 +32,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             var hasOwnerInfo = packet.ReadBit("HasOwnerInfo", idx);
             packet.ReadBit("NoRename", idx);
 
-            packet.ReadWoWString("CustomName", customNameLength, idx);
+            packet.ReadWoWString_Sanitize("CustomName", customNameLength, idx);
 
             if (hasOwnerInfo)
                 V6_0_2_19033.Parsers.BattlePetHandler.ReadClientBattlePetOwnerInfo(packet, "OwnerInfo", idx);
@@ -105,10 +105,10 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                     declinedNamesLen[i] = packet.ReadBits(7);
 
                 for (int i = 0; i < 5; i++)
-                    packet.ReadWoWString("DeclinedNames", declinedNamesLen[i]);
+                    packet.ReadWoWString_Sanitize("DeclinedNames", declinedNamesLen[i]);
             }
 
-            packet.ReadWoWString("Name", nameLen);
+            packet.ReadWoWString_Sanitize("Name", nameLen);
         }
 
         [Parser(Opcode.CMSG_BATTLE_PET_CLEAR_FANFARE)]

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/CharacterHandler.cs
@@ -65,7 +65,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ReadBit("BoostInProgress", idx);
             packet.ReadBits("UnkWod61x", 5, idx);
 
-            packet.ReadWoWString("Character Name", nameLength, idx);
+            packet.ReadWoWString_Sanitize("Character Name", nameLength, idx);
 
             if (firstLogin)
             {
@@ -147,7 +147,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             for (var i = 0; i < 3; i++)
                 packet.ReadByte("CustomDisplay", i);
 
-            packet.ReadWoWString("Name", nameLen);
+            packet.ReadWoWString_Sanitize("Name", nameLen);
 
             if (hasTemplateSet)
                 packet.ReadInt32("TemplateSetID");
@@ -305,7 +305,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
             packet.ResetBitReader();
             var bits19 = packet.ReadBits(6);
-            packet.ReadWoWString("CharName", bits19);
+            packet.ReadWoWString_Sanitize("CharName", bits19);
         }
 
 
@@ -326,7 +326,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ReadByte("FaceID");
             for (uint i = 0; i < 3; ++i)
                 packet.ReadByte("CustomDisplay", i);
-            packet.ReadWoWString("Name", bits20);
+            packet.ReadWoWString_Sanitize("Name", bits20);
         }
 
         [Parser(Opcode.SMSG_CHAR_FACTION_CHANGE_RESULT)]
@@ -353,7 +353,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
                 for (uint i = 0; i < 3; ++i)
                     packet.ReadByte("CustomDisplay", i);
-                packet.ReadWoWString("Name", bits55);
+                packet.ReadWoWString_Sanitize("Name", bits55);
             }
         }
 
@@ -372,7 +372,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
             packet.ResetBitReader();
             var bits55 = packet.ReadBits(6);
-            packet.ReadWoWString("Name", bits55);
+            packet.ReadWoWString_Sanitize("Name", bits55);
         }
     }
 }

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/ChatHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/ChatHandler.cs
@@ -41,7 +41,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
         {
             packet.ReadInt32E<Language>("Language");
             var len = packet.ReadBits(9);
-            packet.ReadWoWString("Text", len);
+            packet.ReadWoWString_Sanitize("Text", len);
         }
 
         [Parser(Opcode.CMSG_CHAT_MESSAGE_CHANNEL)]
@@ -52,9 +52,9 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 packet.ReadPackedGuid128("ChannelGUID");
             var channelNameLen = packet.ReadBits(9);
             var msgLen = packet.ReadBits(9);
-
-            packet.ReadWoWString("Target", channelNameLen);
-            packet.ReadWoWString("Text", msgLen);
+            packet.ResetBitReader();
+            packet.ReadWoWString("Channel Name", channelNameLen);
+            packet.ReadWoWString_Sanitize("Message", msgLen);
         }
 
         [Parser(Opcode.CMSG_CHAT_MESSAGE_WHISPER)]
@@ -64,8 +64,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             var recvName = packet.ReadBits(9);
             var msgLen = packet.ReadBits(9);
 
-            packet.ReadWoWString("Target", recvName);
-            packet.ReadWoWString("Text", msgLen);
+            packet.ReadWoWString_Sanitize("Target", recvName);
+            packet.ReadWoWString_Sanitize("Text", msgLen);
         }
 
         [Parser(Opcode.CMSG_CHAT_MESSAGE_DND)]

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/GarrisonHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/GarrisonHandler.cs
@@ -62,7 +62,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ResetBitReader();
 
             var len = packet.ReadBits(7);
-            packet.ReadWoWString("CustomName", len, indexes);
+            packet.ReadWoWString_Sanitize("CustomName", len, indexes);
         }
 
         public static void ReadGarrisonTalents(Packet packet, params object[] indexes)
@@ -497,10 +497,10 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
         [Parser(Opcode.CMSG_GARRISON_RENAME_FOLLOWER)]
         public static void HandleGarrisonRenameFollower(Packet packet)
         {
-            packet.ReadUInt64("FollowerDbId");
+            packet.ReadUInt64_Sanitize("FollowerDbId");
             var followerNewNameLength = packet.ReadBits("FollowerNewNameLength", 7);
             packet.ResetBitReader();
-            packet.ReadWoWString("FollowerNewName", followerNewNameLength);
+            packet.ReadWoWString_Sanitize("FollowerNewName", followerNewNameLength);
         }
 
         [Parser(Opcode.CMSG_GARRISON_SET_RECRUITMENT_PREFERENCES)]

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/GroupHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/GroupHandler.cs
@@ -36,7 +36,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ResetBitReader();
 
             var len = packet.ReadBits(8);
-            packet.ReadWoWString("PetName", len, index);
+            packet.ReadWoWString_Sanitize("PetName", len, index);
         }
 
         [Parser(Opcode.SMSG_PARTY_MEMBER_FULL_STATE)]
@@ -115,8 +115,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 packet.ReadPackedGuid128("TargetGuid");
             }
 
-            packet.ReadWoWString("TargetName", lenTargetName);
-            packet.ReadWoWString("TargetRealm", lenTargetRealm);
+            packet.ReadWoWString_Sanitize("TargetName", lenTargetName);
+            packet.ReadWoWString_Sanitize("TargetRealm", lenTargetRealm);
         }
 
         [Parser(Opcode.SMSG_PARTY_INVITE)]
@@ -130,13 +130,13 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             var len = packet.ReadBits(6);
 
             packet.ResetBitReader();
-            packet.ReadInt32("InviterVirtualRealmAddress");
+            packet.ReadInt32_Sanitize("InviterVirtualRealmAddress");
             packet.ReadBit("IsLocal");
             packet.ReadBit("Unk2");
             var bits2 = packet.ReadBits(8);
             var bits258 = packet.ReadBits(8);
-            packet.ReadWoWString("InviterRealmNameActual", bits2);
-            packet.ReadWoWString("InviterRealmNameNormalized", bits258);
+            packet.ReadWoWString_Sanitize("InviterRealmNameActual", bits2);
+            packet.ReadWoWString_Sanitize("InviterRealmNameNormalized", bits258);
 
             packet.ReadPackedGuid128("InviterGuid");
             packet.ReadPackedGuid128("InviterBNetAccountID");
@@ -144,7 +144,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ReadInt32("ProposedRoles");
             var lfgSlots = packet.ReadInt32();
             packet.ReadInt32("LfgCompletedMask");
-            packet.ReadWoWString("InviterName", len);
+            packet.ReadWoWString_Sanitize("InviterName", len);
             for (int i = 0; i < lfgSlots; i++)
                 packet.ReadInt32("LfgSlots", i);
         }
@@ -181,7 +181,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 packet.ReadByte("RolesAssigned", i);
                 packet.ReadByteE<Class>("Class", i);
 
-                packet.ReadWoWString("Name", playerNameLength, i);
+                packet.ReadWoWString_Sanitize("Name", playerNameLength, i);
             }
 
             packet.ResetBitReader();
@@ -255,7 +255,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 {
                     packet.ResetBitReader();
                     var len = packet.ReadBits(8);
-                    packet.ReadWoWString("NewPetName", len, "Pet");
+                    packet.ReadWoWString_Sanitize("NewPetName", len, "Pet");
                 }
                 if (petGuidChanged)
                     packet.ReadPackedGuid128("NewPetGuid", "Pet");

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/GuildHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/GuildHandler.cs
@@ -15,7 +15,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             if (hasData)
             {
                 packet.ReadPackedGuid128("GuildGUID");
-                packet.ReadInt32("VirtualRealmAddress");
+                packet.ReadInt32_Sanitize("VirtualRealmAddress");
                 var rankCount = packet.ReadInt32("RankCount");
                 packet.ReadInt32("EmblemColor");
                 packet.ReadInt32("EmblemStyle");
@@ -33,10 +33,10 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
                     packet.ResetBitReader();
                     var rankNameLen = packet.ReadBits(7);
-                    packet.ReadWoWString("Rank Name", rankNameLen, i);
+                    packet.ReadWoWString_Sanitize("Rank Name", rankNameLen, i);
                 }
 
-                packet.ReadWoWString("Guild Name", nameLen);
+                packet.ReadWoWString_Sanitize("Guild Name", nameLen);
             }
         }
 
@@ -70,7 +70,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                     packet.ReadUInt32("Step", i, j);
                 }
 
-                packet.ReadUInt32("VirtualRealmAddress", i);
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress", i);
 
                 packet.ReadByteE<GuildMemberFlag>("Status", i);
                 packet.ReadByte("Level", i);
@@ -86,9 +86,9 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 packet.ReadBit("Authenticated", i);
                 packet.ReadBit("SorEligible", i);
 
-                packet.ReadWoWString("Name", bits36, i);
-                packet.ReadWoWString("Note", bits92, i);
-                packet.ReadWoWString("OfficerNote", bits221, i);
+                packet.ReadWoWString_Sanitize("Name", bits36, i);
+                packet.ReadWoWString_Sanitize("Note", bits92, i);
+                packet.ReadWoWString_Sanitize("OfficerNote", bits221, i);
             }
 
             packet.ReadWoWString("WelcomeText", bits2037);

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/HotfixHandler.cs
@@ -131,7 +131,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
         [Parser(Opcode.SMSG_AVAILABLE_HOTFIXES)]
         public static void HandleHotfixList(Packet packet)
         {
-            packet.ReadInt32("VirtualRealmAddress");
+            packet.ReadInt32_Sanitize("VirtualRealmAddress");
             var hotfixCount = packet.ReadUInt32("HotfixCount");
             for (var i = 0u; i < hotfixCount; ++i)
             {

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/InstanceHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/InstanceHandler.cs
@@ -72,7 +72,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 packet.ReadInt16("BottomOffset", i);
                 packet.ReadInt16("LeftOffset", i);
 
-                packet.ReadWoWString("Name", strlen, i);
+                packet.ReadWoWString_Sanitize("Name", strlen, i);
             }
         }
 

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/LfgHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/LfgHandler.cs
@@ -51,7 +51,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V7_3_0_24920))
                 packet.ReadPackedGuid128("LastTouchedVoiceChat", idx);
 
-            packet.ReadUInt32("VirtualRealmAddress", idx);
+            packet.ReadUInt32_Sanitize("VirtualRealmAddress", idx);
 
             var bnetFriendCount = packet.ReadUInt32();
             var characterFriendCount = packet.ReadUInt32();
@@ -301,7 +301,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 packet.ReadPackedGuid128("Leader", idx);
 
             if (hasVirtualRealmAddress)
-                packet.ReadUInt32("VirtualRealmAddress", idx);
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress", idx);
 
             if (hasCompletedEncountersMask)
                 packet.ReadUInt32("CompletedEncountersMask", idx);
@@ -343,7 +343,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 for (int j = 0; j < memberCount; j++)
                 {
                     packet.ReadPackedGuid128("Guid", i, j);
-                    packet.ReadUInt32("VirtualRealmAddress", i, j);
+                    packet.ReadUInt32_Sanitize("VirtualRealmAddress", i, j);
                     packet.ReadSingle("ItemLevel", i, j);
                     packet.ReadUInt32("Level", i, j);
                     packet.ReadInt32("HonorLevel", i, j);

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/MiscellaneousHandler.cs
@@ -143,8 +143,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
             packet.ReadUInt32("ScrollOfResurrectionRequestsRemaining");
             packet.ReadUInt32("ScrollOfResurrectionMaxRequestsPerDay");
-            packet.ReadUInt32("CfgRealmID");
-            packet.ReadInt32("CfgRealmRecID");
+            packet.ReadUInt32_Sanitize("CfgRealmID");
+            packet.ReadInt32_Sanitize("CfgRealmRecID");
             packet.ReadUInt32("TwitterPostThrottleLimit");
             packet.ReadUInt32("TwitterPostThrottleCooldown");
             packet.ReadUInt32("TokenPollTimeSeconds");
@@ -224,8 +224,8 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
 
             packet.ReadUInt32("ScrollOfResurrectionRequestsRemaining");
             packet.ReadUInt32("ScrollOfResurrectionMaxRequestsPerDay");
-            packet.ReadUInt32("CfgRealmID");
-            packet.ReadInt32("CfgRealmRecID");
+            packet.ReadUInt32_Sanitize("CfgRealmID");
+            packet.ReadInt32_Sanitize("CfgRealmRecID");
             packet.ReadUInt32("TwitterPostThrottleLimit");
             packet.ReadUInt32("TwitterPostThrottleCooldown");
             packet.ReadUInt32("TokenPollTimeSeconds");

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/SpellHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/SpellHandler.cs
@@ -168,7 +168,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
                 }
             }
 
-            packet.ReadWoWString("Name", nameLength, idx);
+            packet.ReadWoWString_Sanitize("Name", nameLength, idx);
         }
 
         public static void ReadRuneData(Packet packet, params object[] idx)
@@ -557,7 +557,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
         {
             packet.ReadPackedGuid128("ResurrectOffererGUID");
 
-            packet.ReadUInt32("ResurrectOffererVirtualRealmAddress");
+            packet.ReadUInt32_Sanitize("ResurrectOffererVirtualRealmAddress");
             packet.ReadUInt32("PetNumber");
             packet.ReadInt32<SpellId>("SpellID");
 
@@ -566,7 +566,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             packet.ReadBit("UseTimer");
             packet.ReadBit("Sickness");
 
-            packet.ReadWoWString("Name", len);
+            packet.ReadWoWString_Sanitize("Name", len);
         }
 
         [Parser(Opcode.SMSG_TOTEM_CREATED, ClientVersionBuild.V7_1_0_22900)]

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/AccountDataHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/AccountDataHandler.cs
@@ -10,7 +10,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         {
             packet.ReadPackedGuid128("WowAccountGUID", idx);
             packet.ReadPackedGuid128("CharacterGUID", idx);
-            packet.ReadUInt32("VirtualRealmAddress", idx);
+            packet.ReadUInt32_Sanitize("VirtualRealmAddress", idx);
             packet.ReadByteE<Race>("Race" ,idx);
             packet.ReadByteE<Class>("Class", idx);
             packet.ReadByteE<Gender>("Gender", idx);
@@ -27,8 +27,8 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             uint characterNameLength = packet.ReadBits(6);
             uint realmNameLength = packet.ReadBits(9);
 
-            packet.ReadWoWString("CharacterName", characterNameLength, idx);
-            packet.ReadWoWString("RealmName", realmNameLength, idx);
+            packet.ReadWoWString_Sanitize("CharacterName", characterNameLength, idx);
+            packet.ReadWoWString_Sanitize("RealmName", realmNameLength, idx);
         }
 
         [Parser(Opcode.SMSG_GET_ACCOUNT_CHARACTER_LIST_RESULT)]

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/AchievementHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/AchievementHandler.cs
@@ -24,7 +24,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 hasRafAcceptanceID = packet.ReadBit();
 
             if (hasRafAcceptanceID)
-                packet.ReadUInt64("RafAcceptanceID");
+                packet.ReadUInt64_Sanitize("RafAcceptanceID");
 
             if (Settings.UseDBC)
                 if (DBC.Criteria.ContainsKey(criteriaId))

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/AuthenticationHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/AuthenticationHandler.cs
@@ -12,13 +12,13 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             packet.ReadUInt64("DosResponse");
             packet.ReadUInt32("RegionID");
             packet.ReadUInt32("BattlegroupID");
-            packet.ReadUInt32("RealmID");
-            packet.ReadBytes("LocalChallenge", 16);
-            packet.ReadBytes("Digest", 24);
+            packet.ReadUInt32_Sanitize("RealmID");
+            packet.ReadBytes_Sanitize("LocalChallenge", 16);
+            packet.ReadBytes_Sanitize("Digest", 24);
             packet.ReadBit("UseIPv6");
 
             var realmJoinTicketSize = packet.ReadInt32();
-            packet.ReadBytes("RealmJoinTicket", realmJoinTicketSize);
+            packet.ReadBytes_Sanitize("RealmJoinTicket", realmJoinTicketSize);
         }
 
         [Parser(Opcode.SMSG_AUTH_RESPONSE)]
@@ -30,7 +30,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             var queued = packet.ReadBit("Queued");
             if (ok)
             {
-                packet.ReadUInt32("VirtualRealmAddress");
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress");
                 var realms = packet.ReadUInt32();
                 packet.ReadUInt32("TimeRested");
                 packet.ReadByte("ActiveExpansionLevel");
@@ -96,7 +96,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
 
                 for (var i = 0; i < realms; ++i)
                 {
-                    packet.ReadUInt32("RealmAddress", "VirtualRealms", i);
+                    packet.ReadUInt32_Sanitize("RealmAddress", "VirtualRealms", i);
                     packet.ResetBitReader();
                     packet.ReadBit("IsLocal", "VirtualRealms", i);
                     packet.ReadBit("IsInternalRealm", "VirtualRealms", i);
@@ -108,8 +108,8 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
 
                     var nameLen1 = packet.ReadBits(bitsCount);
                     var nameLen2 = packet.ReadBits(bitsCount);
-                    packet.ReadWoWString("RealmNameActual", nameLen1, "VirtualRealms", i);
-                    packet.ReadWoWString("RealmNameNormalized", nameLen2, "VirtualRealms", i);
+                    packet.ReadWoWString_Sanitize("RealmNameActual", nameLen1, "VirtualRealms", i);
+                    packet.ReadWoWString_Sanitize("RealmNameNormalized", nameLen2, "VirtualRealms", i);
                 }
 
                 for (var i = 0; i < templates; ++i)

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/CalendarHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/CalendarHandler.cs
@@ -37,7 +37,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             packet.ReadInt32("Flags", indexes);
             packet.ReadInt32("TextureID", indexes);
 
-            packet.ReadUInt64("CommunityID", indexes);
+            packet.ReadUInt64_Sanitize("CommunityID", indexes);
             packet.ReadPackedGuid128("OwnerGUID", indexes);
 
             packet.ResetBitReader();

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/ChannelHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/ChannelHandler.cs
@@ -49,7 +49,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             packet.ResetBitReader();
 
             packet.ReadWoWString("ChannelName", channelLength);
-            packet.ReadWoWString("Password", passwordLength);
+            packet.ReadWoWString_Sanitize("Password", passwordLength);
         }
 
         [Parser(Opcode.CMSG_CHAT_MESSAGE_GUILD, ClientVersionBuild.V8_1_0_28724)]
@@ -61,7 +61,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         {
             packet.ReadInt32E<Language>("Language");
             var len = packet.ReadBits(10);
-            packet.ReadWoWString("Text", len);
+            packet.ReadWoWString_Sanitize("Text", len);
         }
 
         [Parser(Opcode.CMSG_CHAT_MESSAGE_WHISPER, ClientVersionBuild.V8_1_0_28724)]
@@ -71,8 +71,8 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             var recvName = packet.ReadBits(9);
             var msgLen = packet.ReadBits(10);
 
-            packet.ReadWoWString("Target", recvName);
-            packet.ReadWoWString("Text", msgLen);
+            packet.ReadWoWString_Sanitize("Target", recvName);
+            packet.ReadWoWString_Sanitize("Text", msgLen);
         }
     }
 }

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/CharacterHandler.cs
@@ -88,7 +88,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             packet.ReadByteE<Class>("ClassID", idx);
             for (int i = 0; i < 3; i++)
                 packet.ReadByte("CustomDisplay", idx);
-            packet.ReadWoWString("Name", nameLen, idx);
+            packet.ReadWoWString_Sanitize("Name", nameLen, idx);
 
             for (int i = 0; i < itemCount; i++)
                 ReadInspectItemData(packet, idx, i);
@@ -107,14 +107,14 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 count[i] = (int)packet.ReadBits(7);
 
             for (var i = 0; i < 5; ++i)
-                packet.ReadWoWString("Name Declined", count[i], i, idx);
+                packet.ReadWoWString_Sanitize("Name Declined", i, idx);
 
             packet.ReadPackedGuid128("AccountID", idx);
             packet.ReadPackedGuid128("BnetAccountID", idx);
             packet.ReadPackedGuid128("Player Guid", idx);
 
-            packet.ReadUInt64("GuildClubMemberID", idx);
-            packet.ReadUInt32("VirtualRealmAddress", idx);
+            packet.ReadUInt64_Sanitize("GuildClubMemberID");
+            packet.ReadUInt32_Sanitize("VirtualRealmAddress");
 
             data.Race = packet.ReadByteE<Race>("Race", idx);
             data.Gender = packet.ReadByteE<Gender>("Gender", idx);
@@ -124,7 +124,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_1_5_40772))
                 packet.ReadByte("Unused915", idx);
 
-            data.Name = packet.ReadWoWString("Name", bits15, idx);
+            data.Name = packet.ReadWoWString_Sanitize("Name", bits15);
 
             return data;
         }
@@ -154,7 +154,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         {
             packet.ReadPackedGuid128("Guid", idx);
 
-            packet.ReadUInt64("GuildClubMemberID", idx);
+            packet.ReadUInt64_Sanitize("GuildClubMemberID", idx);
 
             packet.ReadByte("ListPosition", idx);
             var race = packet.ReadByteE<Race>("RaceID", idx);
@@ -218,7 +218,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 if (mailSenderLengths[j] > 1)
                     packet.ReadDynamicString("MailSender", mailSenderLengths[j], idx);
 
-            packet.ReadWoWString("Character Name", nameLength, idx);
+            packet.ReadWoWString_Sanitize("Character Name", nameLength, idx);
 
             if (firstLogin)
             {
@@ -402,7 +402,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             for (var i = 0; i < 3; i++)
                 packet.ReadByte("CustomDisplay", i);
 
-            packet.ReadWoWString("Name", nameLen);
+            packet.ReadWoWString_Sanitize("Name", nameLen);
 
             if (hasTemplateSet)
                 packet.ReadInt32("TemplateSetID");

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/GroupHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/GroupHandler.cs
@@ -46,7 +46,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_2_5_43903))
                     packet.ReadByte("FactionGroup", i);
 
-                packet.ReadWoWString("Name", playerNameLength, i);
+                packet.ReadWoWString_Sanitize("Name", playerNameLength, i);
                 packet.ReadDynamicString("VoiceStateID", voiceStateLength, i);
             }
 

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/GuildHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/GuildHandler.cs
@@ -17,7 +17,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             if (hasData)
             {
                 packet.ReadPackedGuid128("GuildGUID");
-                packet.ReadInt32("VirtualRealmAddress");
+                packet.ReadInt32_Sanitize("VirtualRealmAddress");
                 var rankCount = packet.ReadInt32("RankCount");
                 packet.ReadInt32("EmblemColor");
                 packet.ReadInt32("EmblemStyle");
@@ -35,10 +35,10 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
 
                     packet.ResetBitReader();
                     var rankNameLen = packet.ReadBits(7);
-                    packet.ReadWoWString("Rank Name", rankNameLen, i);
+                    packet.ReadWoWString_Sanitize("Rank Name", rankNameLen, i);
                 }
 
-                packet.ReadWoWString("Guild Name", nameLen);
+                packet.ReadWoWString_Sanitize("Guild Name", nameLen);
             }
         }
 
@@ -76,7 +76,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                     packet.ReadUInt32("Step", i, j);
                 }
 
-                packet.ReadUInt32("VirtualRealmAddress", i);
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress", i);
 
                 packet.ReadByteE<GuildMemberFlag>("Status", i);
                 packet.ReadByte("Level", i);
@@ -92,13 +92,13 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 packet.ReadBit("Authenticated", i);
                 packet.ReadBit("SorEligible", i);
 
-                packet.ReadWoWString("Name", nameLen, i);
-                packet.ReadWoWString("Note", noteLen, i);
-                packet.ReadWoWString("OfficerNote", officersNoteLen, i);
+                packet.ReadWoWString_Sanitize("Name", nameLen, i);
+                packet.ReadWoWString_Sanitize("Note", noteLen, i);
+                packet.ReadWoWString_Sanitize("OfficerNote", officersNoteLen, i);
             }
 
-            packet.ReadWoWString("WelcomeText", welcomeTextLen);
-            packet.ReadWoWString("InfoText", infoTextLen);
+            packet.ReadWoWString_Sanitize("WelcomeText", welcomeTextLen);
+            packet.ReadWoWString_Sanitize("InfoText", infoTextLen);
         }
 
         [Parser(Opcode.SMSG_GUILD_BANK_QUERY_RESULTS, ClientVersionBuild.V7_2_0_23826)]
@@ -180,7 +180,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         public static void HandleEventMotd(Packet packet)
         {
             var motdLen = packet.ReadBits(11);
-            packet.ReadWoWString("MotdText", motdLen);
+            packet.ReadWoWString_Sanitize("MotdText", motdLen);
         }
 
         [Parser(Opcode.CMSG_GUILD_SET_RANK_PERMISSIONS, ClientVersionBuild.V8_2_5_31921)]

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/HotfixHandler.cs
@@ -150,7 +150,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         [Parser(Opcode.SMSG_AVAILABLE_HOTFIXES, ClientVersionBuild.V8_1_0_28724, ClientVersionBuild.V8_1_5_29683)]
         public static void HandleHotfixList(Packet packet)
         {
-            packet.ReadInt32("VirtualRealmAddress");
+            packet.ReadInt32_Sanitize("VirtualRealmAddress");
             var hotfixCount = packet.ReadUInt32("HotfixCount");
             for (var i = 0u; i < hotfixCount; ++i)
             {
@@ -164,7 +164,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         [Parser(Opcode.SMSG_AVAILABLE_HOTFIXES, ClientVersionBuild.V8_1_5_29683)]
         public static void HandleHotfixList815(Packet packet)
         {
-            packet.ReadInt32("VirtualRealmAddress");
+            packet.ReadInt32_Sanitize("VirtualRealmAddress");
             var hotfixCount = packet.ReadUInt32("HotfixCount");
             for (var i = 0u; i < hotfixCount; ++i)
             {

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/InstanceHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/InstanceHandler.cs
@@ -59,7 +59,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 packet.ReadInt16("BottomOffset", i);
                 packet.ReadInt16("LeftOffset", i);
 
-                packet.ReadWoWString("Name", strlen, i);
+                packet.ReadWoWString_Sanitize("Name", strlen, i);
             }
         }
     }

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/MiscellaneousHandler.cs
@@ -21,8 +21,8 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
 
             packet.ReadUInt32("ScrollOfResurrectionRequestsRemaining");
             packet.ReadUInt32("ScrollOfResurrectionMaxRequestsPerDay");
-            packet.ReadUInt32("CfgRealmID");
-            packet.ReadInt32("CfgRealmRecID");
+            packet.ReadUInt32_Sanitize("CfgRealmID");
+            packet.ReadInt32_Sanitize("CfgRealmRecID");
 
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V8_2_5_31921))
             {
@@ -193,7 +193,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         public static void HandleQueryPlayerNameByCommunityID(Packet packet)
         {
             packet.ReadPackedGuid128("BNetAccountGUID");
-            packet.ReadUInt64("CommunityDbID");
+            packet.ReadUInt64_Sanitize("CommunityDbID");
         }
 
         [Parser(Opcode.SMSG_UPDATE_EXPANSION_LEVEL)]
@@ -227,14 +227,14 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
 
             packet.ReadPackedGuid128("GuildGUID", idx);
 
-            packet.ReadUInt32("GuildVirtualRealmAddress", idx);
+            packet.ReadUInt32_Sanitize("GuildVirtualRealmAddress", idx);
             packet.ReadInt32<AreaId>("AreaID", idx);
 
             packet.ResetBitReader();
             var guildNameLen = packet.ReadBits(7);
             packet.ReadBit("IsGM", idx);
 
-            packet.ReadWoWString("GuildName", guildNameLen, idx);
+            packet.ReadWoWString_Sanitize("GuildName", guildNameLen, idx);
         }
 
         [Parser(Opcode.SMSG_WHO)]

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/SessionHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/SessionHandler.cs
@@ -11,14 +11,14 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         {
             var sessionKeyLength = (int) packet.ReadBits(7);
 
-            packet.ReadBytes("Digest", 32);
-            packet.ReadBytes("SessionKey", sessionKeyLength);
+            packet.ReadBytes_Sanitize("Digest", 32);
+            packet.ReadBytes_Sanitize("SessionKey", sessionKeyLength);
         }
 
         [Parser(Opcode.SMSG_REALM_QUERY_RESPONSE, ClientVersionBuild.V8_1_0_28724)]
         public static void HandleRealmQueryResponse(Packet packet)
         {
-            packet.ReadUInt32("VirtualRealmAddress");
+            packet.ReadUInt32_Sanitize("VirtualRealmAddress");
 
             var state = packet.ReadByte("LookupState");
             if (state == 0)
@@ -32,8 +32,8 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 var bits258 = packet.ReadBits(9);
                 packet.ReadBit();
 
-                packet.ReadWoWString("RealmNameActual", bits2);
-                packet.ReadWoWString("RealmNameNormalized", bits258);
+                packet.ReadWoWString_Sanitize("RealmNameActual", bits2);
+                packet.ReadWoWString_Sanitize("RealmNameNormalized", bits258);
             }
         }
 
@@ -47,7 +47,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         [Parser(Opcode.SMSG_ENTER_ENCRYPTED_MODE, ClientVersionBuild.V8_2_0_30898)]
         public static void HandleEnterEncryptedMode(Packet packet)
         {
-            packet.ReadBytes("EncryptionKey (RSA encrypted)", 256);
+            packet.ReadBytes_Sanitize("EncryptionKey (RSA encrypted)", 256);
             packet.ResetBitReader();
             packet.ReadBit("Enabled");
         }
@@ -55,19 +55,19 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         [Parser(Opcode.SMSG_CONNECT_TO, ClientVersionBuild.V8_2_0_30898)]
         public static void HandleRedirectClient(Packet packet)
         {
-            packet.ReadBytes("Where (RSA encrypted)", 256);
+            packet.ReadBytes_Sanitize("Where (RSA encrypted)", 256);
 
             AddressType type = packet.ReadByteE<AddressType>("Type");
             switch (type)
             {
                 case AddressType.IPv4:
-                    packet.ReadIPAddress("Address");
+                    packet.ReadIPAddress_Sanitize("Address");
                     break;
                 case AddressType.IPv6:
-                    packet.ReadIPv6Address("Address");
+                    packet.ReadIPv6Address_Sanitize("Address");
                     break;
                 case AddressType.NamedSocket:
-                    packet.ReadWoWString("Address", 128);
+                    packet.ReadWoWString_Sanitize("Address", 128);
                     break;
                 default:
                     break;
@@ -76,7 +76,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             packet.ReadUInt16("Port");
             packet.ReadUInt32E<ConnectToSerial>("Serial");
             packet.ReadByte("Con");
-            packet.ReadUInt64("Key");
+            packet.ReadUInt64_Sanitize("Key");
         }
     }
 }

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/SpellHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/SpellHandler.cs
@@ -83,7 +83,7 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
                 }
             }
 
-            packet.ReadWoWString("Name", nameLength, idx);
+            packet.ReadWoWString_Sanitize("Name", nameLength, idx);
         }
 
         public static void ReadTalentGroupInfo(Packet packet, params object[] idx)

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/TicketHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/TicketHandler.cs
@@ -18,12 +18,12 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
             var textLen = packet.ReadBits(12);
 
             if (hasClubID)
-                packet.ReadUInt64("ClubID", indexes);
+                packet.ReadUInt64_Sanitize("ClubID", indexes);
             if (hasChannelGUID)
                 packet.ReadPackedGuid128("ChannelGUID", indexes);
             if (hasRealmAddress)
             {
-                packet.ReadUInt32("VirtualRealmAddress", indexes);
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress", indexes);
                 packet.ReadUInt16("field_4", indexes);
                 packet.ReadByte("field_6", indexes);
             }
@@ -42,11 +42,11 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
 
         public static void ReadClubFinderResult(Packet packet, params object[] indexes)
         {
-            packet.ReadUInt64("ClubFinderPostingID", indexes);
-            packet.ReadUInt64("ClubID ", indexes);
+            packet.ReadUInt64_Sanitize("ClubFinderPostingID", indexes);
+            packet.ReadUInt64_Sanitize("ClubID ", indexes);
             packet.ReadPackedGuid128("ClubFinderGUID", indexes);
             var nameLen = packet.ReadBits(12);
-            packet.ReadWoWString("ClubName", nameLen, indexes);
+            packet.ReadWoWString_Sanitize("ClubName", nameLen, indexes);
         }
 
         public static void ReadUnused910(Packet packet, params object[] indexes)

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler810.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler810.cs
@@ -1531,7 +1531,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
             }
             data.PlayerTitle = packet.ReadInt32("PlayerTitle", indexes);
             data.FakeInebriation = packet.ReadInt32("FakeInebriation", indexes);
-            data.VirtualPlayerRealm = packet.ReadUInt32("VirtualPlayerRealm", indexes);
+            data.VirtualPlayerRealm = packet.ReadUInt32_Sanitize("VirtualPlayerRealm", indexes);
             data.CurrentSpecID = packet.ReadUInt32("CurrentSpecID", indexes);
             data.TaxiMountAnimKitID = packet.ReadInt32("TaxiMountAnimKitID", indexes);
             for (var i = 0; i < 4; ++i)
@@ -1672,7 +1672,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_0_28724
                 }
                 if (changesMask[24])
                 {
-                    data.VirtualPlayerRealm = packet.ReadUInt32("VirtualPlayerRealm", indexes);
+                    data.VirtualPlayerRealm = packet.ReadUInt32_Sanitize("VirtualPlayerRealm", indexes);
                 }
                 if (changesMask[25])
                 {

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler815.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler815.cs
@@ -1534,7 +1534,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
             }
             data.PlayerTitle = packet.ReadInt32("PlayerTitle", indexes);
             data.FakeInebriation = packet.ReadInt32("FakeInebriation", indexes);
-            data.VirtualPlayerRealm = packet.ReadUInt32("VirtualPlayerRealm", indexes);
+            data.VirtualPlayerRealm = packet.ReadUInt32_Sanitize("VirtualPlayerRealm", indexes);
             data.CurrentSpecID = packet.ReadUInt32("CurrentSpecID", indexes);
             data.TaxiMountAnimKitID = packet.ReadInt32("TaxiMountAnimKitID", indexes);
             for (var i = 0; i < 4; ++i)
@@ -1675,7 +1675,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_1_5_29683
                 }
                 if (changesMask[24])
                 {
-                    data.VirtualPlayerRealm = packet.ReadUInt32("VirtualPlayerRealm", indexes);
+                    data.VirtualPlayerRealm = packet.ReadUInt32_Sanitize("VirtualPlayerRealm", indexes);
                 }
                 if (changesMask[25])
                 {

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler820.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler820.cs
@@ -1660,7 +1660,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
             }
             data.PlayerTitle = packet.ReadInt32("PlayerTitle", indexes);
             data.FakeInebriation = packet.ReadInt32("FakeInebriation", indexes);
-            data.VirtualPlayerRealm = packet.ReadUInt32("VirtualPlayerRealm", indexes);
+            data.VirtualPlayerRealm = packet.ReadUInt32_Sanitize("VirtualPlayerRealm", indexes);
             data.CurrentSpecID = packet.ReadUInt32("CurrentSpecID", indexes);
             data.TaxiMountAnimKitID = packet.ReadInt32("TaxiMountAnimKitID", indexes);
             for (var i = 0; i < 4; ++i)
@@ -1801,7 +1801,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_0_30898
                 }
                 if (changesMask[24])
                 {
-                    data.VirtualPlayerRealm = packet.ReadUInt32("VirtualPlayerRealm", indexes);
+                    data.VirtualPlayerRealm = packet.ReadUInt32_Sanitize("VirtualPlayerRealm", indexes);
                 }
                 if (changesMask[25])
                 {

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler825.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler825.cs
@@ -1667,7 +1667,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
             }
             data.PlayerTitle = packet.ReadInt32("PlayerTitle", indexes);
             data.FakeInebriation = packet.ReadInt32("FakeInebriation", indexes);
-            data.VirtualPlayerRealm = packet.ReadUInt32("VirtualPlayerRealm", indexes);
+            data.VirtualPlayerRealm = packet.ReadUInt32_Sanitize("VirtualPlayerRealm", indexes);
             data.CurrentSpecID = packet.ReadUInt32("CurrentSpecID", indexes);
             data.TaxiMountAnimKitID = packet.ReadInt32("TaxiMountAnimKitID", indexes);
             for (var i = 0; i < 4; ++i)
@@ -1849,7 +1849,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_2_5_31921
                 }
                 if (changesMask[27])
                 {
-                    data.VirtualPlayerRealm = packet.ReadUInt32("VirtualPlayerRealm", indexes);
+                    data.VirtualPlayerRealm = packet.ReadUInt32_Sanitize("VirtualPlayerRealm", indexes);
                 }
                 if (changesMask[28])
                 {

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler830.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/UpdateFieldsHandler830.cs
@@ -1672,7 +1672,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
             }
             data.PlayerTitle = packet.ReadInt32("PlayerTitle", indexes);
             data.FakeInebriation = packet.ReadInt32("FakeInebriation", indexes);
-            data.VirtualPlayerRealm = packet.ReadUInt32("VirtualPlayerRealm", indexes);
+            data.VirtualPlayerRealm = packet.ReadUInt32_Sanitize("VirtualPlayerRealm", indexes);
             data.CurrentSpecID = packet.ReadUInt32("CurrentSpecID", indexes);
             data.TaxiMountAnimKitID = packet.ReadInt32("TaxiMountAnimKitID", indexes);
             for (var i = 0; i < 4; ++i)
@@ -1854,7 +1854,7 @@ namespace WowPacketParserModule.V8_0_1_27101.UpdateFields.V8_3_0_33062
                 }
                 if (changesMask[27])
                 {
-                    data.VirtualPlayerRealm = packet.ReadUInt32("VirtualPlayerRealm", indexes);
+                    data.VirtualPlayerRealm = packet.ReadUInt32_Sanitize("VirtualPlayerRealm", indexes);
                 }
                 if (changesMask[28])
                 {

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/AuthenticationHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/AuthenticationHandler.cs
@@ -9,7 +9,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         [Parser(Opcode.SMSG_ENTER_ENCRYPTED_MODE, ClientVersionBuild.V9_2_7_45114)]
         public static void HandleEnterEncryptedMode(Packet packet)
         {
-            packet.ReadBytes("Signature (ED25519)", 64);
+            packet.ReadBytes_Sanitize("Signature (ED25519)", 64);
             packet.ReadBit("Enabled");
         }
     }

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
@@ -19,7 +19,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         {
             var playerGuid = packet.ReadPackedGuid128("Guid", idx);
 
-            packet.ReadUInt64("GuildClubMemberID", idx);
+            packet.ReadUInt64_Sanitize("GuildClubMemberID", idx);
 
             packet.ReadByte("ListPosition", idx);
             var race = packet.ReadByteE<Race>("RaceID", idx);
@@ -87,7 +87,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
                 if (mailSenderLengths[j] > 1)
                     packet.ReadDynamicString("MailSender", mailSenderLengths[j], idx);
 
-            var name = packet.ReadWoWString("Character Name", nameLength, idx);
+            var name = packet.ReadWoWString_Sanitize("Character Name", nameLength, idx);
 
             if (firstLogin)
             {
@@ -113,7 +113,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
             packet.ReadByteE<Race>("Race", idx);
             packet.ReadByteE<Class>("ClassID", idx);
             var customizationCount = packet.ReadUInt32();
-            packet.ReadWoWString("Name", nameLen, idx);
+            packet.ReadWoWString_Sanitize("Name", nameLen, idx);
 
             for (var j = 0u; j < customizationCount; ++j)
                 ReadChrCustomizationChoice(packet, idx, "Customizations", j);
@@ -237,7 +237,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
 
             var customizationCount = packet.ReadUInt32();
 
-            packet.ReadWoWString("Name", nameLen);
+            packet.ReadWoWString_Sanitize("Name", nameLen);
 
             if (hasTemplateSet)
                 packet.ReadInt32("TemplateSetID");
@@ -257,7 +257,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         public static void HandleCheckCharacterNameAvailability(Packet packet)
         {
             packet.ReadUInt32("SequenceIndex");
-            packet.ReadWoWString("Character Name", packet.ReadBits(6));
+            packet.ReadWoWString_Sanitize("Character Name", packet.ReadBits(6));
         }
     }
 }

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
@@ -85,7 +85,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
 
             for (var j = 0; j < mailSenderLengths.Length; ++j)
                 if (mailSenderLengths[j] > 1)
-                    packet.ReadDynamicString("MailSender", mailSenderLengths[j], idx);
+                    packet.ReadDynamicString_Sanitize("MailSender", mailSenderLengths[j], idx);
 
             var name = packet.ReadWoWString_Sanitize("Character Name", nameLength, idx);
 

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/GuildHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/GuildHandler.cs
@@ -12,7 +12,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
             var nameLength = packet.ReadBits(9);
             var hasArenaTeamId = packet.ReadBit("HasArenaTeamId");
 
-            packet.ReadWoWString("Name", nameLength);
+            packet.ReadWoWString_Sanitize("Name", nameLength);
 
             if (hasArenaTeamId)
                 packet.ReadInt32("ArenaTeamId");
@@ -48,7 +48,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
                     packet.ReadUInt32("Step", i, j);
                 }
 
-                packet.ReadUInt32("VirtualRealmAddress", i);
+                packet.ReadUInt32_Sanitize("VirtualRealmAddress", i);
 
                 packet.ReadByteE<GuildMemberFlag>("Status", i);
                 packet.ReadByte("Level", i);

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/HotfixHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/HotfixHandler.cs
@@ -330,7 +330,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         [Parser(Opcode.SMSG_AVAILABLE_HOTFIXES, ClientVersionBuild.V9_0_5_37503, ClientVersionBuild.V9_1_5_40772)]
         public static void HandleAvailableHotfixes905(Packet packet)
         {
-            packet.ReadInt32("VirtualRealmAddress");
+            packet.ReadInt32_Sanitize("VirtualRealmAddress");
             var hotfixCount = packet.ReadUInt32("HotfixCount");
             for (var i = 0u; i < hotfixCount; ++i)
                 packet.ReadInt32("HotfixID", i);
@@ -339,7 +339,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         [Parser(Opcode.SMSG_AVAILABLE_HOTFIXES, ClientVersionBuild.V9_1_5_40772)]
         public static void HandleAvailableHotfixes915(Packet packet)
         {
-            packet.ReadInt32("VirtualRealmAddress");
+            packet.ReadInt32_Sanitize("VirtualRealmAddress");
             var hotfixCount = packet.ReadUInt32("HotfixCount");
             for (var i = 0u; i < hotfixCount; ++i)
             {

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/MiscellaneousHandler.cs
@@ -22,8 +22,8 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
 
             packet.ReadUInt32("ScrollOfResurrectionRequestsRemaining");
             packet.ReadUInt32("ScrollOfResurrectionMaxRequestsPerDay");
-            packet.ReadUInt32("CfgRealmID");
-            packet.ReadInt32("CfgRealmRecID");
+            packet.ReadUInt32_Sanitize("CfgRealmID");
+            packet.ReadInt32_Sanitize("CfgRealmRecID");
             packet.ReadUInt32("MaxRecruits", "RAFSystem");
             packet.ReadUInt32("MaxRecruitMonths", "RAFSystem");
             packet.ReadUInt32("MaxRecruitmentUses", "RAFSystem");


### PR DESCRIPTION
Some people might be afraid of their privacy and possible data abuse (which is reasonable).
So i made this WIP to be able to sanitize data from packets and redump it.
Sanitizing requires manually marking parts except guids. Guids are always sanitized by different seed.