### PR TITLE
Fix SMSG_ENUM_CHARACTERS_RESULT for 3.4.3.

### DIFF
--- a/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
@@ -91,10 +91,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
             }
 
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V3_4_3_51505))
-            {
-                packet.ReadBit("Unk343_1", idx);
-                packet.ReadBit("Unk343_2", idx);
-            }
+                packet.ReadByte("Unk343_1", idx);
 
             for (var j = 0; j < mailSenderLengths.Length; ++j)
                 mailSenderLengths[j] = packet.ReadBits(6);

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/CharacterHandler.cs
@@ -54,7 +54,8 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
             for (uint j = 0; j < 2; ++j)
                 packet.ReadInt32("ProfessionIDs", idx, j);
 
-            for (uint j = 0; j < 35; ++j)
+            var visualItemSize = ClientVersion.AddedInVersion(ClientVersionBuild.V3_4_3_51505) ? 34 : 35;
+            for (uint j = 0; j < visualItemSize; ++j)
                 ReadVisualItemInfo(packet, idx, j);
 
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V9_0_5_37503))
@@ -87,6 +88,12 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
             {
                 packet.ReadBit("RPEUpgradeEligible", idx);
                 packet.ReadBit("QuestClearAvailable", idx);
+            }
+
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V3_4_3_51505))
+            {
+                packet.ReadBit("Unk343_1", idx);
+                packet.ReadBit("Unk343_2", idx);
             }
 
             for (var j = 0; j < mailSenderLengths.Length; ++j)


### PR DESCRIPTION
Tested on retail classic 3.4.3.51739 and it properly parsed the packet.

Also tested on the wotlk_classic branch with a 3.4.3 client.

Before: 
![image](https://github.com/TrinityCore/WowPacketParser/assets/12139798/bcc13252-6968-4f41-ae80-45dc1c7ded3a)

After:
![image](https://github.com/TrinityCore/WowPacketParser/assets/12139798/10ea0724-d1c0-48c7-b3c5-04027f476875)
