### PR TITLE
Protobuf output: don't set SpellStart/SpellGo struct before the packet is read

### DIFF
--- a/WowPacketParserModule.V1_13_2_31446/Parsers/SpellHandler.cs
+++ b/WowPacketParserModule.V1_13_2_31446/Parsers/SpellHandler.cs
@@ -154,15 +154,17 @@ namespace WowPacketParserModule.V1_13_2_31446.Parsers
         [Parser(Opcode.SMSG_SPELL_START)]
         public static void HandleSpellStart(Packet packet)
         {
-            PacketSpellStart packetSpellStart = packet.Holder.SpellStart = new();
+            PacketSpellStart packetSpellStart = new();
             packetSpellStart.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellStart = packetSpellStart;
         }
 
         [Parser(Opcode.SMSG_SPELL_GO)]
         public static void HandleSpellGo(Packet packet)
         {
-            PacketSpellGo packetSpellGo = packet.Holder.SpellGo = new();
+            PacketSpellGo packetSpellGo = new();
             packetSpellGo.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellGo = packetSpellGo;
 
             packet.ResetBitReader();
 

--- a/WowPacketParserModule.V4_3_4_15595/Parsers/SpellHandler.cs
+++ b/WowPacketParserModule.V4_3_4_15595/Parsers/SpellHandler.cs
@@ -13,15 +13,17 @@ namespace WowPacketParserModule.V4_3_4_15595.Parsers
         [Parser(Opcode.SMSG_SPELL_START)]
         public static void HandleSpellStart(Packet packet)
         {
-            PacketSpellStart packetSpellStart = packet.Holder.SpellStart = new();
+            PacketSpellStart packetSpellStart = new();
             packetSpellStart.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellStart = packetSpellStart;
         }
 
         [Parser(Opcode.SMSG_SPELL_GO)]
         public static void HandleSpellGo(Packet packet)
         {
-            PacketSpellGo packetSpellGo = packet.Holder.SpellGo = new();
+            PacketSpellGo packetSpellGo = new();
             packetSpellGo.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellGo = packetSpellGo;
         }
 
         public static PacketSpellData ReadSpellCastData(Packet packet, params object[] idx)

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/SpellHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/SpellHandler.cs
@@ -309,15 +309,17 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
         [Parser(Opcode.SMSG_SPELL_START)]
         public static void HandleSpellStart(Packet packet)
         {
-            PacketSpellStart packetSpellStart = packet.Holder.SpellStart = new();
+            PacketSpellStart packetSpellStart = new();
             packetSpellStart.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellStart = packetSpellStart;
         }
 
         [Parser(Opcode.SMSG_SPELL_GO)]
         public static void HandleSpellGo(Packet packet)
         {
-            PacketSpellGo packetSpellGo = packet.Holder.SpellGo = new();
+            PacketSpellGo packetSpellGo = new();
             packetSpellGo.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellGo = packetSpellGo;
 
             packet.ResetBitReader();
 

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/SpellHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/SpellHandler.cs
@@ -265,15 +265,17 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
         [Parser(Opcode.SMSG_SPELL_START)]
         public static void HandleSpellStart(Packet packet)
         {
-            PacketSpellStart packetSpellStart = packet.Holder.SpellStart = new();
+            PacketSpellStart packetSpellStart = new();
             packetSpellStart.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellStart = packetSpellStart;
         }
 
         [Parser(Opcode.SMSG_SPELL_GO)]
         public static void HandleSpellGo(Packet packet)
         {
-            PacketSpellGo packetSpellGo = packet.Holder.SpellGo = new();
+            PacketSpellGo packetSpellGo = new();
             packetSpellGo.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellGo = packetSpellGo;
 
             packet.ResetBitReader();
 

--- a/WowPacketParserModule.V8_0_1_27101/Parsers/SpellHandler.cs
+++ b/WowPacketParserModule.V8_0_1_27101/Parsers/SpellHandler.cs
@@ -210,15 +210,17 @@ namespace WowPacketParserModule.V8_0_1_27101.Parsers
         [Parser(Opcode.SMSG_SPELL_START)]
         public static void HandleSpellStart(Packet packet)
         {
-            PacketSpellStart packetSpellStart = packet.Holder.SpellStart = new();
+            PacketSpellStart packetSpellStart = new();
             packetSpellStart.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellStart = packetSpellStart;
         }
 
         [Parser(Opcode.SMSG_SPELL_GO)]
         public static void HandleSpellGo(Packet packet)
         {
-            PacketSpellGo packetSpellGo = packet.Holder.SpellGo = new();
+            PacketSpellGo packetSpellGo = new();
             packetSpellGo.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellGo = packetSpellGo;
 
             packet.ResetBitReader();
 

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/SpellHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/SpellHandler.cs
@@ -150,15 +150,17 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
         [Parser(Opcode.SMSG_SPELL_START)]
         public static void HandleSpellStart(Packet packet)
         {
-            PacketSpellStart packetSpellStart = packet.Holder.SpellStart = new();
+            PacketSpellStart packetSpellStart = new();
             packetSpellStart.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellStart = packetSpellStart;
         }
 
         [Parser(Opcode.SMSG_SPELL_GO)]
         public static void HandleSpellGo(Packet packet)
         {
-            PacketSpellGo packetSpellGo = packet.Holder.SpellGo = new();
+            PacketSpellGo packetSpellGo = new();
             packetSpellGo.Data = ReadSpellCastData(packet, "Cast");
+            packet.Holder.SpellGo = packetSpellGo;
 
             packet.ResetBitReader();
 


### PR DESCRIPTION
This PR modifies the order in which the `SpellStart`/`SpellGo` properties are assigned within the protobuf output. Before the change, the property was set, then parsing was done. When an exception occurs within the parsing code, the property is in a weird state - the spell start/go is not null, but the data inside is.

After the change, the value is assigned only after the packet is parsed.