### PR TITLE
Drop ancient zlib dependency in favor of native .NET library calls.

### DIFF
--- a/WowPacketParser/Misc/FlushCode.cs
+++ b/WowPacketParser/Misc/FlushCode.cs
@@ -1,0 +1,10 @@
+﻿namespace WowPacketParser.Misc
+{
+    public enum FlushCode
+    {
+        NoFlush   = 0,
+        SyncFlush = 2,
+        Finish    = 4,
+        Block     = 5
+    }
+}

--- a/WowPacketParser/Misc/ZLibHelper.cs
+++ b/WowPacketParser/Misc/ZLibHelper.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using WowPacketParser.Parsing.Parsers;
+
+namespace WowPacketParser.Misc
+{
+    internal partial class ZLibHelper
+    {
+        private const string CompressionLib = "compression_native";
+
+        [LibraryImport(CompressionLib, EntryPoint = "CompressionNative_InflateInit2_")]
+        private static partial int InflateInit2(ref ZStream zStream, int windowBits);
+
+        [LibraryImport(CompressionLib, EntryPoint = "CompressionNative_Inflate")]
+        private static partial int Inflate(ref ZStream zStream, FlushCode flush);
+
+        [LibraryImport(CompressionLib, EntryPoint = "CompressionNative_InflateEnd")]
+        private static partial int InflateEnd(ref ZStream zStream);
+
+        public static void ResetInflateStream(int connectionIndex)
+        {
+            ref var zStream = ref CollectionsMarshal.GetValueRefOrAddDefault(SessionHandler.ZStreams, connectionIndex, out bool exists);
+
+            InflateInit2(ref zStream, 15);
+        }
+
+        public static unsafe bool TryInflate(int inflatedSize, int index, byte[] arr, ref byte[] newarr)
+        {
+            try
+            {
+                ref var zStream = ref CollectionsMarshal.GetValueRefOrAddDefault(SessionHandler.ZStreams, index, out bool exists);
+
+                if (!exists)
+                {
+                    var initResult = InflateInit2(ref zStream, 15);
+
+                    if (initResult != 0)
+                        return false;
+                }
+
+                fixed (byte* compressedData = arr)
+                fixed (byte* uncompressedData = newarr)
+                {
+                    zStream.AvailIn = (uint)arr.Length;
+                    zStream.NextIn = compressedData;
+                    zStream.AvailOut = (uint)inflatedSize;
+                    zStream.NextOut = uncompressedData;
+
+                    Inflate(ref zStream, FlushCode.SyncFlush);
+                }
+
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public static unsafe void Inflate(int inflatedSize, byte[] arr, byte[] newarr)
+        {
+            ZStream zStream = default;
+
+            InflateInit2(ref zStream, 15);
+
+            fixed (byte* compressedData = arr)
+            fixed (byte* uncompressedData = newarr)
+            {
+                zStream.AvailIn = (uint)arr.Length;
+                zStream.NextIn = compressedData;
+                zStream.AvailOut = (uint)inflatedSize;
+                zStream.NextOut = uncompressedData;
+
+                Inflate(ref zStream, FlushCode.NoFlush);
+                Inflate(ref zStream, FlushCode.Finish);
+                InflateEnd(ref zStream);
+            }
+        }
+    }
+}

--- a/WowPacketParser/Misc/ZStream.cs
+++ b/WowPacketParser/Misc/ZStream.cs
@@ -1,0 +1,17 @@
+﻿using System.Runtime.InteropServices;
+
+namespace WowPacketParser.Misc
+{
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Ansi)]
+    public unsafe struct ZStream
+    {
+        internal byte* NextIn;
+        internal byte* NextOut;
+        internal nint Msg;
+
+        readonly nint InternalState;
+
+        internal uint AvailIn;
+        internal uint AvailOut;
+    }
+}

--- a/WowPacketParser/Parsing/Parsers/SessionHandler.cs
+++ b/WowPacketParser/Parsing/Parsers/SessionHandler.cs
@@ -1,4 +1,3 @@
-using Ionic.Zlib;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -10,7 +9,7 @@ namespace WowPacketParser.Parsing.Parsers
     public static class SessionHandler
     {
         public static WowGuid LoginGuid;
-        public static Dictionary<int, ZlibCodec> ZStreams = new Dictionary<int, ZlibCodec>();
+        public static Dictionary<int, ZStream> ZStreams = new Dictionary<int, ZStream>();
 
         [Parser(Opcode.SMSG_AUTH_CHALLENGE, ClientVersionBuild.Zero, ClientVersionBuild.V4_0_1a_13205)]
         public static void HandleServerAuthChallenge(Packet packet)
@@ -559,7 +558,7 @@ namespace WowPacketParser.Parsing.Parsers
         public static void HandleResetCompressionContext(Packet packet)
         {
             packet.ReadInt32("Unk?");
-            ZStreams[packet.ConnectionIndex] = new ZlibCodec(CompressionMode.Decompress);
+            packet.ResetInflateStream();
         }
     }
 }

--- a/WowPacketParser/Program.cs
+++ b/WowPacketParser/Program.cs
@@ -3,6 +3,8 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
+using System.Runtime.InteropServices;
 using System.Threading;
 using WowPacketParser.Loading;
 using WowPacketParser.Misc;
@@ -15,6 +17,23 @@ namespace WowPacketParser
     {
         private static void Main(string[] args)
         {
+            NativeLibrary.SetDllImportResolver(Assembly.GetExecutingAssembly(), (libraryName, assembly, searchPath) =>
+            {
+                if (libraryName.Equals("compression_native", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                        return NativeLibrary.Load("System.IO.Compression.Native.dll", assembly, searchPath);
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                        return NativeLibrary.Load("libSystem.IO.Compression.Native.dylib", assembly, searchPath);
+
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                        return NativeLibrary.Load("libSystem.IO.Compression.Native.so", assembly, searchPath);
+                }
+
+                return default;
+            });
+
             SetUpWindowTitle();
             SetUpConsole();
 

--- a/WowPacketParser/WowPacketParser.csproj
+++ b/WowPacketParser/WowPacketParser.csproj
@@ -5,7 +5,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Iconic.Zlib.Netstandard" Version="1.0.0" />
         <PackageReference Include="MySql.Data" Version="8.3.0" />
         <PackageReference Include="RawScape.Wintellect.PowerCollections" Version="1.0.1" />
         <PackageReference Include="Sigil" Version="5.0.0" />


### PR DESCRIPTION
Due to different naming of those compression libraries per OS there is a custom library import resolver used.

This is a followup change for the closed issue https://github.com/TrinityCore/WowPacketParser/issues/896