### PR TITLE
Update SMSG_ITEM_PUSH_RESULT and SMSG_SELL_RESPONSE for 10.1.7

### DIFF
--- a/WowPacketParserModule.V10_0_0_46181/Parsers/ItemHandler.cs
+++ b/WowPacketParserModule.V10_0_0_46181/Parsers/ItemHandler.cs
@@ -39,6 +39,10 @@ namespace WowPacketParserModule.V10_0_0_46181.Parsers
 
             packet.ReadBit("Pushed");
             packet.ReadBit("Created");
+
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V10_1_7_51187))
+                packet.ReadBit("ReadBit_1017");
+
             packet.ReadBits("DisplayText", 3);
             packet.ReadBit("IsBonusRoll");
             packet.ReadBit("IsEncounterLoot");
@@ -59,6 +63,18 @@ namespace WowPacketParserModule.V10_0_0_46181.Parsers
         public static void HandleLootMoney(Packet packet)
         {
             packet.ReadBit("IsSoftInteract");
+        }
+
+        [Parser(Opcode.SMSG_SELL_RESPONSE, ClientVersionBuild.V10_1_7_51187)]
+        public static void HandleSellResponse(Packet packet)
+        {
+            packet.ReadPackedGuid128("VendorGUID");
+            var itemGuidCount = packet.ReadUInt32("ItemGuidCount");
+
+            packet.ReadInt32E<SellResult>("Reason");
+
+            for (var i = 0; i < itemGuidCount; ++i)
+                packet.ReadPackedGuid128("ItemGuid", i);
         }
     }
 }


### PR DESCRIPTION
- Update SMSG_SELL_RESPONSE  structure 
<img width="564" alt="image" src="https://github.com/TrinityCore/WowPacketParser/assets/445742/64b00bf7-cea2-40ee-bac7-29990df45f82">

Core use Enum and already cast it as int32

-  Update SMSG_ITEM_PUSH_RESULT
<img width="445" alt="image" src="https://github.com/TrinityCore/WowPacketParser/assets/445742/03467b18-0f01-48da-b85a-1755b93be547">

SMSG_ITEM_PUSH_RESULT change is not present in TrinityCore
The changes exist in build 50893