### PR TITLE
Fixed SMSG_PLAYER_CHOICE_CLEAR struct for 10.0.7

### DIFF
--- a/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
@@ -152,10 +152,10 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         [Parser(Opcode.SMSG_PLAYER_CHOICE_CLEAR)]
         public static void HandleEmpty(Packet packet)
         {
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V10_0_7_48676)) // maybe this change is already present in an older build
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V10_0_2_46924)) // maybe this change is already present in an older build
             {
-                packet.ReadInt32("UnkInt32");
-                packet.ReadBit("UnkBit");
+                packet.ReadInt32("ChoiceID");
+                packet.ReadBit("Clear");
             }
         }
 

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
@@ -152,6 +152,11 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         [Parser(Opcode.SMSG_PLAYER_CHOICE_CLEAR)]
         public static void HandleEmpty(Packet packet)
         {
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V10_0_7_48676)) // maybe this change is already present in an older build
+            {
+                packet.ReadInt32("UnkInt32");
+                packet.ReadBit("UnkBit");
+            }
         }
 
         [Parser(Opcode.SMSG_ENUM_CHARACTERS_RESULT)]

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
@@ -150,9 +150,9 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         }
 
         [Parser(Opcode.SMSG_PLAYER_CHOICE_CLEAR)]
-        public static void HandleEmpty(Packet packet)
+        public static void HandlePlayerChoiceClear(Packet packet)
         {
-            if (ClientVersion.AddedInVersion(ClientVersionBuild.V10_0_2_46924)) // maybe this change is already present in an older build
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_2_5_43903))
             {
                 packet.ReadInt32("ChoiceID");
                 packet.ReadBit("Clear");


### PR DESCRIPTION
ToDo: 
* Check in which build was the opcode structure changed. Because maybe the opcode structure has changed before, but I don't know which was the exact build in which it was modified, so I left the build of my sniff, since my .exe is from a more advanced build.