### PR TITLE
Adding structure for Opcode SMSG_REQUEST_SCHEDULED_PVP_INFO_RESPONSE

### DIFF
--- a/WowPacketParserModule.V10_0_0_46181/Parsers/BattlegroundHandler.cs
+++ b/WowPacketParserModule.V10_0_0_46181/Parsers/BattlegroundHandler.cs
@@ -40,5 +40,34 @@ namespace WowPacketParserModule.V10_0_0_46181.Parsers
                     ReadRatedMatchDeserterPenalty(packet, "RatedMatchDeserterPenalty");
             }
         }
+        
+        public static void ReadBrawlInfo(Packet packet, params object[] idx)
+        {
+            packet.ReadInt32("PvpBrawlId");
+            packet.ReadInt32("Time");
+            packet.ResetBitReader();
+            packet.ReadBit("Started");
+        }
+        
+        public static void ReadSpecialEventInfo(Packet packet, params object[] idx)
+        {
+            packet.ReadInt32("PvpBrawlID");
+            packet.ReadInt32<AchievementId>("AchievementId");
+            packet.ResetBitReader();
+            packet.ReadBit("CanQueue");
+        }
+
+        [Parser(Opcode.SMSG_REQUEST_SCHEDULED_PVP_INFO_RESPONSE)]
+        public static void HandleRequestScheduledPvpInfoResponse(Packet packet)
+        {
+            var hasBrawlInfo = packet.ReadBit("HasBrawlInfo");
+            var hasSpecialEventInfo = packet.ReadBit("HasSpecialEventInfo");
+
+            if (hasBrawlInfo)
+                ReadBrawlInfo(packet, "BrawlInfo");
+
+            if (hasSpecialEventInfo)
+                ReadSpecialEventInfo(packet, "SpecialEventInfo");
+        }
     }
 }


### PR DESCRIPTION
activates Brawl PvP information 

![adad](https://user-images.githubusercontent.com/123419223/227744634-9b09aef5-4503-45f3-bfff-817535a98701.png)

All credits and thanks to MaxtorCoder

ServerToClient: SMSG_REQUEST_SCHEDULED_PVP_INFO_RESPONSE (0x2936) Length: 10 ConnIdx: 1 Time: 03/25/2023 14:45:02.369 Number: 3023
HasBrawlInfo: True
HasSpecialEventInfo: False
(BrawlInfo) PvpBrawlId: 121 (BrawlCompStomp)
(BrawlInfo) Time: 333939
(BrawlInfo) Started: True