### PR TITLE
Fix reading BitVectors after 11.0.5 changes

### DIFF
--- a/WowPacketParserModule.V11_0_0_55666/Parsers/UpdateFieldsHandler1105.cs
+++ b/WowPacketParserModule.V11_0_0_55666/Parsers/UpdateFieldsHandler1105.cs
@@ -2553,7 +2553,7 @@ namespace WowPacketParserModule.V11_0_0_55666.UpdateFields.V11_0_5_57171
             packet.ResetBitReader();
             var rawChangesMask = new int[1];
             var rawMaskMask = new int[1];
-            rawMaskMask[0] = (int)packet.ReadBits(32);
+            rawMaskMask[0] = (int)packet.ReadBits(1);
             var maskMask = new BitArray(rawMaskMask);
             if (maskMask[0])
                 rawChangesMask[0] = (int)packet.ReadBits(32);
@@ -2567,7 +2567,7 @@ namespace WowPacketParserModule.V11_0_0_55666.UpdateFields.V11_0_5_57171
                     if (changesMask[1 + i])
                     {
                         var rawChangesMask2 = new int[1];
-                        rawChangesMask2[0] = (int)packet.ReadBits(1);
+                        rawChangesMask2[0] = (int)packet.ReadBits(2);
                         var changesMask2 = new BitArray(rawChangesMask2);
                         if (changesMask2[0])
                         {


### PR DESCRIPTION
Before:
![kép](https://github.com/user-attachments/assets/ef6a198b-c17d-443b-b6ff-a78c8cbaddd4)

After:
![kép](https://github.com/user-attachments/assets/87badaf2-c46f-44ab-bf9d-dd7617aca2ec)

Thanks for the hard work