### PR TITLE
Fix parsing SMSG_GOSSIP_MESSAGE

### DIFF
--- a/WowPacketParser/Parsing/Parsers/NpcHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/NpcHandler.cs
@@ -95,12 +95,21 @@ namespace WowPacketParser.Parsing.Parsers
             }
         }
 
+        public static bool HasLastGossipOption(TimeSpan timeSpan, uint? menuId)
+        {
+            if (LastGossipOption.HasSelection)
+                if ((timeSpan - LastGossipOption.TimeSpan).Duration() <= TimeSpan.FromMilliseconds(2500))
+                    return true;
+
+            return false;
+        }
+
         public static void UpdateLastGossipOptionActionMessage(TimeSpan timeSpan, uint? menuId)
         {
             if (!LastGossipOption.HasSelection)
                 return;
 
-            if ((timeSpan - LastGossipOption.TimeSpan).Duration() <= TimeSpan.FromMilliseconds(2500))
+            if (HasLastGossipOption(timeSpan, menuId))
             {
                 Storage.GossipMenuOptions[(LastGossipOption.MenuId, LastGossipOption.OptionIndex)].Item1.ActionMenuID = menuId;
                 Storage.GossipMenuOptions[(LastGossipOption.MenuId, LastGossipOption.OptionIndex)].Item1.ActionPoiID = LastGossipOption.ActionPoiId ?? 0;
@@ -577,7 +586,7 @@ namespace WowPacketParser.Parsing.Parsers
             for (int i = 0; i < questsCount; i++)
                 ReadGossipQuestTextData(packet, i, "GossipQuests");
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {

--- a/WowPacketParserModule.V4_4_0_54481/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V4_4_0_54481/Parsers/NpcHandler.cs
@@ -184,7 +184,7 @@ namespace WowPacketParserModule.V4_4_0_54481.Parsers
             for (int i = 0; i < questsCount; ++i)
                 packetGossip.Quests.Add(ReadGossipQuestTextData(packet, i, "GossipQuests"));
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !CoreParsers.NpcHandler.HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {

--- a/WowPacketParserModule.V5_3_0_16981/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V5_3_0_16981/Parsers/NpcHandler.cs
@@ -160,7 +160,7 @@ namespace WowPacketParserModule.V5_3_0_16981.Parsers
             gossip.ObjectType = guid.GetObjectType();
             gossip.ObjectEntry = guid.GetEntry();
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !CoreParsers.NpcHandler.HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {

--- a/WowPacketParserModule.V5_4_0_17359/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V5_4_0_17359/Parsers/NpcHandler.cs
@@ -171,7 +171,7 @@ namespace WowPacketParserModule.V5_4_0_17359.Parsers
             gossip.ObjectType = guid.GetObjectType();
             gossip.ObjectEntry = guid.GetEntry();
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !CoreParsers.NpcHandler.HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {

--- a/WowPacketParserModule.V5_4_1_17538/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V5_4_1_17538/Parsers/NpcHandler.cs
@@ -115,7 +115,7 @@ namespace WowPacketParserModule.V5_4_1_17538.Parsers
             gossip.ObjectType = guid.GetObjectType();
             gossip.ObjectEntry = guid.GetEntry();
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !CoreParsers.NpcHandler.HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {

--- a/WowPacketParserModule.V5_4_2_17658/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V5_4_2_17658/Parsers/NpcHandler.cs
@@ -144,7 +144,7 @@ namespace WowPacketParserModule.V5_4_2_17658.Parsers
             gossip.ObjectType = guid.GetObjectType();
             gossip.ObjectEntry = guid.GetEntry();
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !CoreParsers.NpcHandler.HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {

--- a/WowPacketParserModule.V5_4_7_17898/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V5_4_7_17898/Parsers/NpcHandler.cs
@@ -177,7 +177,7 @@ namespace WowPacketParserModule.V5_4_7_17898.Parsers
             gossip.ObjectType = guid.GetObjectType();
             gossip.ObjectEntry = guid.GetEntry();
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !CoreParsers.NpcHandler.HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {

--- a/WowPacketParserModule.V5_4_8_18291/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V5_4_8_18291/Parsers/NpcHandler.cs
@@ -170,7 +170,7 @@ namespace WowPacketParserModule.V5_4_8_18291.Parsers
             gossip.ObjectType = guid.GetObjectType();
             gossip.ObjectEntry = guid.GetEntry();
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !CoreParsers.NpcHandler.HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {

--- a/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V6_0_2_19033/Parsers/NpcHandler.cs
@@ -316,7 +316,7 @@ namespace WowPacketParserModule.V6_0_2_19033.Parsers
             for (int i = 0; i < questsCount; ++i)
                 packetGossip.Quests.Add(ReadGossipQuestTextData(packet, i, "GossipQuests"));
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !CoreParsers.NpcHandler.HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {

--- a/WowPacketParserModule.V7_0_3_22248/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V7_0_3_22248/Parsers/NpcHandler.cs
@@ -93,7 +93,7 @@ namespace WowPacketParserModule.V7_0_3_22248.Parsers
             for (int i = 0; i < questsCount; ++i)
                 packetGossip.Quests.Add(ReadGossipQuestTextData(packet, i, "GossipQuests"));
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !CoreParsers.NpcHandler.HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {

--- a/WowPacketParserModule.V9_0_1_36216/Parsers/NpcHandler.cs
+++ b/WowPacketParserModule.V9_0_1_36216/Parsers/NpcHandler.cs
@@ -167,7 +167,7 @@ namespace WowPacketParserModule.V9_0_1_36216.Parsers
             for (int i = 0; i < questsCount; ++i)
                 packetGossip.Quests.Add(V7_0_3_22248.Parsers.NpcHandler.ReadGossipQuestTextData(packet, i, "GossipQuests"));
 
-            if (guid.GetObjectType() == ObjectType.Unit)
+            if (guid.GetObjectType() == ObjectType.Unit && !CoreParsers.NpcHandler.HasLastGossipOption(packet.TimeSpan, (uint)menuId))
             {
                 CreatureTemplateGossip creatureTemplateGossip = new()
                 {


### PR DESCRIPTION
- Avoid adding gossips launched by gossip_menu_option to creature_template_gossip
- Update parsing for SMSG_GOSSIP_MESSAGE (TWW). Old NpcTextID is now another BroadcastTextID