### PR TITLE
Allow to create packet structures for a specific build version.

### DIFF
--- a/WowPacketParser/Enums/ClientVersionBuild.cs
+++ b/WowPacketParser/Enums/ClientVersionBuild.cs
@@ -3,6 +3,7 @@ namespace WowPacketParser.Enums
     public enum ClientVersionBuild
     {
         // ReSharper disable InconsistentNaming
+        None = -1,
         Zero = 0,
 
         V1_12_1_5875 = 5875,

--- a/WowPacketParser/Parsing/BuildMatchAttribute.cs
+++ b/WowPacketParser/Parsing/BuildMatchAttribute.cs
@@ -1,0 +1,21 @@
+using System;
+using WowPacketParser.Enums;
+using WowPacketParser.Misc;
+
+namespace WowPacketParser.Parsing
+{
+    [AttributeUsage(AttributeTargets.Method, AllowMultiple = true, Inherited = false)]
+    public sealed class BuildMatchAttribute : Attribute
+    {        
+        /// <param name="buildVersion"></param>
+        public BuildMatchAttribute(ClientVersionBuild buildVersion)
+        {
+            if (ClientVersion.Build == buildVersion)
+                BuildVersion = buildVersion;
+            else
+                BuildVersion = ClientVersionBuild.None;
+        }
+
+        public ClientVersionBuild BuildVersion { get; private set; }
+    }
+}

--- a/WowPacketParser/Parsing/Handler.cs
+++ b/WowPacketParser/Parsing/Handler.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reflection;
 using WowPacketParser.Enums;
 using WowPacketParser.Enums.Version;
@@ -40,36 +41,44 @@ namespace WowPacketParser.Parsing
                 if (!type.IsAbstract || !type.IsPublic)
                     continue;
 
-                var methods = type.GetMethods();
+                var methods = type.GetMethods().Where(m =>
+                {
+                    var parameters = m.GetParameters();
+                    return parameters.Length > 0 && parameters[0].ParameterType == typeof(Packet);
+                });
 
                 foreach (MethodInfo method in methods)
                 {
                     if (!method.IsPublic)
                         continue;
 
-                    var attrs = (ParserAttribute[])method.GetCustomAttributes(typeof(ParserAttribute), false);
+                    var parseAttrs = method.GetCustomAttributes(typeof(ParserAttribute), false).Where(x =>
+                        ((ParserAttribute)x).Opcode != Opcode.NULL_OPCODE);        
 
-                    if (attrs.Length <= 0)
-                        continue;
+                    List<KeyValuePair<ClientVersionBuild, Opcode>> pairs = new();
 
-                    var parms = method.GetParameters();
-
-                    if (parms.Length <= 0)
-                        continue;
-
-                    if (parms[0].ParameterType != typeof(Packet))
-                        continue;
-
-                    foreach (ParserAttribute attr in attrs)
+                    foreach (ParserAttribute attr in parseAttrs)
                     {
-                        Opcode opc = attr.Opcode;
-                        if (opc == Opcode.NULL_OPCODE)
-                            continue;
+                        if (!attr.OnlyForSpecificBuild)
+                        {
+                            pairs.Add(new KeyValuePair<ClientVersionBuild, Opcode>(build, attr.Opcode));
+                        }
 
-                        var key = new KeyValuePair<ClientVersionBuild, Opcode>(build, opc);
+                        var buildMatchAttrs = method.GetCustomAttributes(typeof(BuildMatchAttribute), false).Where(x =>
+                        ((BuildMatchAttribute)x).BuildVersion != ClientVersionBuild.None);
 
+                        foreach (BuildMatchAttribute buildMatch in buildMatchAttrs)
+                        {
+                            pairs.Add(new KeyValuePair<ClientVersionBuild, Opcode>(buildMatch.BuildVersion, attr.Opcode));
+                        }
+                    }
+
+                    if (pairs.Count <= 0)
+                        continue;
+
+                    foreach (var key in pairs)
+                    {
                         var del = (Action<Packet>)Delegate.CreateDelegate(typeof(Action<Packet>), method);
-
                         if (handlers.ContainsKey(key))
                         {
                             // @TODO This is a hack to keep things easy regarding declaration of opcodes.
@@ -79,10 +88,10 @@ namespace WowPacketParser.Parsing
                             // The last one would be MSG_, UMSG_, TEST_, etc... opcodes
                             // However that's just too much pain to do considering the mess Blizzard does
                             // by naming their opcodes sometimes without following their own rules.
-                            Direction direction = attr.Opcode.ToString()[0] == 'S' ? Direction.ServerToClient : Direction.ClientToServer;
+                            Direction direction = key.Value.ToString()[0] == 'S' ? Direction.ServerToClient : Direction.ClientToServer;
                             // ReSharper disable once UseStringInterpolation
                             Trace.WriteLine(string.Format("Error: (Build: {0}) tried to overwrite delegate for opcode {1} ({2}); new handler: {3}; old handler: {4}",
-                                ClientVersion.Build, Opcodes.GetOpcode(attr.Opcode, direction), attr.Opcode, del.Method, handlers[key].Method));
+                                ClientVersion.Build, Opcodes.GetOpcode(key.Value, direction), key.Value, del.Method, handlers[key].Method));
                             continue;
                         }
 
@@ -104,7 +113,7 @@ namespace WowPacketParser.Parsing
                 return;
 
             var opcode = Opcodes.GetOpcode(packet.Opcode, packet.Direction);
-            var key = new KeyValuePair<ClientVersionBuild, Opcode>(ClientVersion.VersionDefiningBuild, opcode);
+            var key = new KeyValuePair<ClientVersionBuild, Opcode>(ClientVersion.Build, opcode);
 
             Action<Packet> handler;
             var hasHandler = VersionHandlers.TryGetValue(key, out handler);

--- a/WowPacketParser/Parsing/ParserAttribute.cs
+++ b/WowPacketParser/Parsing/ParserAttribute.cs
@@ -12,6 +12,14 @@ namespace WowPacketParser.Parsing
             Opcode = opcode;
         }
 
+        /// <param name="opcode"></param>
+        /// <param name="onlyForSpecificBuild"></param>
+        public ParserAttribute(Opcode opcode, bool onlyForSpecificBuild)
+        {
+            Opcode = opcode;
+            OnlyForSpecificBuild = onlyForSpecificBuild;
+        }
+
         /// <summary>
         /// [addedInVersion, +inf[
         /// </summary>
@@ -61,5 +69,6 @@ namespace WowPacketParser.Parsing
         }
 
         public Opcode Opcode { get; private set; }
+        public bool OnlyForSpecificBuild { get; private set; }
     }
 }


### PR DESCRIPTION
I've read discussions here about how Blizzard is making the principles of introducing new packages and their structure more and more confusing. The project is becoming more and more confusing. Therefore, I propose to add small changes so that you can add the desired structure for the desired version of the client without worrying about breaking the cascade system.

How it works?
1) You need to use the **BuildMatchAttribute** indicating the specific version of the client build for the structure you are interested in.
2) It is advisable that this structure be implemented in a project that is closest to your version of the client.
3) If there is a conflict with older opcodes, use a new overload for **ParserAttribute** with a boolean value
4) You do not have to create a new structure, but only mark an existing one with **BuildMatchAttribute** (the existing structure must be implemented in the project that most closely matches the client version or the project that will be added using the cascade system).

For example:
https://github.com/TrinityCore/WowPacketParser/pull/850