### PR TITLE
Fixed missing sql output generation for go spawns

### DIFF
--- a/WowPacketParser/SQL/Builders/Spawns.cs
+++ b/WowPacketParser/SQL/Builders/Spawns.cs
@@ -439,8 +439,7 @@ namespace WowPacketParser.SQL.Builders
                         addonRow.Comment += " - !!! on transport - transport template not found !!!";
                     }
                 }
-                else
-                    ++count;
+                ++count;
 
                 rows.Add(row);
             }


### PR DESCRIPTION
When the parser identifies the spawn of a temporary transport/go, it doesn't increment the variable "count" which causes the next go in the Dictionary to have the same guid as the temporary transport/go and, therefore, that it isn't added to the RowList