### PR TITLE
Add support for seven additional 5.5.3 builds

### DIFF
--- a/WowPacketParser/Enums/ClientVersionBuild.cs
+++ b/WowPacketParser/Enums/ClientVersionBuild.cs
@@ -1106,12 +1106,19 @@ namespace WowPacketParser.Enums
 
         V5_5_3_64802 = 64802, // both live and ptr
         V5_5_3_64857 = 64857, // live
+        V5_5_3_65302 = 65302, // live //
         V5_5_3_65703 = 65703, // live
         V5_5_3_65746 = 65746, // live
         V5_5_3_65890 = 65890, // live
         V5_5_3_65988 = 65988, // live
         V5_5_3_66128 = 66128, // live
         V5_5_3_66290 = 66290, // live
+        V5_5_3_66382 = 66382, // ptr
+        V5_5_3_66509 = 66509, // live
+        V5_5_3_66565 = 66565, // live
+        V5_5_3_66839 = 66839, // live
+        V5_5_3_67158 = 67158, // live
+        V5_5_3_67509 = 67509, // live
         // Battle.net - should probably not mix this but oh well
         BattleNetV37165 = 37165,
 

--- a/WowPacketParser/Enums/Version/Opcodes.cs
+++ b/WowPacketParser/Enums/Version/Opcodes.cs
@@ -1266,12 +1266,19 @@ namespace WowPacketParser.Enums.Version
                     return ClientVersionBuild.V5_5_2_64068;
                 case ClientVersionBuild.V5_5_3_64802:
                 case ClientVersionBuild.V5_5_3_64857:
+                case ClientVersionBuild.V5_5_3_65302:
                 case ClientVersionBuild.V5_5_3_65703:
                 case ClientVersionBuild.V5_5_3_65746:
                 case ClientVersionBuild.V5_5_3_65890:
                 case ClientVersionBuild.V5_5_3_65988:
                 case ClientVersionBuild.V5_5_3_66128:
                 case ClientVersionBuild.V5_5_3_66290:
+                case ClientVersionBuild.V5_5_3_66382:
+                case ClientVersionBuild.V5_5_3_66509:
+                case ClientVersionBuild.V5_5_3_66565:
+                case ClientVersionBuild.V5_5_3_66839:
+                case ClientVersionBuild.V5_5_3_67158:
+                case ClientVersionBuild.V5_5_3_67509:
                     return ClientVersionBuild.V5_5_3_64802;
                 case ClientVersionBuild.V2_5_5_64796:
                 case ClientVersionBuild.V2_5_5_64912:

--- a/WowPacketParser/Enums/Version/UpdateFields.cs
+++ b/WowPacketParser/Enums/Version/UpdateFields.cs
@@ -1521,13 +1521,20 @@ namespace WowPacketParser.Enums.Version
                 }
                 case ClientVersionBuild.V5_5_3_64802:
                 case ClientVersionBuild.V5_5_3_64857:
+                case ClientVersionBuild.V5_5_3_65302:
                 case ClientVersionBuild.V5_5_3_65703:
                 case ClientVersionBuild.V5_5_3_65746:
                 case ClientVersionBuild.V5_5_3_65890:
                 case ClientVersionBuild.V5_5_3_65988:
                 case ClientVersionBuild.V5_5_3_66128:
                 case ClientVersionBuild.V5_5_3_66290:
-                    {
+                case ClientVersionBuild.V5_5_3_66382:
+                case ClientVersionBuild.V5_5_3_66509:
+                case ClientVersionBuild.V5_5_3_66565:
+                case ClientVersionBuild.V5_5_3_66839:
+                case ClientVersionBuild.V5_5_3_67158:
+                case ClientVersionBuild.V5_5_3_67509:
+                {
                     return ClientVersionBuild.V5_5_3_64802;
                 }
                 default:

--- a/WowPacketParser/Misc/ClientVersion.cs
+++ b/WowPacketParser/Misc/ClientVersion.cs
@@ -1740,11 +1740,18 @@ namespace WowPacketParser.Misc
                 case ClientVersionBuild.V5_5_2_64481:
                 case ClientVersionBuild.V5_5_3_64802:
                 case ClientVersionBuild.V5_5_3_64857:
+                case ClientVersionBuild.V5_5_3_65302:
                 case ClientVersionBuild.V5_5_3_65746:
                 case ClientVersionBuild.V5_5_3_65890:
                 case ClientVersionBuild.V5_5_3_65988:
                 case ClientVersionBuild.V5_5_3_66128:
                 case ClientVersionBuild.V5_5_3_66290:
+                case ClientVersionBuild.V5_5_3_66382:
+                case ClientVersionBuild.V5_5_3_66509:
+                case ClientVersionBuild.V5_5_3_66565:
+                case ClientVersionBuild.V5_5_3_66839:
+                case ClientVersionBuild.V5_5_3_67158:
+                case ClientVersionBuild.V5_5_3_67509:
                 case ClientVersionBuild.V1_15_8_63829:
                 case ClientVersionBuild.V1_15_8_64057:
                 case ClientVersionBuild.V1_15_8_64130:
@@ -2487,11 +2494,18 @@ namespace WowPacketParser.Misc
                 case ClientVersionBuild.V5_5_2_64481:
                 case ClientVersionBuild.V5_5_3_64802:
                 case ClientVersionBuild.V5_5_3_64857:
+                case ClientVersionBuild.V5_5_3_65302:
                 case ClientVersionBuild.V5_5_3_65746:
                 case ClientVersionBuild.V5_5_3_65890:
                 case ClientVersionBuild.V5_5_3_65988:
                 case ClientVersionBuild.V5_5_3_66128:
                 case ClientVersionBuild.V5_5_3_66290:
+                case ClientVersionBuild.V5_5_3_66382:
+                case ClientVersionBuild.V5_5_3_66509:
+                case ClientVersionBuild.V5_5_3_66565:
+                case ClientVersionBuild.V5_5_3_66839:
+                case ClientVersionBuild.V5_5_3_67158:
+                case ClientVersionBuild.V5_5_3_67509:
                     return true;
                 default:
                     return false;


### PR DESCRIPTION
Adds support for the following 5.5.3 client builds so packet dumps from these versions can be parsed:

- 5.5.3.65302
- 5.5.3.66382
- 5.5.3.66509
- 5.5.3.66565
- 5.5.3.66839
- 5.5.3.67158
- 5.5.3.67509

No packet structures or opcode mappings were changed.