### PR TITLE
SMSG_ENCOUNTER_START add StackData

### DIFF
--- a/WowPacketParserModule.V10_0_0_46181/Parsers/InstanceHandler.cs
+++ b/WowPacketParserModule.V10_0_0_46181/Parsers/InstanceHandler.cs
@@ -10,6 +10,9 @@ namespace WowPacketParserModule.V10_0_0_46181.Parsers
         {
             packet.ReadPackedGuid128("CasterGUID", idx);
             packet.ReadUInt32<SpellId>("SpellID", idx);
+
+            if (ClientVersion.AddedInVersion(ClientVersionBuild.V12_0_7_67808))
+                packet.ReadInt32("StackData", idx);
         }
 
         public static void ReadItemInfo(Packet packet, params object[] idx)

--- a/WowPacketParserModule.V10_0_0_46181/Parsers/InstanceHandler.cs
+++ b/WowPacketParserModule.V10_0_0_46181/Parsers/InstanceHandler.cs
@@ -12,7 +12,7 @@ namespace WowPacketParserModule.V10_0_0_46181.Parsers
             packet.ReadUInt32<SpellId>("SpellID", idx);
 
             if (ClientVersion.AddedInVersion(ClientVersionBuild.V12_0_7_67808))
-                packet.ReadInt32("StackData", idx);
+                packet.ReadInt32("Applications", idx);
         }
 
         public static void ReadItemInfo(Packet packet, params object[] idx)


### PR DESCRIPTION
Add an extra ReadInt32 in ReadAuraInfo used by SMSG_ENCOUNTER_START.

Its used for COMBATANT_INFO, and got the name from here: https://wowcoach.gg/docs/combat-log/combatant-info

- Im not sure if 12.0.7 is the version when it got added
- Im not sure about the naming