### PR TITLE
Added structure for SMSG_WEEKLY_REWARDS_PROGRESS_RESULT

### DIFF
--- a/WowPacketParserModule.V10_0_0_46181/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParserModule.V10_0_0_46181/Parsers/MiscellaneousHandler.cs
@@ -95,5 +95,47 @@ namespace WowPacketParserModule.V10_0_0_46181.Parsers
             if (hasLastSpendTime)
                 packet.ReadTime64("LastSpendTime");
         }
+		
+		public static void ReadUnkStruct(Packet packet, params object[] idx)
+        {
+            packet.ReadInt32("UnkInt32", idx);
+            packet.ReadInt32("UnkInt32", idx);
+            packet.ReadInt32("UnkInt32", idx);
+            var count = packet.ReadInt32("UnkInt32", idx);
+            for (int i = 0; i < count; i++)
+            {
+                packet.ReadInt32("UnkInt32", idx, i);
+                packet.ReadInt32("UnkInt32", idx, i);
+            }
+
+            packet.ResetBitReader();
+            bool unkbool = packet.ReadBit("UnkBit", idx);
+            if (unkbool)
+                ReadUnkStruct2(packet, "ReadUnkStruct2", idx);
+        }
+
+        public static void ReadUnkStruct2(Packet packet, params object[] idx)
+        {
+            packet.ReadInt32("UnkInt32", idx);
+
+            packet.ResetBitReader();
+            bool unkbool = packet.ReadBit("UnkBit", idx);
+            if (unkbool)
+            {
+                var count = packet.ReadInt32("UnkInt32", idx);
+                for (int i = 0; i < count; i++)
+                    packet.ReadInt32("UnkInt32", idx, i);
+            }
+        }
+
+        [Parser(Opcode.SMSG_WEEKLY_REWARDS_PROGRESS_RESULT)]
+        public static void HandleWeeklyRewardsProgressResult(Packet packet)
+        {
+            packet.ReadInt32("UnkInt32");
+            packet.ReadInt32("UnkInt32");
+            var count = packet.ReadInt32("UnkInt32");
+            for (int i = 0; i < count; i++)
+                ReadUnkStruct(packet, "ReadUnkStruct", i);
+        }
     }
 }

--- a/WowPacketParserModule.V10_0_0_46181/Parsers/MiscellaneousHandler.cs
+++ b/WowPacketParserModule.V10_0_0_46181/Parsers/MiscellaneousHandler.cs
@@ -95,8 +95,8 @@ namespace WowPacketParserModule.V10_0_0_46181.Parsers
             if (hasLastSpendTime)
                 packet.ReadTime64("LastSpendTime");
         }
-		
-		public static void ReadUnkStruct(Packet packet, params object[] idx)
+
+        public static void ReadUnkStruct(Packet packet, params object[] idx)
         {
             packet.ReadInt32("UnkInt32", idx);
             packet.ReadInt32("UnkInt32", idx);


### PR DESCRIPTION
ToDo: 
* Rename the unknow fields
* Parse a sniff in which this opcode appears and use ReadUnkStruct2, because in my sniffs it appears without the struct
[SMSG_WEEKLY_REWARDS_PROGRESS_RESULT.txt](https://github.com/TrinityCore/WowPacketParser/files/11356008/SMSG_WEEKLY_REWARDS_PROGRESS_RESULT.txt)
