### PR TITLE
fix: remove comments blocking UpdateFields for WotLK Classic

### DIFF
--- a/WowPacketParserModule.V3_4_0_45166/Parsers/UpdateFieldsHandler341.cs
+++ b/WowPacketParserModule.V3_4_0_45166/Parsers/UpdateFieldsHandler341.cs
@@ -741,7 +741,6 @@ namespace WowPacketParserModule.V3_4_0_45166.UpdateFields.V3_4_1_47014
         public override IUnitData ReadUpdateUnitData(Packet packet, params object[] indexes)
         {
             var data = new UnitData();
-            /*
             var rawChangesMask = new int[7];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(7);
@@ -1331,7 +1330,6 @@ namespace WowPacketParserModule.V3_4_0_45166.UpdateFields.V3_4_1_47014
                     }
                 }
             }
-            */
             return data;
         }
 

--- a/WowPacketParserModule.V3_4_0_45166/Parsers/UpdateFieldsHandler342.cs
+++ b/WowPacketParserModule.V3_4_0_45166/Parsers/UpdateFieldsHandler342.cs
@@ -744,7 +744,6 @@ namespace WowPacketParserModule.V3_4_0_45166.UpdateFields.V3_4_2_50129
         {
             var data = new UnitData();
             packet.ResetBitReader();
-            /*
             var rawChangesMask = new int[8];
             var rawMaskMask = new int[1];
             rawMaskMask[0] = (int)packet.ReadBits(8);
@@ -1342,7 +1341,6 @@ namespace WowPacketParserModule.V3_4_0_45166.UpdateFields.V3_4_2_50129
                     }
                 }
             }
-            */
             return data;
         }
 


### PR DESCRIPTION
Before it'd look like this:

```
ServerToClient: SMSG_UPDATE_OBJECT (0x27D1) Length: 206 ConnIdx: 1 Time: 08/25/2023 20:52:36.761 Number: 133695
NumObjUpdates: 5
MapID: 571 (571)
HasRemovedObjects: False
Data size: 195
[0] UpdateType: Values
[0] Object Guid: Full: 0x20449C4760177A400015140000693E7B Creature/0 R4391/S5396 Map: 571 Entry: 24041 Low: 6897275
[1] UpdateType: Values
[1] Object Guid: Full: 0x20449C4760177B000015140000693E7B Creature/0 R4391/S5396 Map: 571 Entry: 24044 Low: 6897275
[2] UpdateType: Values
[2] Object Guid: Full: 0x20449C4760177B000015140000E93E7B Creature/0 R4391/S5396 Map: 571 Entry: 24044 Low: 15285883
[3] UpdateType: Values
[3] Object Guid: Full: 0x20449C4760177B000015140001693E7B Creature/0 R4391/S5396 Map: 571 Entry: 24044 Low: 23674491
[4] UpdateType: Values
[4] Object Guid: Full: 0x20449C4760177B000015140001E93E7B Creature/0 R4391/S5396 Map: 571 Entry: 24044 Low: 32063099
```

Now it looks like this:

```
[0] UpdateType: Values
[0] Object Guid: Full: 0x20449C4760177A400015140000693E7B Creature/0 ... Entry: 24041
[0] EmoteState: 375
[1] Flags: 295168
[1] EmoteState: 375
```

No errors from what I could see? Tried in all 3.4.x versions.